### PR TITLE
feat(api): add GET /api/applications/:id endpoint

### DIFF
--- a/apps/api/src/controllers/application.controller.ts
+++ b/apps/api/src/controllers/application.controller.ts
@@ -23,3 +23,35 @@ export const getApplications = async (_req: Request, res: Response): Promise<voi
     res.status(500).json({ message: "Internal server error" });
   }
 };
+
+export const getApplicationById = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const applicationId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+
+    const application = await prisma.application.findUnique({
+      where: { id: applicationId },
+      include: {
+        family: true,
+        schoolYear: true,
+        students: {
+          include: {
+            level: true
+          }
+        },
+        emailLogs: {
+          orderBy: { createdAt: "desc" }
+        }
+      }
+    });
+
+    if (!application) {
+      res.status(404).json({ message: "Application not found" });
+      return;
+    }
+
+    res.status(200).json(application);
+  } catch (error) {
+    console.error("Failed to fetch application:", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+};

--- a/apps/api/src/routes/application.routes.ts
+++ b/apps/api/src/routes/application.routes.ts
@@ -1,9 +1,13 @@
 import { Router } from "express";
 
-import { getApplications } from "../controllers/application.controller";
+import {
+  getApplicationById,
+  getApplications
+} from "../controllers/application.controller";
 
 const router = Router();
 
 router.get("/applications", getApplications);
+router.get("/applications/:id", getApplicationById);
 
 export default router;


### PR DESCRIPTION
## Objectif

Implémenter un endpoint de détail pour une demande d’inscription.

## Contenu

- ajout du endpoint GET /api/applications/:id
- ajout du contrôleur getApplicationById()
- récupération complète d’une demande avec ses relations :
  - family
  - schoolYear
  - students
  - students.level
  - emailLogs
- tri des emailLogs par createdAt DESC
- gestion d’un cas 404 si l’id n’existe pas

## Technique

- Express + TypeScript
- Prisma Client singleton existant
- aucune modification de l’architecture globale

## Résultat

GET /api/applications/:id retourne :
- la demande
- la famille liée
- l’année scolaire
- les élèves
- les niveaux des élèves
- l’historique des emails

## Vérifications

- [x] npx tsc --noEmit -p apps/api/tsconfig.json
- [x] npm run dev:api
- [x] GET /api/applications/:id : 200 avec un id existant
- [x] GET /api/applications/application-does-not-exist : 404
- [x] students.level présents
- [x] emailLogs présents et triés

## Notes

- aucune modification du schéma Prisma
- aucune modification des migrations
- aucune modification des seeds
- aucun changement dans server.ts nécessaire