### PR TITLE
feat(api): add POST /api/applications/:id/send-email endpoint

### DIFF
--- a/apps/api/src/controllers/application.controller.ts
+++ b/apps/api/src/controllers/application.controller.ts
@@ -1,5 +1,7 @@
 import {
   ApplicationStatus,
+  EmailSendStatus,
+  EmailType,
   type Prisma
 } from "@prisma/client";
 import type { Request, Response } from "express";
@@ -33,11 +35,20 @@ const isApplicationStatus = (value: string): value is ApplicationStatus => {
 };
 
 type ApplicationDecisionStatus = "ACCEPTED" | "REFUSED";
+type ApplicationEmailType = "ACCEPTANCE" | "REFUSAL" | "CUSTOM";
 
 const isApplicationDecisionStatus = (
   value: string
 ): value is ApplicationDecisionStatus => {
   return value === "ACCEPTED" || value === "REFUSED";
+};
+
+const isApplicationEmailType = (value: string): value is ApplicationEmailType => {
+  return (
+    value === EmailType.ACCEPTANCE ||
+    value === EmailType.REFUSAL ||
+    value === EmailType.CUSTOM
+  );
 };
 
 export const getApplications = async (req: Request, res: Response): Promise<void> => {
@@ -265,6 +276,61 @@ export const updateApplicationDecision = async (req: Request, res: Response): Pr
     res.status(200).json(updatedApplication);
   } catch (error) {
     console.error("Failed to update application decision:", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+};
+
+export const sendApplicationEmail = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const applicationId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+    const emailType = getQueryParam(req.body?.emailType);
+    const subject = getQueryParam(req.body?.subject);
+    const body = getQueryParam(req.body?.body);
+
+    if (!emailType || !isApplicationEmailType(emailType)) {
+      res.status(400).json({ message: "Invalid email type" });
+      return;
+    }
+
+    if (!subject || !body) {
+      res.status(400).json({ message: "Invalid email payload" });
+      return;
+    }
+
+    const application = await prisma.application.findUnique({
+      where: { id: applicationId },
+      include: {
+        family: true
+      }
+    });
+
+    if (!application) {
+      res.status(404).json({ message: "Application not found" });
+      return;
+    }
+
+    const recipientEmail = application.family.contactEmail.trim();
+
+    if (!recipientEmail) {
+      res.status(400).json({ message: "Missing recipient email" });
+      return;
+    }
+
+    const emailLog = await prisma.applicationEmailLog.create({
+      data: {
+        applicationId: application.id,
+        emailType,
+        recipientEmail,
+        subject,
+        bodySnapshot: body,
+        sentAt: new Date(),
+        sendStatus: EmailSendStatus.SENT
+      }
+    });
+
+    res.status(201).json(emailLog);
+  } catch (error) {
+    console.error("Failed to send application email:", error);
     res.status(500).json({ message: "Internal server error" });
   }
 };

--- a/apps/api/src/routes/application.routes.ts
+++ b/apps/api/src/routes/application.routes.ts
@@ -4,6 +4,7 @@ import {
   updateApplicationDecision,
   getApplicationById,
   getApplications,
+  sendApplicationEmail,
   updateApplicationPriority,
   updateApplicationStatus
 } from "../controllers/application.controller";
@@ -15,5 +16,6 @@ router.get("/applications/:id", getApplicationById);
 router.patch("/applications/:id/status", updateApplicationStatus);
 router.patch("/applications/:id/priority", updateApplicationPriority);
 router.patch("/applications/:id/decision", updateApplicationDecision);
+router.post("/applications/:id/send-email", sendApplicationEmail);
 
 export default router;


### PR DESCRIPTION
## Objectif

Implémenter un endpoint permettant de simuler l’envoi d’un email lié à une demande d’inscription et d’enregistrer un log métier en base.

## Contenu

- ajout du endpoint POST /api/applications/:id/send-email
- validation de :
  - `emailType`
  - `subject`
  - `body`
- récupération de l’application avec sa famille
- lecture de `family.contactEmail`
- création d’un `ApplicationEmailLog`
- simulation d’envoi :
  - `sentAt = new Date()`
  - `sendStatus = SENT`

## Comportement

- `400` si `emailType` est invalide
- `400` si `subject` ou `body` sont invalides
- `400` si aucun email destinataire n’est disponible
- `404` si la demande n’existe pas
- `201` avec le log créé si tout est valide

## Technique

- Express + TypeScript
- Prisma Client singleton existant
- aucun transport SMTP intégré dans cette version
- aucun log email créé hors de la base métier

## Vérifications

- [x] npx tsc --noEmit -p apps/api/tsconfig.json
- [x] npm run dev:api
- [x] POST /api/applications/:id/send-email avec payload valide : 201
- [x] log visible ensuite via GET /api/applications/:id
- [x] POST avec emailType invalide : 400
- [x] POST avec subject/body invalides : 400
- [x] POST avec id inexistant : 404
- [x] cas Missing recipient email vérifié

## Notes

- aucune modification du schéma Prisma
- aucune modification des migrations
- aucune modification des seeds
- aucun envoi réel SMTP/Nodemailer dans cette PR
- le log de test a été supprimé après validation