### PR TITLE
feat(api): add GET /api/school-years/active endpoint

### DIFF
--- a/apps/api/src/controllers/school-year.controller.ts
+++ b/apps/api/src/controllers/school-year.controller.ts
@@ -23,3 +23,31 @@ export const getSchoolYears = async (_req: Request, res: Response): Promise<void
     res.status(500).json({ message: "Internal server error" });
   }
 };
+
+export const getActiveSchoolYear = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const schoolYear = await prisma.schoolYear.findFirst({
+      where: { isActive: true },
+      select: {
+        id: true,
+        label: true,
+        startYear: true,
+        endYear: true,
+        isActive: true,
+        createdAt: true,
+        updatedAt: true
+      },
+      orderBy: { startYear: "desc" }
+    });
+
+    if (!schoolYear) {
+      res.status(404).json({ message: "Active school year not found" });
+      return;
+    }
+
+    res.status(200).json(schoolYear);
+  } catch (error) {
+    console.error("Failed to fetch active school year:", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+};

--- a/apps/api/src/routes/school-year.routes.ts
+++ b/apps/api/src/routes/school-year.routes.ts
@@ -1,9 +1,13 @@
 import { Router } from "express";
 
-import { getSchoolYears } from "../controllers/school-year.controller";
+import {
+  getActiveSchoolYear,
+  getSchoolYears
+} from "../controllers/school-year.controller";
 
 const router = Router();
 
+router.get("/school-years/active", getActiveSchoolYear);
 router.get("/school-years", getSchoolYears);
 
 export default router;


### PR DESCRIPTION
## Objectif

Implémenter un endpoint de lecture pour récupérer l’année scolaire active.

## Contenu

- ajout du endpoint GET /api/school-years/active
- ajout de la fonction getActiveSchoolYear() dans le controller existant
- lecture via Prisma avec recherche de l’année active
- tri par startYear DESC si plusieurs années actives existent
- retour 404 si aucune année active n’est trouvée

## Technique

- Express + TypeScript
- Prisma Client singleton existant
- lecture seule
- gestion d’erreur simple via try/catch

## Résultat

GET /api/school-years/active retourne :
- id
- label
- startYear
- endYear
- isActive
- createdAt
- updatedAt

## Vérifications

- [x] npm run dev:api
- [x] GET /api/school-years/active : 200 OK
- [x] année active seedée retournée
- [x] GET /api/school-years continue de fonctionner
- [x] gestion 404 implémentée

## Notes

- aucune modification du schéma Prisma
- aucune modification des migrations
- aucune modification des seeds
- server.ts inchangé