### PR TITLE
feat(api): add PATCH /api/levels/:id/available-places endpoint

### DIFF
--- a/apps/api/src/controllers/level.controller.ts
+++ b/apps/api/src/controllers/level.controller.ts
@@ -21,3 +21,42 @@ export const getLevels = async (_req: Request, res: Response): Promise<void> => 
     res.status(500).json({ message: "Internal server error" });
   }
 };
+
+export const updateLevelAvailablePlaces = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const levelId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+    const availablePlaces = req.body?.availablePlaces;
+
+    if (
+      typeof availablePlaces !== "number" ||
+      !Number.isInteger(availablePlaces) ||
+      availablePlaces < 0
+    ) {
+      res.status(400).json({ message: "Invalid available places value" });
+      return;
+    }
+
+    const existingLevel = await prisma.level.findUnique({
+      where: { id: levelId },
+      select: { id: true }
+    });
+
+    if (!existingLevel) {
+      res.status(404).json({ message: "Level not found" });
+      return;
+    }
+
+    const updatedLevel = await prisma.level.update({
+      where: { id: levelId },
+      data: { availablePlaces }
+    });
+
+    res.status(200).json(updatedLevel);
+  } catch (error) {
+    console.error("Failed to update level available places:", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+};

--- a/apps/api/src/routes/level.routes.ts
+++ b/apps/api/src/routes/level.routes.ts
@@ -1,9 +1,13 @@
 import { Router } from "express";
 
-import { getLevels } from "../controllers/level.controller";
+import {
+  getLevels,
+  updateLevelAvailablePlaces
+} from "../controllers/level.controller";
 
 const router = Router();
 
 router.get("/levels", getLevels);
+router.patch("/levels/:id/available-places", updateLevelAvailablePlaces);
 
 export default router;


### PR DESCRIPTION
## Objectif

Implémenter un endpoint permettant de mettre à jour le nombre de places disponibles d’un niveau.

## Contenu

- ajout du endpoint PATCH /api/levels/:id/available-places
- validation stricte de `req.body.availablePlaces`
- vérification de l’existence du niveau
- mise à jour ciblée du champ `availablePlaces`

## Comportement

- `400` si `availablePlaces` est absent, invalide ou négatif
- `404` si le niveau n’existe pas
- `200` avec le niveau mis à jour si tout est valide

## Technique

- Express + TypeScript
- Prisma Client singleton existant
- aucune logique métier supplémentaire
- update ciblé sur un seul champ

## Vérifications

- [x] tsc --noEmit -p apps/api/tsconfig.json
- [x] npm run dev:api
- [x] PATCH avec valeur invalide : 400
- [x] PATCH avec id inexistant : 404
- [x] PATCH avec valeur valide : 200
- [x] GET /api/levels reflète bien la nouvelle valeur
- [x] donnée de test restaurée après vérification

## Notes

- aucune modification du schéma Prisma
- aucune modification des migrations
- aucune modification des seeds