### PR TITLE
feat(api): add isPriority filter to GET /api/applications

### DIFF
--- a/apps/api/src/controllers/application.controller.ts
+++ b/apps/api/src/controllers/application.controller.ts
@@ -55,6 +55,7 @@ export const getApplications = async (req: Request, res: Response): Promise<void
   try {
     const status = getQueryParam(req.query.status);
     const schoolYearId = getQueryParam(req.query.schoolYearId);
+    const isPriority = getQueryParam(req.query.isPriority);
     const search = getQueryParam(req.query.search);
     const where: Prisma.ApplicationWhereInput = {};
 
@@ -69,6 +70,15 @@ export const getApplications = async (req: Request, res: Response): Promise<void
 
     if (schoolYearId) {
       where.schoolYearId = schoolYearId;
+    }
+
+    if (isPriority) {
+      if (isPriority !== "true" && isPriority !== "false") {
+        res.status(400).json({ message: "Invalid priority filter" });
+        return;
+      }
+
+      where.isPriority = isPriority === "true";
     }
 
     if (search) {


### PR DESCRIPTION
## Objectif

Étendre l’endpoint GET /api/applications pour permettre de filtrer les demandes prioritaires.

## Contenu

- ajout du filtre optionnel `isPriority`
- support des valeurs :
  - `true`
  - `false`
- conservation des filtres existants :
  - `status`
  - `schoolYearId`
  - `search`
- combinaison naturelle avec les autres filtres

## Comportement

- si `isPriority` est absent :
  - aucun filtre supplémentaire n’est appliqué
- si `isPriority=true` :
  - retourne uniquement les demandes prioritaires
- si `isPriority=false` :
  - retourne uniquement les demandes non prioritaires
- si `isPriority` est invalide :
  - `400` avec `{ "message": "Invalid priority filter" }`

## Technique

- Express + TypeScript
- modification ciblée dans le controller
- tri `createdAt DESC` conservé
- includes Prisma conservés :
  - `family`
  - `schoolYear`
  - `students`
  - `students.level`

## Vérifications

- [x] npx tsc --noEmit -p apps/api/tsconfig.json
- [x] npm run dev:api
- [x] GET /api/applications
- [x] GET /api/applications?isPriority=true
- [x] GET /api/applications?isPriority=false
- [x] combinaison avec les autres filtres
- [x] valeur invalide → 400
- [x] aucune régression sur le tri ni sur les includes

## Notes

- aucune modification du schéma Prisma
- aucune modification des migrations
- aucune modification des seeds
- route inchangée