### PR TITLE
feat(api): add GET /api/school-years endpoint

### DIFF
--- a/apps/api/src/controllers/school-year.controller.ts
+++ b/apps/api/src/controllers/school-year.controller.ts
@@ -1,0 +1,25 @@
+import type { Request, Response } from "express";
+
+import { prisma } from "../prisma/client";
+
+export const getSchoolYears = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const schoolYears = await prisma.schoolYear.findMany({
+      select: {
+        id: true,
+        label: true,
+        startYear: true,
+        endYear: true,
+        isActive: true,
+        createdAt: true,
+        updatedAt: true
+      },
+      orderBy: { startYear: "desc" }
+    });
+
+    res.status(200).json(schoolYears);
+  } catch (error) {
+    console.error("Failed to fetch school years:", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+};

--- a/apps/api/src/routes/school-year.routes.ts
+++ b/apps/api/src/routes/school-year.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+
+import { getSchoolYears } from "../controllers/school-year.controller";
+
+const router = Router();
+
+router.get("/school-years", getSchoolYears);
+
+export default router;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -4,6 +4,7 @@ import express from "express";
 
 import applicationRoutes from "./routes/application.routes";
 import levelRoutes from "./routes/level.routes";
+import schoolYearRoutes from "./routes/school-year.routes";
 
 const app = express();
 const PORT = Number(process.env.PORT) || 3000;
@@ -12,6 +13,7 @@ app.use(cors());
 app.use(express.json());
 app.use("/api", applicationRoutes);
 app.use("/api", levelRoutes);
+app.use("/api", schoolYearRoutes);
 
 app.get("/health", (_req, res) => {
   res.json({


### PR DESCRIPTION
## Objectif

Implémenter un endpoint de lecture des années scolaires.

## Contenu

- ajout du endpoint GET /api/school-years
- création d’un controller dédié
- création d’une route dédiée
- lecture via Prisma avec tri par startYear DESC
- branchement sous /api

## Technique

- Express + TypeScript
- Prisma Client singleton existant
- lecture seule
- gestion d’erreur simple via try/catch

## Résultat

GET /api/school-years retourne une liste d’années scolaires avec :
- id
- label
- startYear
- endYear
- isActive
- createdAt
- updatedAt

## Vérifications

- [x] npm run dev:api
- [x] GET /api/school-years : 200 OK
- [x] tri par startYear DESC
- [x] année active présente dans la réponse

## Notes

- aucune modification du schéma Prisma
- aucune modification des migrations
- aucune modification des seeds
- GET /api/school-years/active non implémenté dans cette PR