### PR TITLE
feat(api): add GET /api/levels endpoint with Prisma integration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "dist/server.js",
   "scripts": {
-    "dev": "ts-node-dev --respawn --transpile-only src/server.ts"
+    "dev": "DOTENV_CONFIG_PATH=../../.env ts-node-dev --respawn --transpile-only src/server.ts"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.7.0",

--- a/apps/api/src/controllers/level.controller.ts
+++ b/apps/api/src/controllers/level.controller.ts
@@ -1,0 +1,23 @@
+import type { Request, Response } from "express";
+
+import { prisma } from "../prisma/client";
+
+export const getLevels = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const levels = await prisma.level.findMany({
+      select: {
+        id: true,
+        code: true,
+        label: true,
+        sortOrder: true,
+        availablePlaces: true
+      },
+      orderBy: { sortOrder: "asc" }
+    });
+
+    res.status(200).json(levels);
+  } catch (error) {
+    console.error("Failed to fetch levels:", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+};

--- a/apps/api/src/routes/level.routes.ts
+++ b/apps/api/src/routes/level.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+
+import { getLevels } from "../controllers/level.controller";
+
+const router = Router();
+
+router.get("/levels", getLevels);
+
+export default router;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2,11 +2,14 @@ import "dotenv/config";
 import cors from "cors";
 import express from "express";
 
+import levelRoutes from "./routes/level.routes";
+
 const app = express();
 const PORT = Number(process.env.PORT) || 3000;
 
 app.use(cors());
 app.use(express.json());
+app.use("/api", levelRoutes);
 
 app.get("/health", (_req, res) => {
   res.json({

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   schema: "prisma/schema.prisma",
   migrations: {
     path: "prisma/migrations",
+    seed: "node prisma/seed.js",
   },
   datasource: {
     url: process.env["DATABASE_URL"],


### PR DESCRIPTION
## Objectif

Implémenter un endpoint de lecture des niveaux depuis la base de données.

## Contenu

- création route GET /api/levels
- controller Prisma avec tri par sortOrder
- utilisation du singleton Prisma existant
- séparation route / controller

## Technique

- Express + TypeScript
- Prisma Client (singleton)
- PostgreSQL

## Résultat

GET /api/levels retourne :

- liste des niveaux seedés
- triés par sortOrder ASC
- payload limité à :
  id, code, label, sortOrder, availablePlaces

## Vérifications

- npm run dev:api : OK
- GET http://localhost:3000/api/levels : 200 OK
- données cohérentes avec le seed

## Notes

- aucune modification du schéma Prisma
- aucune modification des migrations
- aucune modification des seeds