### PR TITLE
feat(api): add GET /api/dashboard/stats endpoint

### DIFF
--- a/apps/api/src/controllers/dashboard.controller.ts
+++ b/apps/api/src/controllers/dashboard.controller.ts
@@ -1,0 +1,106 @@
+import { ApplicationStatus } from "@prisma/client";
+import type { Request, Response } from "express";
+
+import { prisma } from "../prisma/client";
+
+type DashboardStatusCounts = {
+  RECEIVED: number;
+  IN_REVIEW: number;
+  ACCEPTED: number;
+  REFUSED: number;
+};
+
+export const getDashboardStats = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const [totalApplications, statusCounts, levels, priorityApplications] = await Promise.all([
+      prisma.application.count(),
+      prisma.application.groupBy({
+        by: ["status"],
+        _count: {
+          _all: true
+        }
+      }),
+      prisma.level.findMany({
+        select: {
+          code: true,
+          label: true,
+          sortOrder: true,
+          _count: {
+            select: {
+              students: true
+            }
+          }
+        },
+        orderBy: {
+          sortOrder: "asc"
+        }
+      }),
+      prisma.application.findMany({
+        where: {
+          isPriority: true
+        },
+        orderBy: {
+          createdAt: "desc"
+        },
+        select: {
+          id: true,
+          status: true,
+          isPriority: true,
+          createdAt: true,
+          family: {
+            select: {
+              contactEmail: true,
+              fatherLastName: true,
+              motherLastName: true
+            }
+          },
+          schoolYear: {
+            select: {
+              label: true,
+              isActive: true
+            }
+          },
+          students: {
+            select: {
+              firstName: true,
+              lastName: true,
+              level: {
+                select: {
+                  code: true,
+                  label: true
+                }
+              }
+            }
+          }
+        }
+      })
+    ]);
+
+    const byStatus: DashboardStatusCounts = {
+      [ApplicationStatus.RECEIVED]: 0,
+      [ApplicationStatus.IN_REVIEW]: 0,
+      [ApplicationStatus.ACCEPTED]: 0,
+      [ApplicationStatus.REFUSED]: 0
+    };
+
+    for (const statusCount of statusCounts) {
+      byStatus[statusCount.status] = statusCount._count._all;
+    }
+
+    const byLevel = levels.map((level) => ({
+      code: level.code,
+      label: level.label,
+      count: level._count.students
+    }));
+
+    res.status(200).json({
+      totalApplications,
+      byStatus,
+      byLevel,
+      priorityApplications
+    });
+  } catch (error) {
+    console.error("Failed to fetch dashboard stats:", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+};

--- a/apps/api/src/routes/dashboard.routes.ts
+++ b/apps/api/src/routes/dashboard.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+
+import { getDashboardStats } from "../controllers/dashboard.controller";
+
+const router = Router();
+
+router.get("/dashboard/stats", getDashboardStats);
+
+export default router;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -3,6 +3,7 @@ import cors from "cors";
 import express from "express";
 
 import applicationRoutes from "./routes/application.routes";
+import dashboardRoutes from "./routes/dashboard.routes";
 import levelRoutes from "./routes/level.routes";
 import schoolYearRoutes from "./routes/school-year.routes";
 
@@ -12,6 +13,7 @@ const PORT = Number(process.env.PORT) || 3000;
 app.use(cors());
 app.use(express.json());
 app.use("/api", applicationRoutes);
+app.use("/api", dashboardRoutes);
 app.use("/api", levelRoutes);
 app.use("/api", schoolYearRoutes);
 


### PR DESCRIPTION
## Objectif

Implémenter un endpoint de statistiques pour alimenter le dashboard admin.

## Contenu

Ajout du endpoint GET /api/dashboard/stats avec :

- nombre total de demandes
- répartition des demandes par statut
- répartition des élèves par niveau
- liste des demandes prioritaires

## Détail des données retournées

### totalApplications
Nombre total de demandes d’inscription

### byStatus
Répartition des demandes par statut :
- RECEIVED
- IN_REVIEW
- ACCEPTED
- REFUSED

### byLevel
Répartition des élèves par niveau, triée selon l’ordre métier

### priorityApplications
Liste des demandes marquées `isPriority = true`, avec :
- family
- schoolYear
- students
- students.level

## Technique

- Express + TypeScript
- Prisma Client singleton existant
- `count` pour le total
- `groupBy` pour les statuts
- `_count.students` via les niveaux
- `findMany` pour les demandes prioritaires

## Vérifications

- [x] npm exec -w apps/api tsc -- --noEmit
- [x] npm run dev:api
- [x] GET /api/dashboard/stats : 200 OK
- [x] totalApplications cohérent avec le seed
- [x] byStatus cohérent avec le seed
- [x] byLevel trié dans l’ordre métier
- [x] priorityApplications contient uniquement les demandes prioritaires

## Valeurs constatées sur la base seedée

- totalApplications: 6
- byStatus:
  - RECEIVED: 2
  - IN_REVIEW: 1
  - ACCEPTED: 2
  - REFUSED: 1
- priorityApplications: 2 demandes

## Notes

- aucune modification du schéma Prisma
- aucune modification des migrations
- aucune modification des seeds
- endpoint prêt pour la future page dashboard du frontend