### PR TITLE
feat(web): add dashboard page connected to API

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,16 +1,7 @@
-import './App.css'
+import DashboardPage from "./pages/DashboardPage";
 
 function App() {
-  return (
-    <main className="min-h-screen bg-background p-8">
-      <div className="mx-auto max-w-4xl rounded-xl border border-border bg-white p-6 shadow-sm">
-        <h1 className="text-3xl font-semibold text-primary">ECE Admin App</h1>
-        <p className="mt-2 text-gray-600">
-          Initialisation du projet en cours.
-        </p>
-      </div>
-    </main>
-  );
+  return <DashboardPage />;
 }
 
 export default App;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3,13 +3,33 @@
 @tailwind utilities;
 
 :root {
-  font-family: Inter, system-ui, sans-serif;
+  font-family: "Avenir Next", "Segoe UI", "Helvetica Neue", sans-serif;
+  color: #172033;
+  background:
+    radial-gradient(circle at top left, rgba(212, 162, 76, 0.12), transparent 28%),
+    radial-gradient(circle at top right, rgba(31, 77, 58, 0.12), transparent 32%),
+    #f8f6f2;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+#root {
+  min-height: 100vh;
 }
 
 body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
-  background: #F8F6F2;
-  color: #1F2937;
+  background: inherit;
+  color: inherit;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,0 +1,46 @@
+import type { DashboardStats } from "../types/dashboard";
+
+const API_BASE_URL = (import.meta.env.VITE_API_URL ?? "").replace(/\/$/, "");
+
+const buildApiUrl = (path: string): string => {
+  return `${API_BASE_URL}${path}`;
+};
+
+const getErrorMessage = async (response: Response): Promise<string> => {
+  try {
+    const data = (await response.json()) as { message?: unknown };
+
+    if (typeof data.message === "string" && data.message.trim().length > 0) {
+      return data.message;
+    }
+  } catch {
+    // Ignore invalid JSON and fall back to the HTTP status.
+  }
+
+  return `La requête a échoué (${response.status}).`;
+};
+
+export const fetchJson = async <T>(
+  path: string,
+  init?: RequestInit
+): Promise<T> => {
+  const response = await fetch(buildApiUrl(path), {
+    ...init,
+    headers: {
+      Accept: "application/json",
+      ...init?.headers
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(await getErrorMessage(response));
+  }
+
+  return (await response.json()) as T;
+};
+
+export const fetchDashboardStats = async (
+  init?: RequestInit
+): Promise<DashboardStats> => {
+  return fetchJson<DashboardStats>("/api/dashboard/stats", init);
+};

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,0 +1,448 @@
+import { useEffect, useState } from "react";
+
+import { fetchDashboardStats } from "../lib/api";
+import type {
+  DashboardApplicationStatus,
+  DashboardPriorityApplication,
+  DashboardStats
+} from "../types/dashboard";
+
+type StatusCardConfig = {
+  status: DashboardApplicationStatus;
+  label: string;
+  description: string;
+  valueClassName: string;
+};
+
+const statusCards: StatusCardConfig[] = [
+  {
+    status: "RECEIVED",
+    label: "Reçues",
+    description: "Demandes nouvellement importées ou enregistrées.",
+    valueClassName: "text-slate-900"
+  },
+  {
+    status: "IN_REVIEW",
+    label: "En revue",
+    description: "Demandes en cours d'analyse par l'administration.",
+    valueClassName: "text-info"
+  },
+  {
+    status: "ACCEPTED",
+    label: "Acceptées",
+    description: "Décisions favorables déjà prises.",
+    valueClassName: "text-success"
+  },
+  {
+    status: "REFUSED",
+    label: "Refusées",
+    description: "Demandes clôturées avec décision négative.",
+    valueClassName: "text-danger"
+  }
+];
+
+const priorityStatusStyles: Record<DashboardApplicationStatus, string> = {
+  RECEIVED: "bg-slate-100 text-slate-700 ring-slate-200",
+  IN_REVIEW: "bg-info/15 text-info ring-info/20",
+  ACCEPTED: "bg-success/15 text-success ring-success/20",
+  REFUSED: "bg-danger/15 text-danger ring-danger/20"
+};
+
+const priorityStatusLabels: Record<DashboardApplicationStatus, string> = {
+  RECEIVED: "Reçue",
+  IN_REVIEW: "En revue",
+  ACCEPTED: "Acceptée",
+  REFUSED: "Refusée"
+};
+
+const createdAtFormatter = new Intl.DateTimeFormat("fr-FR", {
+  dateStyle: "medium",
+  timeStyle: "short"
+});
+
+const isAbortError = (error: unknown): boolean => {
+  return error instanceof DOMException && error.name === "AbortError";
+};
+
+const getFamilyDisplayName = (
+  application: DashboardPriorityApplication
+): string => {
+  const familyNames = [
+    application.family.fatherLastName,
+    application.family.motherLastName
+  ].filter((value): value is string => typeof value === "string" && value.trim().length > 0);
+
+  if (familyNames.length > 0) {
+    return Array.from(new Set(familyNames)).join(" / ");
+  }
+
+  const studentLastNames = application.students
+    .map((student) => student.lastName.trim())
+    .filter((value) => value.length > 0);
+
+  if (studentLastNames.length > 0) {
+    return Array.from(new Set(studentLastNames)).join(" / ");
+  }
+
+  return "Famille non renseignée";
+};
+
+const getPriorityDescription = (
+  application: DashboardPriorityApplication
+): string => {
+  if (application.students.length === 0) {
+    return "Aucun élève rattaché à cette demande.";
+  }
+
+  return application.students
+    .map(
+      (student) => `${student.firstName} ${student.lastName} · ${student.level.label}`
+    )
+    .join(" | ");
+};
+
+type MetricCardProps = {
+  label: string;
+  value: number;
+  description: string;
+  valueClassName?: string;
+};
+
+const MetricCard = ({
+  label,
+  value,
+  description,
+  valueClassName = "text-primary"
+}: MetricCardProps) => {
+  return (
+    <article className="rounded-3xl border border-white/80 bg-white/90 p-5 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] backdrop-blur">
+      <p className="text-sm font-medium uppercase tracking-[0.2em] text-slate-500">
+        {label}
+      </p>
+      <p className={`mt-4 text-4xl font-semibold ${valueClassName}`}>{value}</p>
+      <p className="mt-3 text-sm leading-6 text-slate-600">{description}</p>
+    </article>
+  );
+};
+
+const LoadingState = () => {
+  return (
+    <section className="space-y-6" aria-live="polite" aria-busy="true">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+        {Array.from({ length: 5 }, (_, index) => (
+          <div
+            key={index}
+            className="h-40 animate-pulse rounded-3xl border border-white/70 bg-white/70"
+          />
+        ))}
+      </div>
+      <div className="grid gap-6 xl:grid-cols-[1.1fr_1.4fr]">
+        <div className="h-80 animate-pulse rounded-3xl border border-white/70 bg-white/70" />
+        <div className="h-80 animate-pulse rounded-3xl border border-white/70 bg-white/70" />
+      </div>
+    </section>
+  );
+};
+
+const ErrorState = ({
+  message,
+  onRetry
+}: {
+  message: string;
+  onRetry: () => void;
+}) => {
+  return (
+    <section className="rounded-3xl border border-danger/20 bg-white/90 p-8 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)]">
+      <p className="text-sm font-semibold uppercase tracking-[0.2em] text-danger">
+        Erreur API
+      </p>
+      <h2 className="mt-3 text-2xl font-semibold text-slate-900">
+        Impossible de charger le dashboard
+      </h2>
+      <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">{message}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-6 inline-flex items-center rounded-full bg-danger px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-red-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-danger"
+      >
+        Réessayer
+      </button>
+    </section>
+  );
+};
+
+const EmptyState = () => {
+  return (
+    <section className="rounded-3xl border border-dashed border-border bg-white/85 p-10 text-center shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)]">
+      <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primaryLight">
+        Dashboard vide
+      </p>
+      <h2 className="mt-3 text-2xl font-semibold text-slate-900">
+        Aucune demande n&apos;est encore disponible
+      </h2>
+      <p className="mt-3 text-sm leading-6 text-slate-600">
+        Les cartes et les listes s&apos;alimenteront automatiquement dès qu&apos;une
+        demande et des élèves seront présents en base.
+      </p>
+    </section>
+  );
+};
+
+const DashboardPage = () => {
+  const [data, setData] = useState<DashboardStats | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const loadDashboard = async (signal?: AbortSignal): Promise<void> => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const dashboardData = await fetchDashboardStats({ signal });
+
+      if (signal?.aborted) {
+        return;
+      }
+
+      setData(dashboardData);
+    } catch (loadError) {
+      if (isAbortError(loadError) || signal?.aborted) {
+        return;
+      }
+
+      setData(null);
+      setError(
+        loadError instanceof Error
+          ? loadError.message
+          : "Une erreur inattendue est survenue."
+      );
+    } finally {
+      if (!signal?.aborted) {
+        setIsLoading(false);
+      }
+    }
+  };
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    void loadDashboard(controller.signal);
+
+    return () => {
+      controller.abort();
+    };
+  }, []);
+
+  if (isLoading && !data) {
+    return (
+      <main className="min-h-screen bg-background px-4 py-10 text-slate-900 sm:px-6 lg:px-8">
+        <DashboardShell>
+          <LoadingState />
+        </DashboardShell>
+      </main>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <main className="min-h-screen bg-background px-4 py-10 text-slate-900 sm:px-6 lg:px-8">
+        <DashboardShell>
+          <ErrorState message={error} onRetry={() => void loadDashboard()} />
+        </DashboardShell>
+      </main>
+    );
+  }
+
+  if (!data || data.totalApplications === 0) {
+    return (
+      <main className="min-h-screen bg-background px-4 py-10 text-slate-900 sm:px-6 lg:px-8">
+        <DashboardShell>
+          <EmptyState />
+        </DashboardShell>
+      </main>
+    );
+  }
+
+  const maxLevelCount = Math.max(...data.byLevel.map((level) => level.count), 0);
+
+  return (
+    <main className="min-h-screen bg-background px-4 py-10 text-slate-900 sm:px-6 lg:px-8">
+      <DashboardShell>
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+          <MetricCard
+            label="Demandes totales"
+            value={data.totalApplications}
+            description="Volume global des demandes présentes dans la base seedée."
+          />
+          {statusCards.map((card) => (
+            <MetricCard
+              key={card.status}
+              label={card.label}
+              value={data.byStatus[card.status]}
+              description={card.description}
+              valueClassName={card.valueClassName}
+            />
+          ))}
+        </section>
+
+        <section className="mt-6 grid gap-6 xl:grid-cols-[1.05fr_1.45fr]">
+          <article className="rounded-3xl border border-white/80 bg-white/90 p-6 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)]">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primaryLight">
+                  Répartition par niveau
+                </p>
+                <h2 className="mt-2 text-2xl font-semibold text-slate-900">
+                  Élèves par classe demandée
+                </h2>
+              </div>
+              <div className="rounded-full bg-secondary/15 px-4 py-2 text-sm font-medium text-secondaryDark">
+                {data.byLevel.reduce((sum, level) => sum + level.count, 0)} élèves
+              </div>
+            </div>
+
+            <div className="mt-6 space-y-4">
+              {data.byLevel.length === 0 ? (
+                <p className="rounded-2xl border border-dashed border-border bg-background/70 px-4 py-6 text-sm text-slate-500">
+                  Aucun niveau disponible.
+                </p>
+              ) : (
+                data.byLevel.map((level) => {
+                  const width =
+                    maxLevelCount === 0 ? 0 : (level.count / maxLevelCount) * 100;
+
+                  return (
+                    <div key={level.code} className="space-y-2">
+                      <div className="flex items-center justify-between gap-4">
+                        <div>
+                          <p className="font-semibold text-slate-900">{level.label}</p>
+                          <p className="text-sm text-slate-500">{level.code}</p>
+                        </div>
+                        <p className="text-sm font-semibold text-slate-700">
+                          {level.count}
+                        </p>
+                      </div>
+                      <div className="h-3 overflow-hidden rounded-full bg-slate-100">
+                        <div
+                          className="h-full rounded-full bg-primary"
+                          style={{ width: `${width}%` }}
+                        />
+                      </div>
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          </article>
+
+          <article className="rounded-3xl border border-white/80 bg-white/90 p-6 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)]">
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primaryLight">
+                  Demandes prioritaires
+                </p>
+                <h2 className="mt-2 text-2xl font-semibold text-slate-900">
+                  Dossiers à traiter en priorité
+                </h2>
+              </div>
+              <div className="rounded-full bg-primary/10 px-4 py-2 text-sm font-medium text-primaryDark">
+                {data.priorityApplications.length} priorité
+                {data.priorityApplications.length > 1 ? "s" : ""}
+              </div>
+            </div>
+
+            <div className="mt-6 space-y-4">
+              {data.priorityApplications.length === 0 ? (
+                <p className="rounded-2xl border border-dashed border-border bg-background/70 px-4 py-6 text-sm text-slate-500">
+                  Aucune demande prioritaire pour le moment.
+                </p>
+              ) : (
+                data.priorityApplications.map((application) => (
+                  <article
+                    key={application.id}
+                    className="rounded-3xl border border-slate-200 bg-slate-50/80 p-5"
+                  >
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <h3 className="text-lg font-semibold text-slate-900">
+                            Famille {getFamilyDisplayName(application)}
+                          </h3>
+                          <span className="rounded-full bg-secondary/20 px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-secondaryDark">
+                            Prioritaire
+                          </span>
+                        </div>
+                        <p className="mt-2 text-sm text-slate-500">
+                          {application.schoolYear.label}
+                          {application.schoolYear.isActive ? " · année active" : ""}
+                        </p>
+                      </div>
+                      <span
+                        className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ring-1 ${priorityStatusStyles[application.status]}`}
+                      >
+                        {priorityStatusLabels[application.status]}
+                      </span>
+                    </div>
+
+                    <p className="mt-4 text-sm leading-6 text-slate-600">
+                      {getPriorityDescription(application)}
+                    </p>
+
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      {application.students.map((student) => (
+                        <span
+                          key={`${application.id}-${student.firstName}-${student.lastName}-${student.level.code}`}
+                          className="rounded-full bg-white px-3 py-1.5 text-xs font-medium text-slate-700 ring-1 ring-slate-200"
+                        >
+                          {student.firstName} {student.lastName} · {student.level.code}
+                        </span>
+                      ))}
+                    </div>
+
+                    <div className="mt-5 flex flex-wrap items-center justify-between gap-3 border-t border-slate-200 pt-4 text-sm text-slate-500">
+                      <span>
+                        Contact : {application.family.contactEmail ?? "non renseigné"}
+                      </span>
+                      <span>Créée le {createdAtFormatter.format(new Date(application.createdAt))}</span>
+                    </div>
+                  </article>
+                ))
+              )}
+            </div>
+          </article>
+        </section>
+      </DashboardShell>
+    </main>
+  );
+};
+
+const DashboardShell = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div className="relative mx-auto max-w-7xl">
+      <div className="absolute inset-x-0 top-0 -z-10 h-56 rounded-[2rem] bg-gradient-to-r from-secondary/15 via-white/30 to-primary/10 blur-3xl" />
+      <header className="mb-8 rounded-[2rem] border border-white/80 bg-white/85 p-6 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] backdrop-blur sm:p-8">
+        <p className="text-sm font-semibold uppercase tracking-[0.24em] text-primaryLight">
+          Dashboard Admin
+        </p>
+        <div className="mt-3 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <h1 className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
+              Vue d&apos;ensemble des demandes d&apos;inscription
+            </h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-600 sm:text-base">
+              Première version branchée sur l&apos;API réelle pour suivre le volume
+              global, les statuts, la répartition des élèves et les dossiers
+              prioritaires.
+            </p>
+          </div>
+          <div className="rounded-2xl border border-primary/10 bg-primary/5 px-4 py-3 text-sm text-primaryDark">
+            Source : <span className="font-semibold">GET /api/dashboard/stats</span>
+          </div>
+        </div>
+      </header>
+      {children}
+    </div>
+  );
+};
+
+export default DashboardPage;

--- a/apps/web/src/types/dashboard.ts
+++ b/apps/web/src/types/dashboard.ts
@@ -1,0 +1,44 @@
+export type DashboardApplicationStatus =
+  | "RECEIVED"
+  | "IN_REVIEW"
+  | "ACCEPTED"
+  | "REFUSED";
+
+export type DashboardStats = {
+  totalApplications: number;
+  byStatus: Record<DashboardApplicationStatus, number>;
+  byLevel: DashboardLevelStat[];
+  priorityApplications: DashboardPriorityApplication[];
+};
+
+export type DashboardLevelStat = {
+  code: string;
+  label: string;
+  count: number;
+};
+
+export type DashboardPriorityApplication = {
+  id: string;
+  status: DashboardApplicationStatus;
+  isPriority: boolean;
+  createdAt: string;
+  family: {
+    contactEmail: string | null;
+    fatherLastName: string | null;
+    motherLastName: string | null;
+  };
+  schoolYear: {
+    label: string;
+    isActive: boolean;
+  };
+  students: DashboardPriorityStudent[];
+};
+
+export type DashboardPriorityStudent = {
+  firstName: string;
+  lastName: string;
+  level: {
+    code: string;
+    label: string;
+  };
+};

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,4 +4,12 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:3000",
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Objectif

Créer une première page Dashboard côté frontend branchée sur l’API réelle.

## Contenu

- création de la page Dashboard
- consommation de `GET /api/dashboard/stats`
- affichage des cartes de synthèse :
  - totalApplications
  - RECEIVED
  - IN_REVIEW
  - ACCEPTED
  - REFUSED
- affichage de la répartition par niveau
- affichage des demandes prioritaires
- gestion des états :
  - loading
  - error
  - empty

## Technique

- React + Vite + TypeScript
- petit client API frontend dédié
- types frontend pour le payload dashboard
- proxy Vite `/api` → `http://localhost:3000` en développement

## Fichiers concernés

- `apps/web/src/pages/DashboardPage.tsx`
- `apps/web/src/lib/api.ts`
- `apps/web/src/types/dashboard.ts`
- `apps/web/src/App.tsx`
- `apps/web/src/index.css`
- `apps/web/vite.config.ts`

## Vérifications

- [x] `npm exec -w apps/web -- tsc -b`
- [x] `npm run build -w apps/web`
- [x] `npm run dev:api`
- [x] `npm run dev:web`
- [x] le proxy Vite retourne bien les données de `/api/dashboard/stats`
- [x] les données seedées sont affichables côté frontend
- [x] le chemin d’erreur fonctionne si le backend est indisponible

## Notes

- aucune modification du backend dans cette PR
- première page frontend réellement branchée à l’API
- base solide pour la suite du back-office