### PR TITLE
feat(api): add GET /api/applications/:id/email-logs endpoint

### DIFF
--- a/apps/api/src/controllers/application.controller.ts
+++ b/apps/api/src/controllers/application.controller.ts
@@ -179,6 +179,35 @@ export const getApplicationById = async (req: Request, res: Response): Promise<v
   }
 };
 
+export const getApplicationEmailLogs = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const applicationId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+
+    const existingApplication = await prisma.application.findUnique({
+      where: { id: applicationId },
+      select: { id: true }
+    });
+
+    if (!existingApplication) {
+      res.status(404).json({ message: "Application not found" });
+      return;
+    }
+
+    const emailLogs = await prisma.applicationEmailLog.findMany({
+      where: { applicationId },
+      orderBy: { createdAt: "desc" }
+    });
+
+    res.status(200).json(emailLogs);
+  } catch (error) {
+    console.error("Failed to fetch application email logs:", error);
+    res.status(500).json({ message: "Internal server error" });
+  }
+};
+
 export const updateApplicationStatus = async (req: Request, res: Response): Promise<void> => {
   try {
     const applicationId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;

--- a/apps/api/src/routes/application.routes.ts
+++ b/apps/api/src/routes/application.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 
 import {
+  getApplicationEmailLogs,
   updateApplicationDecision,
   getApplicationById,
   getApplications,
@@ -13,6 +14,7 @@ const router = Router();
 
 router.get("/applications", getApplications);
 router.get("/applications/:id", getApplicationById);
+router.get("/applications/:id/email-logs", getApplicationEmailLogs);
 router.patch("/applications/:id/status", updateApplicationStatus);
 router.patch("/applications/:id/priority", updateApplicationPriority);
 router.patch("/applications/:id/decision", updateApplicationDecision);


### PR DESCRIPTION
## Objectif

Permettre de récupérer les logs email d’une demande d’inscription.

## Contenu

- ajout du endpoint GET /api/applications/:id/email-logs
- vérification de l’existence de la demande
- récupération des logs email associés
- tri par createdAt DESC

## Comportement

- `404` si la demande n’existe pas
- `200` avec la liste des logs email sinon
- `500` en cas d’erreur serveur

## Technique

- Prisma Client singleton
- requête sur ApplicationEmailLog
- tri descendant sur createdAt
- aucun impact sur les autres endpoints

## Vérifications

- [x] tsc --noEmit OK
- [x] npm run dev:api OK
- [x] GET avec id invalide → 404
- [x] GET avec id valide → 200
- [x] logs correctement triés (DESC)
- [x] cohérence avec POST /send-email validée
- [x] base locale remise dans l’état propre du seed après test

## Notes

- aucun changement sur schema Prisma
- aucune modification des migrations
- aucune modification des seeds