### PR TITLE
feat(api): add PATCH /api/applications/:id/priority endpoint

### DIFF
--- a/apps/api/src/controllers/application.controller.ts
+++ b/apps/api/src/controllers/application.controller.ts
@@ -191,3 +191,35 @@ export const updateApplicationStatus = async (req: Request, res: Response): Prom
     res.status(500).json({ message: "Internal server error" });
   }
 };
+
+export const updateApplicationPriority = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const applicationId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+    const isPriority = req.body?.isPriority;
+
+    if (typeof isPriority !== "boolean") {
+      res.status(400).json({ message: "Invalid priority value" });
+      return;
+    }
+
+    const existingApplication = await prisma.application.findUnique({
+      where: { id: applicationId },
+      select: { id: true }
+    });
+
+    if (!existingApplication) {
+      res.status(404).json({ message: "Application not found" });
+      return;
+    }
+
+    const updatedApplication = await prisma.application.update({
+      where: { id: applicationId },
+      data: { isPriority }
+    });
+
+    res.status(200).json(updatedApplication);
+  } catch (error) {
+    console.error("Failed to update application priority:", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+};

--- a/apps/api/src/routes/application.routes.ts
+++ b/apps/api/src/routes/application.routes.ts
@@ -3,6 +3,7 @@ import { Router } from "express";
 import {
   getApplicationById,
   getApplications,
+  updateApplicationPriority,
   updateApplicationStatus
 } from "../controllers/application.controller";
 
@@ -11,5 +12,6 @@ const router = Router();
 router.get("/applications", getApplications);
 router.get("/applications/:id", getApplicationById);
 router.patch("/applications/:id/status", updateApplicationStatus);
+router.patch("/applications/:id/priority", updateApplicationPriority);
 
 export default router;


### PR DESCRIPTION
## Objectif

Implémenter un endpoint permettant d’activer ou de désactiver la priorité d’une demande d’inscription.

## Contenu

- ajout du endpoint PATCH /api/applications/:id/priority
- lecture de la valeur depuis `req.body.isPriority`
- validation stricte sur un booléen
- vérification de l’existence de la demande
- mise à jour ciblée du champ `isPriority`

## Comportement

- `400` si `isPriority` est absent ou invalide
- `404` si la demande n’existe pas
- `200` avec la demande mise à jour si tout est valide

## Technique

- Express + TypeScript
- Prisma Client singleton existant
- aucune modification de l’architecture globale
- aucune logique métier supplémentaire ajoutée

## Vérifications

- [x] npx tsc --noEmit -p apps/api/tsconfig.json
- [x] npm run dev:api
- [x] PATCH /api/applications/:id/priority avec true / false
- [x] isPriority bien modifié en base
- [x] PATCH avec valeur invalide ou absente : 400
- [x] PATCH avec id inexistant : 404
- [x] aucun autre champ métier modifié
- [x] updatedAt évolue normalement via @updatedAt

## Notes

- aucune modification du schéma Prisma
- aucune modification des migrations
- aucune modification des seeds
- endpoint limité à la gestion de la priorité