### PR TITLE
feat(api): add GET /api/applications endpoint

### DIFF
--- a/apps/api/src/controllers/application.controller.ts
+++ b/apps/api/src/controllers/application.controller.ts
@@ -1,0 +1,25 @@
+import type { Request, Response } from "express";
+
+import { prisma } from "../prisma/client";
+
+export const getApplications = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const applications = await prisma.application.findMany({
+      orderBy: { createdAt: "desc" },
+      include: {
+        family: true,
+        schoolYear: true,
+        students: {
+          include: {
+            level: true
+          }
+        }
+      }
+    });
+
+    res.status(200).json(applications);
+  } catch (error) {
+    console.error("Failed to fetch applications:", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+};

--- a/apps/api/src/routes/application.routes.ts
+++ b/apps/api/src/routes/application.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+
+import { getApplications } from "../controllers/application.controller";
+
+const router = Router();
+
+router.get("/applications", getApplications);
+
+export default router;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2,6 +2,7 @@ import "dotenv/config";
 import cors from "cors";
 import express from "express";
 
+import applicationRoutes from "./routes/application.routes";
 import levelRoutes from "./routes/level.routes";
 
 const app = express();
@@ -9,6 +10,7 @@ const PORT = Number(process.env.PORT) || 3000;
 
 app.use(cors());
 app.use(express.json());
+app.use("/api", applicationRoutes);
 app.use("/api", levelRoutes);
 
 app.get("/health", (_req, res) => {


### PR DESCRIPTION
## Objectif

Implémenter un endpoint de lecture des demandes d’inscription depuis la base de données.

## Contenu

- création de la route GET /api/applications
- création du controller associé
- lecture via Prisma avec relations incluses :
  - family
  - schoolYear
  - students
  - students.level
- tri des demandes par createdAt DESC
- branchement sous /api

## Technique

- Express + TypeScript
- Prisma Client singleton existant
- PostgreSQL

## Résultat

GET /api/applications retourne une liste exploitable pour le frontend avec :
- informations de la demande
- famille
- année scolaire
- élèves
- niveau demandé par élève

## Vérifications

- [x] npx tsc --noEmit -p apps/api/tsconfig.json
- [x] npm run dev:api
- [x] GET /api/applications : 200 OK
- [x] relations Prisma présentes dans le JSON
- [x] tri createdAt DESC respecté

## Notes

- aucune modification du schéma Prisma
- aucune modification des migrations
- aucune modification des seeds