### PR TITLE
feat(web): add application detail page connected to API

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,3 +1,4 @@
+import ApplicationDetailPage from "./pages/ApplicationDetailPage";
 import ApplicationsPage from "./pages/ApplicationsPage";
 import DashboardPage from "./pages/DashboardPage";
 
@@ -23,76 +24,6 @@ const getApplicationDetailId = (pathname: string): string | null => {
   }
 
   return decodePathSegment(match[1]);
-};
-
-const ApplicationDetailPlaceholderPage = ({
-  applicationId
-}: {
-  applicationId: string;
-}) => {
-  return (
-    <main className="min-h-screen bg-background px-4 py-10 text-slate-900 sm:px-6 lg:px-8">
-      <div className="relative mx-auto max-w-5xl">
-        <div className="absolute inset-x-0 top-0 -z-10 h-56 rounded-[2rem] bg-gradient-to-r from-secondary/15 via-white/30 to-primary/10 blur-3xl" />
-
-        <section className="rounded-[2rem] border border-white/80 bg-white/90 p-6 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] backdrop-blur sm:p-8">
-          <div className="flex flex-wrap gap-2">
-            <a
-              href="/"
-              className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary/25 hover:text-primaryDark"
-            >
-              Dashboard
-            </a>
-            <a
-              href="/applications"
-              className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary/25 hover:text-primaryDark"
-            >
-              Demandes
-            </a>
-            <span className="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white">
-              Détail
-            </span>
-          </div>
-
-          <p className="mt-6 text-sm font-semibold uppercase tracking-[0.24em] text-primaryLight">
-            Détail Demande
-          </p>
-          <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
-            Page détail à finaliser
-          </h1>
-          <p className="mt-4 max-w-3xl text-sm leading-6 text-slate-600 sm:text-base">
-            Le backend expose déjà <span className="font-semibold">GET /api/applications/:id</span>.
-            Cette route frontend sert pour l&apos;instant de point d&apos;entrée depuis
-            la liste en attendant la fiche complète.
-          </p>
-
-          <div className="mt-6 rounded-3xl border border-slate-200 bg-slate-50/80 p-5">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-              Identifiant ciblé
-            </p>
-            <p className="mt-2 break-all text-lg font-semibold text-slate-900">
-              {applicationId}
-            </p>
-          </div>
-
-          <div className="mt-8 flex flex-wrap gap-3">
-            <a
-              href="/applications"
-              className="inline-flex items-center rounded-full bg-primary px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-primaryDark"
-            >
-              Retour à la liste
-            </a>
-            <a
-              href="/"
-              className="inline-flex items-center rounded-full border border-slate-300 px-5 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
-            >
-              Retour au dashboard
-            </a>
-          </div>
-        </section>
-      </div>
-    </main>
-  );
 };
 
 const NotFoundPage = () => {
@@ -141,7 +72,7 @@ function App() {
   }
 
   if (applicationId) {
-    return <ApplicationDetailPlaceholderPage applicationId={applicationId} />;
+    return <ApplicationDetailPage applicationId={applicationId} />;
   }
 
   return <NotFoundPage />;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,5 +1,7 @@
 import type {
+  ApplicationDetail,
   ApplicationFilterParams,
+  ApplicationEmailLog,
   ApplicationListItem,
   SchoolYearSummary
 } from "../types/application";
@@ -78,6 +80,26 @@ export const getApplications = async (
   });
 
   return fetchJson<ApplicationListItem[]>(`/api/applications${queryString}`, init);
