### PR TITLE
feat(api): add PATCH /api/applications/:id/status endpoint

### DIFF
--- a/apps/api/src/controllers/application.controller.ts
+++ b/apps/api/src/controllers/application.controller.ts
@@ -159,3 +159,35 @@ export const getApplicationById = async (req: Request, res: Response): Promise<v
     res.status(500).json({ message: "Internal server error" });
   }
 };
+
+export const updateApplicationStatus = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const applicationId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+    const status = getQueryParam(req.body?.status);
+
+    if (!status || !isApplicationStatus(status)) {
+      res.status(400).json({ message: "Invalid application status" });
+      return;
+    }
+
+    const existingApplication = await prisma.application.findUnique({
+      where: { id: applicationId },
+      select: { id: true }
+    });
+
+    if (!existingApplication) {
+      res.status(404).json({ message: "Application not found" });
+      return;
+    }
+
+    const updatedApplication = await prisma.application.update({
+      where: { id: applicationId },
+      data: { status }
+    });
+
+    res.status(200).json(updatedApplication);
+  } catch (error) {
+    console.error("Failed to update application status:", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+};

--- a/apps/api/src/routes/application.routes.ts
+++ b/apps/api/src/routes/application.routes.ts
@@ -2,12 +2,14 @@ import { Router } from "express";
 
 import {
   getApplicationById,
-  getApplications
+  getApplications,
+  updateApplicationStatus
 } from "../controllers/application.controller";
 
 const router = Router();
 
 router.get("/applications", getApplications);
 router.get("/applications/:id", getApplicationById);
+router.patch("/applications/:id/status", updateApplicationStatus);
 
 export default router;


### PR DESCRIPTION
## Objectif

Implémenter un endpoint permettant de modifier le statut d’une demande d’inscription.

## Contenu

- ajout du endpoint PATCH /api/applications/:id/status
- lecture du nouveau statut depuis `req.body.status`
- validation du statut contre l’enum `ApplicationStatus`
- vérification de l’existence de la demande
- mise à jour ciblée du champ `status`

## Comportement

- `400` si le statut est absent ou invalide
- `404` si la demande n’existe pas
- `200` avec la demande mise à jour si tout est valide

## Technique

- Express + TypeScript
- Prisma Client singleton existant
- aucune modification de l’architecture globale
- aucune logique métier complexe ajoutée

## Vérifications

- [x] npx tsc --noEmit -p apps/api/tsconfig.json
- [x] npm run dev:api
- [x] PATCH /api/applications/:id/status avec statut valide
- [x] statut bien modifié en base
- [x] PATCH avec statut invalide : 400
- [x] PATCH avec id inexistant : 404
- [x] decisionAt inchangé
- [x] decisionNote inchangé

## Notes

- aucune modification du schéma Prisma
- aucune modification des migrations
- aucune modification des seeds
- pas de logique automatique sur la décision dans cette PR