### PR TITLE
feat(api): add PATCH /api/school-years/:id/activate endpoint

### DIFF
--- a/apps/api/src/controllers/school-year.controller.ts
+++ b/apps/api/src/controllers/school-year.controller.ts
@@ -51,3 +51,46 @@ export const getActiveSchoolYear = async (_req: Request, res: Response): Promise
     res.status(500).json({ message: "Internal server error" });
   }
 };
+
+export const activateSchoolYear = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const schoolYearId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+
+    const existingSchoolYear = await prisma.schoolYear.findUnique({
+      where: { id: schoolYearId },
+      select: { id: true }
+    });
+
+    if (!existingSchoolYear) {
+      res.status(404).json({ message: "School year not found" });
+      return;
+    }
+
+    const [, activatedSchoolYear] = await prisma.$transaction([
+      prisma.schoolYear.updateMany({
+        where: {
+          id: { not: schoolYearId }
+        },
+        data: { isActive: false }
+      }),
+      prisma.schoolYear.update({
+        where: { id: schoolYearId },
+        data: { isActive: true },
+        select: {
+          id: true,
+          label: true,
+          startYear: true,
+          endYear: true,
+          isActive: true,
+          createdAt: true,
+          updatedAt: true
+        }
+      })
+    ]);
+
+    res.status(200).json(activatedSchoolYear);
+  } catch (error) {
+    console.error("Failed to activate school year:", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+};

--- a/apps/api/src/routes/school-year.routes.ts
+++ b/apps/api/src/routes/school-year.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 
 import {
+  activateSchoolYear,
   getActiveSchoolYear,
   getSchoolYears
 } from "../controllers/school-year.controller";
@@ -9,5 +10,6 @@ const router = Router();
 
 router.get("/school-years/active", getActiveSchoolYear);
 router.get("/school-years", getSchoolYears);
+router.patch("/school-years/:id/activate", activateSchoolYear);
 
 export default router;


### PR DESCRIPTION
## Objectif

Implémenter un endpoint permettant d’activer une année scolaire et de désactiver toutes les autres.

## Contenu

- ajout du endpoint PATCH /api/school-years/:id/activate
- vérification de l’existence de l’année scolaire
- exécution d’une transaction Prisma pour :
  - désactiver les autres années
  - activer l’année ciblée
- retour de l’année activée

## Comportement

- `404` si l’année scolaire n’existe pas
- `200` avec l’année activée si l’opération réussit

## Technique

- Express + TypeScript
- Prisma Client singleton existant
- transaction Prisma via `prisma.$transaction`
- aucune modification de l’architecture globale

## Vérifications

- [x] npm run dev:api
- [x] PATCH /api/school-years/not-found/activate : 404
- [x] PATCH /api/school-years/:id/activate : 200
- [x] une seule année scolaire active après appel
- [x] GET /api/school-years/active retourne la nouvelle année active
- [x] année initiale restaurée après test

## Notes

- aucune modification du schéma Prisma
- aucune modification des migrations
- aucune modification des seeds
- server.ts inchangé