### PR TITLE
feat(api): add PATCH /api/applications/:id/decision endpoint

### DIFF
--- a/apps/api/src/controllers/application.controller.ts
+++ b/apps/api/src/controllers/application.controller.ts
@@ -32,6 +32,14 @@ const isApplicationStatus = (value: string): value is ApplicationStatus => {
   return Object.values(ApplicationStatus).includes(value as ApplicationStatus);
 };
 
+type ApplicationDecisionStatus = "ACCEPTED" | "REFUSED";
+
+const isApplicationDecisionStatus = (
+  value: string
+): value is ApplicationDecisionStatus => {
+  return value === "ACCEPTED" || value === "REFUSED";
+};
+
 export const getApplications = async (req: Request, res: Response): Promise<void> => {
   try {
     const status = getQueryParam(req.query.status);
@@ -220,6 +228,43 @@ export const updateApplicationPriority = async (req: Request, res: Response): Pr
     res.status(200).json(updatedApplication);
   } catch (error) {
     console.error("Failed to update application priority:", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+};
+
+export const updateApplicationDecision = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const applicationId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+    const status = getQueryParam(req.body?.status);
+    const decisionNote = typeof req.body?.decisionNote === "string" ? req.body.decisionNote : null;
+
+    if (!status || !isApplicationDecisionStatus(status)) {
+      res.status(400).json({ message: "Invalid application decision status" });
+      return;
+    }
+
+    const existingApplication = await prisma.application.findUnique({
+      where: { id: applicationId },
+      select: { id: true }
+    });
+
+    if (!existingApplication) {
+      res.status(404).json({ message: "Application not found" });
+      return;
+    }
+
+    const updatedApplication = await prisma.application.update({
+      where: { id: applicationId },
+      data: {
+        status,
+        decisionAt: new Date(),
+        decisionNote
+      }
+    });
+
+    res.status(200).json(updatedApplication);
+  } catch (error) {
+    console.error("Failed to update application decision:", error);
     res.status(500).json({ message: "Internal server error" });
   }
 };

--- a/apps/api/src/routes/application.routes.ts
+++ b/apps/api/src/routes/application.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 
 import {
+  updateApplicationDecision,
   getApplicationById,
   getApplications,
   updateApplicationPriority,
@@ -13,5 +14,6 @@ router.get("/applications", getApplications);
 router.get("/applications/:id", getApplicationById);
 router.patch("/applications/:id/status", updateApplicationStatus);
 router.patch("/applications/:id/priority", updateApplicationPriority);
+router.patch("/applications/:id/decision", updateApplicationDecision);
 
 export default router;


### PR DESCRIPTION
## Objectif

Implémenter un endpoint permettant d’enregistrer la décision finale d’une demande d’inscription.

## Contenu

- ajout du endpoint PATCH /api/applications/:id/decision
- lecture de la décision depuis `req.body.status`
- validation stricte sur les seules valeurs :
  - `ACCEPTED`
  - `REFUSED`
- lecture optionnelle de `req.body.decisionNote`
- mise à jour ciblée de :
  - `status`
  - `decisionAt`
  - `decisionNote`

## Comportement

- `400` si le statut de décision est absent ou invalide
- `404` si la demande n’existe pas
- `200` avec la demande mise à jour si tout est valide

## Règle sur decisionNote

- si `decisionNote` est fournie et de type string → elle est enregistrée
- sinon → elle est mise à `null`

## Technique

- Express + TypeScript
- Prisma Client singleton existant
- aucune logique d’email ajoutée
- aucune création de log email
- aucune couche service ajoutée dans cette PR

## Vérifications

- [x] npx tsc --noEmit -p apps/api/tsconfig.json
- [x] npm run dev:api
- [x] PATCH /api/applications/:id/decision avec ACCEPTED
- [x] PATCH /api/applications/:id/decision avec REFUSED
- [x] decisionAt bien renseigné
- [x] decisionNote bien enregistrée quand fournie
- [x] decisionNote remise à null quand absente
- [x] PATCH avec statut invalide : 400
- [x] PATCH avec id inexistant : 404
- [x] emailLogs inchangés

## Notes

- aucune modification du schéma Prisma
- aucune modification des migrations
- aucune modification des seeds
- aucun envoi d’email dans cette PR