+};
+
+export const getApplicationById = async (
+  applicationId: string,
+  init?: RequestInit
+): Promise<ApplicationDetail> => {
+  return fetchJson<ApplicationDetail>(
+    `/api/applications/${encodeURIComponent(applicationId)}`,
+    init
+  );
+};
+
+export const getApplicationEmailLogs = async (
+  applicationId: string,
+  init?: RequestInit
+): Promise<ApplicationEmailLog[]> => {
+  return fetchJson<ApplicationEmailLog[]>(
+    `/api/applications/${encodeURIComponent(applicationId)}/email-logs`,
+    init
+  );
 };
 
 export const getSchoolYears = async (

--- a/apps/web/src/pages/ApplicationDetailPage.tsx
+++ b/apps/web/src/pages/ApplicationDetailPage.tsx
@@ -1,0 +1,567 @@
+import { useEffect, useState } from "react";
+
+import { getApplicationById, getApplicationEmailLogs } from "../lib/api";
+import type {
+  ApplicationDetail,
+  ApplicationEmailLog,
+  ApplicationEmailSendStatus,
+  ApplicationEmailType,
+  ApplicationGender,
+  ApplicationStatus
+} from "../types/application";
+
+const statusLabels: Record<ApplicationStatus, string> = {
+  RECEIVED: "Reçue",
+  IN_REVIEW: "En revue",
+  ACCEPTED: "Acceptée",
+  REFUSED: "Refusée"
+};
+
+const statusStyles: Record<ApplicationStatus, string> = {
+  RECEIVED: "bg-slate-100 text-slate-700 ring-slate-200",
+  IN_REVIEW: "bg-info/15 text-info ring-info/20",
+  ACCEPTED: "bg-success/15 text-success ring-success/20",
+  REFUSED: "bg-danger/15 text-danger ring-danger/20"
+};
+
+const emailTypeLabels: Record<ApplicationEmailType, string> = {
+  ACCEPTANCE: "Acceptation",
+  REFUSAL: "Refus",
+  CUSTOM: "Personnalisé"
+};
+
+const emailTypeStyles: Record<ApplicationEmailType, string> = {
+  ACCEPTANCE: "bg-success/10 text-success ring-success/20",
+  REFUSAL: "bg-danger/10 text-danger ring-danger/20",
+  CUSTOM: "bg-slate-100 text-slate-700 ring-slate-200"
+};
+
+const emailSendStatusLabels: Record<ApplicationEmailSendStatus, string> = {
+  PENDING: "En attente",
+  SENT: "Envoyé",
+  FAILED: "Échec"
+};
+
+const emailSendStatusStyles: Record<ApplicationEmailSendStatus, string> = {
+  PENDING: "bg-warning/10 text-warning ring-warning/20",
+  SENT: "bg-success/10 text-success ring-success/20",
+  FAILED: "bg-danger/10 text-danger ring-danger/20"
+};
+
+const genderLabels: Record<ApplicationGender, string> = {
+  BOY: "Garçon",
+  GIRL: "Fille",
+  UNKNOWN: "Non renseigné"
+};
+
+const dateTimeFormatter = new Intl.DateTimeFormat("fr-FR", {
+  dateStyle: "medium",
+  timeStyle: "short"
+});
+
+const dateFormatter = new Intl.DateTimeFormat("fr-FR", {
+  dateStyle: "medium"
+});
+
+const isAbortError = (error: unknown): boolean => {
+  return error instanceof DOMException && error.name === "AbortError";
+};
+
+const formatOptionalText = (value: string | null | undefined): string => {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value;
+  }
+
+  return "Non renseigné";
+};
+
+const formatOptionalDateTime = (value: string | null | undefined): string => {
+  if (!value) {
+    return "Non renseigné";
+  }
+
+  return dateTimeFormatter.format(new Date(value));
+};
+
+const formatOptionalDate = (value: string | null | undefined): string => {
+  if (!value) {
+    return "Non renseigné";
+  }
+
+  return dateFormatter.format(new Date(value));
+};
+
+const formatParentName = (
+  firstName: string | null | undefined,
+  lastName: string | null | undefined
+): string => {
+  const parts = [firstName, lastName].filter(
+    (value): value is string => typeof value === "string" && value.trim().length > 0
+  );
+
+  return parts.length > 0 ? parts.join(" ") : "Non renseigné";
+};
+
+const getApplicationFamilyTitle = (
+  application: ApplicationDetail | null
+): string => {
+  if (!application) {
+    return "Chargement du détail";
+  }
+
+  const familyNames = [
+    formatParentName(
+      application.family.fatherFirstName,
+      application.family.fatherLastName
+    ),
+    formatParentName(
+      application.family.motherFirstName,
+      application.family.motherLastName
+    )
+  ].filter((value, index, values) => {
+    return value !== "Non renseigné" && values.indexOf(value) === index;
+  });
+
+  if (familyNames.length > 0) {
+    return `Famille ${familyNames.join(" / ")}`;
+  }
+
+  return "Famille non renseignée";
+};
+
+const LoadingState = () => {
+  return (
+    <section className="space-y-6" aria-live="polite" aria-busy="true">
+      <div className="h-56 animate-pulse rounded-3xl border border-white/70 bg-white/70" />
+      <div className="grid gap-6 xl:grid-cols-2">
+        <div className="h-80 animate-pulse rounded-3xl border border-white/70 bg-white/70" />
+        <div className="h-80 animate-pulse rounded-3xl border border-white/70 bg-white/70" />
+      </div>
+      <div className="h-72 animate-pulse rounded-3xl border border-white/70 bg-white/70" />
+    </section>
+  );
+};
+
+const ErrorState = ({
+  message
+}: {
+  message: string;
+}) => {
+  const isNotFound = message === "Application not found";
+
+  return (
+    <section className="rounded-3xl border border-danger/20 bg-white/90 p-8 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)]">
+      <p className="text-sm font-semibold uppercase tracking-[0.2em] text-danger">
+        {isNotFound ? "Demande introuvable" : "Erreur API"}
+      </p>
+      <h2 className="mt-3 text-2xl font-semibold text-slate-900">
+        {isNotFound
+          ? "Cette demande n'existe pas ou n'est plus accessible"
+          : "Impossible de charger le détail de la demande"}
+      </h2>
+      <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+        {isNotFound
+          ? "Revenez à la liste des demandes et vérifiez l'identifiant ciblé."
+          : message}
+      </p>
+      <div className="mt-6 flex flex-wrap gap-3">
+        <a
+          href="/applications"
+          className="inline-flex items-center rounded-full bg-primary px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-primaryDark"
+        >
+          Retour à la liste
+        </a>
+        <a
+          href="/"
+          className="inline-flex items-center rounded-full border border-slate-300 px-5 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+        >
+          Retour au dashboard
+        </a>
+      </div>
+    </section>
+  );
+};
+
+const DetailField = ({
+  label,
+  value
+}: {
+  label: string;
+  value: string;
+}) => {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4">
+      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+        {label}
+      </p>
+      <p className="mt-2 text-sm font-semibold text-slate-900">{value}</p>
+    </div>
+  );
+};
+
+const SectionCard = ({
+  title,
+  subtitle,
+  children
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}) => {
+  return (
+    <section className="rounded-3xl border border-white/80 bg-white/90 p-6 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] backdrop-blur">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold text-slate-900">{title}</h2>
+          {subtitle ? (
+            <p className="mt-2 text-sm leading-6 text-slate-600">{subtitle}</p>
+          ) : null}
+        </div>
+      </div>
+      <div className="mt-6">{children}</div>
+    </section>
+  );
+};
+
+const ApplicationDetailPage = ({
+  applicationId
+}: {
+  applicationId: string;
+}) => {
+  const [application, setApplication] = useState<ApplicationDetail | null>(null);
+  const [emailLogs, setEmailLogs] = useState<ApplicationEmailLog[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const loadApplicationDetail = async (): Promise<void> => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const [applicationData, emailLogsData] = await Promise.all([
+          getApplicationById(applicationId, { signal: controller.signal }),
+          getApplicationEmailLogs(applicationId, { signal: controller.signal })
+        ]);
+
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        setApplication(applicationData);
+        setEmailLogs(emailLogsData);
+      } catch (loadError) {
+        if (isAbortError(loadError) || controller.signal.aborted) {
+          return;
+        }
+
+        setApplication(null);
+        setEmailLogs([]);
+        setError(
+          loadError instanceof Error
+            ? loadError.message
+            : "Une erreur inattendue est survenue."
+        );
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadApplicationDetail();
+
+    return () => {
+      controller.abort();
+    };
+  }, [applicationId]);
+
+  if (isLoading) {
+    return (
+      <main className="min-h-screen bg-background px-4 py-10 text-slate-900 sm:px-6 lg:px-8">
+        <ApplicationDetailShell application={null}>
+          <LoadingState />
+        </ApplicationDetailShell>
+      </main>
+    );
+  }
+
+  if (error || !application) {
+    return (
+      <main className="min-h-screen bg-background px-4 py-10 text-slate-900 sm:px-6 lg:px-8">
+        <ApplicationDetailShell application={null}>
+          <ErrorState message={error ?? "Application not found"} />
+        </ApplicationDetailShell>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-background px-4 py-10 text-slate-900 sm:px-6 lg:px-8">
+      <ApplicationDetailShell application={application}>
+        <div className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+          <SectionCard
+            title="Demande"
+            subtitle="Informations générales du dossier et état actuel de la décision."
+          >
+            <div className="grid gap-4 md:grid-cols-2">
+              <DetailField label="Identifiant" value={application.id} />
+              <DetailField
+                label="Créée le"
+                value={formatOptionalDateTime(application.createdAt)}
+              />
+              <DetailField label="Statut" value={statusLabels[application.status]} />
+              <DetailField
+                label="Priorité"
+                value={application.isPriority ? "Oui" : "Non"}
+              />
+              <DetailField
+                label="Décision prise le"
+                value={formatOptionalDateTime(application.decisionAt)}
+              />
+              <DetailField
+                label="Note de décision"
+                value={formatOptionalText(application.decisionNote)}
+              />
+            </div>
+          </SectionCard>
+
+          <SectionCard
+            title="Année scolaire"
+            subtitle="Campagne d'inscription associée à cette demande."
+          >
+            <div className="grid gap-4">
+              <DetailField label="Libellé" value={application.schoolYear.label} />
+              <DetailField
+                label="Statut"
+                value={application.schoolYear.isActive ? "Année active" : "Historique"}
+              />
+            </div>
+          </SectionCard>
+        </div>
+
+        <div className="mt-6 grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+          <SectionCard
+            title="Famille"
+            subtitle="Coordonnées et informations de contact utilisées par l'administration."
+          >
+            <div className="grid gap-4 md:grid-cols-2">
+              <DetailField
+                label="Email de contact"
+                value={formatOptionalText(application.family.contactEmail)}
+              />
+              <DetailField
+                label="Téléphone"
+                value={formatOptionalText(application.family.contactPhone)}
+              />
+              <DetailField
+                label="Père"
+                value={formatParentName(
+                  application.family.fatherFirstName,
+                  application.family.fatherLastName
+                )}
+              />
+              <DetailField
+                label="Mère"
+                value={formatParentName(
+                  application.family.motherFirstName,
+                  application.family.motherLastName
+                )}
+              />
+              <DetailField
+                label="Situation familiale"
+                value={formatOptionalText(application.family.familyStatus)}
+              />
+              <DetailField
+                label="Adresse postale"
+                value={formatOptionalText(application.family.postalAddress)}
+              />
+            </div>
+          </SectionCard>
+
+          <SectionCard
+            title="Élèves"
+            subtitle="Enfants rattachés à la demande et niveaux demandés."
+          >
+            {application.students.length === 0 ? (
+              <p className="rounded-2xl border border-dashed border-border bg-background/70 px-4 py-6 text-sm text-slate-500">
+                Aucun élève n'est rattaché à cette demande.
+              </p>
+            ) : (
+              <div className="space-y-4">
+                {application.students.map((student) => (
+                  <article
+                    key={student.id}
+                    className="rounded-3xl border border-slate-200 bg-slate-50/80 p-5"
+                  >
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <h3 className="text-lg font-semibold text-slate-900">
+                          {student.firstName} {student.lastName}
+                        </h3>
+                        <p className="mt-1 text-sm text-slate-500">
+                          {student.level.label} · {student.level.code}
+                        </p>
+                      </div>
+                      {student.rankInForm ? (
+                        <span className="rounded-full bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-slate-700 ring-1 ring-slate-200">
+                          Rang {student.rankInForm}
+                        </span>
+                      ) : null}
+                    </div>
+
+                    <div className="mt-4 grid gap-3 md:grid-cols-2">
+                      <DetailField label="Genre" value={genderLabels[student.gender]} />
+                      <DetailField
+                        label="Date de naissance"
+                        value={formatOptionalDate(student.birthDate)}
+                      />
+                    </div>
+                  </article>
+                ))}
+              </div>
+            )}
+          </SectionCard>
+        </div>
+
+        <div className="mt-6">
+          <SectionCard
+            title="Historique email"
+            subtitle="Logs métiers des emails envoyés ou simulés pour cette demande."
+          >
+            {emailLogs.length === 0 ? (
+              <p className="rounded-2xl border border-dashed border-border bg-background/70 px-4 py-6 text-sm text-slate-500">
+                Aucun email n'a encore été enregistré pour cette demande.
+              </p>
+            ) : (
+              <div className="space-y-4">
+                {emailLogs.map((emailLog) => (
+                  <article
+                    key={emailLog.id}
+                    className="rounded-3xl border border-slate-200 bg-slate-50/80 p-5"
+                  >
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <h3 className="text-lg font-semibold text-slate-900">
+                            {emailLog.subject}
+                          </h3>
+                          <span
+                            className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ring-1 ${emailTypeStyles[emailLog.emailType]}`}
+                          >
+                            {emailTypeLabels[emailLog.emailType]}
+                          </span>
+                          <span
+                            className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ring-1 ${emailSendStatusStyles[emailLog.sendStatus]}`}
+                          >
+                            {emailSendStatusLabels[emailLog.sendStatus]}
+                          </span>
+                        </div>
+                        <p className="mt-2 text-sm text-slate-500">
+                          Destinataire : {emailLog.recipientEmail}
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+                      <DetailField
+                        label="Type d'email"
+                        value={emailTypeLabels[emailLog.emailType]}
+                      />
+                      <DetailField
+                        label="Statut d'envoi"
+                        value={emailSendStatusLabels[emailLog.sendStatus]}
+                      />
+                      <DetailField
+                        label="Envoyé le"
+                        value={formatOptionalDateTime(emailLog.sentAt)}
+                      />
+                      <DetailField
+                        label="Log créé le"
+                        value={formatOptionalDateTime(emailLog.createdAt)}
+                      />
+                    </div>
+                  </article>
+                ))}
+              </div>
+            )}
+          </SectionCard>
+        </div>
+      </ApplicationDetailShell>
+    </main>
+  );
+};
+
+const ApplicationDetailShell = ({
+  application,
+  children
+}: {
+  application: ApplicationDetail | null;
+  children: React.ReactNode;
+}) => {
+  return (
+    <div className="relative mx-auto max-w-7xl">
+      <div className="absolute inset-x-0 top-0 -z-10 h-56 rounded-[2rem] bg-gradient-to-r from-secondary/15 via-white/30 to-primary/10 blur-3xl" />
+      <header className="mb-8 rounded-[2rem] border border-white/80 bg-white/85 p-6 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] backdrop-blur sm:p-8">
+        <div className="flex flex-wrap gap-2">
+          <a
+            href="/"
+            className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary/25 hover:text-primaryDark"
+          >
+            Dashboard
+          </a>
+          <a
+            href="/applications"
+            className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary/25 hover:text-primaryDark"
+          >
+            Demandes
+          </a>
+          <span className="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white">
+            Détail
+          </span>
+        </div>
+
+        <div className="mt-4 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-primaryLight">
+              Demande d'inscription
+            </p>
+            <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
+              {getApplicationFamilyTitle(application)}
+            </h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-600 sm:text-base">
+              Consultation détaillée d'une demande, de sa composition familiale, des
+              élèves rattachés et de l'historique email.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            {application ? (
+              <>
+                {application.isPriority ? (
+                  <span className="rounded-full bg-secondary/20 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-secondaryDark">
+                    Prioritaire
+                  </span>
+                ) : null}
+                <span
+                  className={`rounded-full px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] ring-1 ${statusStyles[application.status]}`}
+                >
+                  {statusLabels[application.status]}
+                </span>
+              </>
+            ) : (
+              <span className="rounded-full border border-primary/10 bg-primary/5 px-4 py-2 text-sm text-primaryDark">
+                Chargement...
+              </span>
+            )}
+          </div>
+        </div>
+      </header>
+      {children}
+    </div>
+  );
+};
+
+export default ApplicationDetailPage;

