### PR TITLE
feat(web): add priority action to application detail page

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -3,6 +3,7 @@ import type {
   ApplicationFilterParams,
   ApplicationEmailLog,
   ApplicationListItem,
+  ApplicationPriorityUpdateResult,
   ApplicationStatus,
   ApplicationStatusUpdateResult,
   SchoolYearSummary
@@ -119,6 +120,25 @@ export const updateApplicationStatus = async (
         ...init?.headers
       },
       body: JSON.stringify({ status })
+    }
+  );
+};
+
+export const updateApplicationPriority = async (
+  applicationId: string,
+  isPriority: boolean,
+  init?: RequestInit
+): Promise<ApplicationPriorityUpdateResult> => {
+  return fetchJson<ApplicationPriorityUpdateResult>(
+    `/api/applications/${encodeURIComponent(applicationId)}/priority`,
+    {
+      ...init,
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        ...init?.headers
+      },
+      body: JSON.stringify({ isPriority })
     }
   );
 };

--- a/apps/web/src/pages/ApplicationDetailPage.tsx
+++ b/apps/web/src/pages/ApplicationDetailPage.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import {
   getApplicationById,
   getApplicationEmailLogs,
+  updateApplicationPriority,
   updateApplicationStatus
 } from "../lib/api";
 import type {
@@ -264,6 +265,9 @@ const ApplicationDetailPage = ({
   const [statusActionError, setStatusActionError] = useState<string | null>(null);
   const [statusActionSuccess, setStatusActionSuccess] = useState<string | null>(null);
   const [isStatusSubmitting, setIsStatusSubmitting] = useState(false);
+  const [priorityActionError, setPriorityActionError] = useState<string | null>(null);
+  const [priorityActionSuccess, setPriorityActionSuccess] = useState<string | null>(null);
+  const [isPrioritySubmitting, setIsPrioritySubmitting] = useState(false);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -354,6 +358,49 @@ const ApplicationDetailPage = ({
       );
     } finally {
       setIsStatusSubmitting(false);
+    }
+  };
+
+  const handlePriorityToggle = async (): Promise<void> => {
+    if (!application) {
+      return;
+    }
+
+    const nextPriorityValue = !application.isPriority;
+
+    setIsPrioritySubmitting(true);
+    setPriorityActionError(null);
+    setPriorityActionSuccess(null);
+
+    try {
+      const updatedApplication = await updateApplicationPriority(
+        application.id,
+        nextPriorityValue
+      );
+
+      setApplication((currentApplication) => {
+        if (!currentApplication || currentApplication.id !== updatedApplication.id) {
+          return currentApplication;
+        }
+
+        return {
+          ...currentApplication,
+          isPriority: updatedApplication.isPriority
+        };
+      });
+      setPriorityActionSuccess(
+        nextPriorityValue
+          ? "La demande est maintenant prioritaire."
+          : "La priorité a été retirée."
+      );
+    } catch (updateError) {
+      setPriorityActionError(
+        updateError instanceof Error
+          ? updateError.message
+          : "Impossible de mettre à jour la priorité."
+      );
+    } finally {
+      setIsPrioritySubmitting(false);
     }
   };
 
@@ -476,6 +523,53 @@ const ApplicationDetailPage = ({
                   ) : null}
                 </div>
               </form>
+
+              <div className="mt-6 border-t border-slate-200 pt-6">
+                <div className="space-y-4">
+                  <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4">
+                    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                      Priorité actuelle
+                    </p>
+                    <div className="mt-2 flex flex-wrap items-center gap-2">
+                      {application.isPriority ? (
+                        <span className="rounded-full bg-secondary/20 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-secondaryDark">
+                          Prioritaire
+                        </span>
+                      ) : (
+                        <span className="rounded-full bg-slate-100 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-slate-700">
+                          Standard
+                        </span>
+                      )}
+                    </div>
+                  </div>
+
+                  <button
+                    type="button"
+                    onClick={() => void handlePriorityToggle()}
+                    disabled={isPrioritySubmitting}
+                    className="inline-flex items-center rounded-full border border-slate-300 px-5 py-2.5 text-sm font-semibold text-slate-800 transition hover:border-slate-400 hover:bg-slate-50 disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400"
+                  >
+                    {isPrioritySubmitting
+                      ? "Mise à jour..."
+                      : application.isPriority
+                        ? "Désactiver la priorité"
+                        : "Activer la priorité"}
+                  </button>
+
+                  <div className="space-y-2" aria-live="polite">
+                    {priorityActionSuccess ? (
+                      <p className="rounded-2xl border border-success/20 bg-success/10 px-4 py-3 text-sm text-success">
+                        {priorityActionSuccess}
+                      </p>
+                    ) : null}
+                    {priorityActionError ? (
+                      <p className="rounded-2xl border border-danger/20 bg-danger/10 px-4 py-3 text-sm text-danger">
+                        {priorityActionError}
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
             </SectionCard>
 
             <SectionCard

--- a/apps/web/src/types/application.ts
+++ b/apps/web/src/types/application.ts
@@ -85,6 +85,11 @@ export type ApplicationStatusUpdateResult = {
   status: ApplicationStatus;
 };
 
+export type ApplicationPriorityUpdateResult = {
+  id: string;
+  isPriority: boolean;
+};
+
 export type ApplicationFilterParams = {
   status?: ApplicationStatus;
   schoolYearId?: string;


### PR DESCRIPTION
## Objectif

Ajouter une action admin permettant d’activer ou de désactiver la priorité d’une demande depuis la page détail.

## Contenu

- ajout d’une action de priorité dans le bloc Actions
- appel de `PATCH /api/applications/:id/priority`
- gestion de l’état de soumission
- affichage d’un message de succès / erreur
- mise à jour locale de la demande après succès
- synchronisation immédiate du badge “Prioritaire”

## Technique

- React + Vite + TypeScript
- utilisation du client API frontend existant
- ajout de `updateApplicationPriority()` côté frontend
- aucune modification backend dans cette PR

## Fichiers concernés

- `apps/web/src/pages/ApplicationDetailPage.tsx`
- `apps/web/src/lib/api.ts`
- `apps/web/src/types/application.ts`

## Vérifications

- [x] `npm exec -w apps/web -- tsc -b`
- [x] `npm run build -w apps/web`
- [x] `npm run dev:web`
- [x] PATCH réel via le proxy Vite
- [x] `GET /api/applications/:id` reflète bien la nouvelle valeur de `isPriority`
- [x] badge prioritaire mis à jour après succès
- [x] restauration de l’état initial après test
- [x] aucune régression frontend constatée

## Notes

- aucune modification du backend
- deuxième action admin réellement branchée côté frontend
- la décision finale et l’envoi d’email seront traités dans des tâches suivantes