--- a/apps/web/src/types/application.ts
+++ b/apps/web/src/types/application.ts
@@ -9,6 +9,10 @@ export type ApplicationLevel = {
   label: string;
 };
 
+export type ApplicationGender = "BOY" | "GIRL" | "UNKNOWN";
+export type ApplicationEmailType = "ACCEPTANCE" | "REFUSAL" | "CUSTOM";
+export type ApplicationEmailSendStatus = "PENDING" | "SENT" | "FAILED";
+
 export type ApplicationStudent = {
   id: string;
   firstName: string;
@@ -16,10 +20,24 @@ export type ApplicationStudent = {
   level: ApplicationLevel;
 };
 
+export type ApplicationDetailStudent = ApplicationStudent & {
+  gender: ApplicationGender;
+  birthDate: string;
+  rankInForm: number | null;
+};
+
 export type ApplicationFamily = {
   contactEmail: string | null;
   fatherLastName: string | null;
   motherLastName: string | null;
+};
+
+export type ApplicationDetailFamily = ApplicationFamily & {
+  contactPhone: string | null;
+  fatherFirstName: string | null;
+  motherFirstName: string | null;
+  postalAddress: string | null;
+  familyStatus: string | null;
 };
 
 export type ApplicationSchoolYear = {
@@ -36,6 +54,30 @@ export type ApplicationListItem = {
   family: ApplicationFamily;
   schoolYear: ApplicationSchoolYear;
   students: ApplicationStudent[];
+};
+
+export type ApplicationDetail = {
+  id: string;
+  status: ApplicationStatus;
+  isPriority: boolean;
+  createdAt: string;
+  decisionAt: string | null;
+  decisionNote: string | null;
+  family: ApplicationDetailFamily;
+  schoolYear: ApplicationSchoolYear;
+  students: ApplicationDetailStudent[];
+};
+
+export type ApplicationEmailLog = {
+  id: string;
+  applicationId: string;
+  emailType: ApplicationEmailType;
+  recipientEmail: string;
+  subject: string;
+  bodySnapshot: string;
+  sentAt: string | null;
+  sendStatus: ApplicationEmailSendStatus;
+  createdAt: string;
 };
 
 export type ApplicationFilterParams = {


### PR DESCRIPTION
## Objectif

Créer une vraie page détail pour une demande d’inscription, branchée sur l’API réelle.

## Contenu

- création de la page `/applications/:id`
- chargement de la demande via `GET /api/applications/:id`
- chargement de l’historique email via `GET /api/applications/:id/email-logs`
- affichage structuré des blocs :
  - demande
  - famille
  - année scolaire
  - élèves
  - historique email
- ajout d’un lien de retour vers la liste
- gestion des états :
  - loading
  - error
  - empty

## Technique

- React + Vite + TypeScript
- proxy Vite existant
- types frontend enrichis pour le payload réel du détail
- aucune modification backend dans cette PR

## Fichiers concernés

- `apps/web/src/pages/ApplicationDetailPage.tsx`
- `apps/web/src/types/application.ts`
- `apps/web/src/lib/api.ts`
- `apps/web/src/App.tsx`

## Vérifications

- [x] `npm exec -w apps/web -- tsc -b`
- [x] `npm run build -w apps/web`
- [x] `npm run dev:web`
- [x] navigation vers `/applications/:id` fonctionnelle
- [x] chargement réel de `GET /api/applications/:id`
- [x] chargement réel de `GET /api/applications/:id/email-logs`
- [x] historique email non vide vérifié sur une demande seedée
- [x] aucune régression sur le dashboard
- [x] aucune régression sur la liste des demandes

## Notes

- aucune modification du backend
- première version fonctionnelle avant raffinement UI / pixel perfect
- base prête pour brancher ensuite les actions admin depuis cette page