### PR TITLE
feat(ui): add global toast feedback system

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,3 +1,5 @@
+import ToastViewport from "./components/ui/ToastViewport";
+import { ToastProvider } from "./context/ToastContext";
 import ApplicationDetailPage from "./pages/ApplicationDetailPage";
 import ApplicationsPage from "./pages/ApplicationsPage";
 import DashboardPage from "./pages/DashboardPage";
@@ -59,7 +61,7 @@ const NotFoundPage = () => {
   );
 };
 
-function App() {
+const AppContent = () => {
   const pathname = normalizePathname(window.location.pathname);
   const applicationId = getApplicationDetailId(pathname);
 
@@ -76,6 +78,15 @@ function App() {
   }
 
   return <NotFoundPage />;
+};
+
+function App() {
+  return (
+    <ToastProvider>
+      <AppContent />
+      <ToastViewport />
+    </ToastProvider>
+  );
 }
 
 export default App;

--- a/apps/web/src/components/ui/Toast.tsx
+++ b/apps/web/src/components/ui/Toast.tsx
@@ -1,0 +1,67 @@
+import type { ToastItem, ToastType } from "../../context/ToastContext";
+
+type ToastProps = {
+  toast: ToastItem;
+  onDismiss: (toastId: number) => void;
+};
+
+const variantStyles: Record<
+  ToastType,
+  {
+    badgeClassName: string;
+    borderClassName: string;
+    label: string;
+    labelClassName: string;
+  }
+> = {
+  success: {
+    badgeClassName: "bg-success",
+    borderClassName: "border-success/20",
+    label: "Succès",
+    labelClassName: "text-success"
+  },
+  error: {
+    badgeClassName: "bg-danger",
+    borderClassName: "border-danger/20",
+    label: "Erreur",
+    labelClassName: "text-danger"
+  }
+};
+
+const Toast = ({ toast, onDismiss }: ToastProps) => {
+  const variant = variantStyles[toast.type];
+
+  return (
+    <article
+      role={toast.type === "error" ? "alert" : "status"}
+      className={`pointer-events-auto rounded-3xl border bg-white/95 p-4 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] backdrop-blur ${variant.borderClassName}`}
+    >
+      <div className="flex items-start gap-3">
+        <span
+          aria-hidden="true"
+          className={`mt-2 h-2.5 w-2.5 flex-none rounded-full ${variant.badgeClassName}`}
+        />
+
+        <div className="min-w-0 flex-1">
+          <p
+            className={`text-xs font-semibold uppercase tracking-[0.18em] ${variant.labelClassName}`}
+          >
+            {variant.label}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-slate-700">{toast.message}</p>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => onDismiss(toast.id)}
+          className="inline-flex flex-none items-center rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.12em] text-slate-500 transition hover:border-slate-300 hover:bg-slate-50 hover:text-slate-700"
+          aria-label="Fermer la notification"
+        >
+          X
+        </button>
+      </div>
+    </article>
+  );
+};
+
+export default Toast;

--- a/apps/web/src/components/ui/ToastViewport.tsx
+++ b/apps/web/src/components/ui/ToastViewport.tsx
@@ -1,0 +1,23 @@
+import Toast from "./Toast";
+import { useToast } from "../../context/ToastContext";
+
+const ToastViewport = () => {
+  const { dismissToast, toasts } = useToast();
+
+  if (toasts.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      aria-label="Notifications"
+      className="pointer-events-none fixed inset-x-4 top-4 z-50 flex flex-col gap-3 sm:left-auto sm:right-6 sm:top-6 sm:w-96"
+    >
+      {toasts.map((toast) => (
+        <Toast key={toast.id} toast={toast} onDismiss={dismissToast} />
+      ))}
+    </section>
+  );
+};
+
+export default ToastViewport;

--- a/apps/web/src/context/ToastContext.tsx
+++ b/apps/web/src/context/ToastContext.tsx
@@ -1,0 +1,109 @@
+import { createContext, useContext, useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
+
+export type ToastType = "success" | "error";
+
+export type ToastItem = {
+  id: number;
+  type: ToastType;
+  message: string;
+};
+
+type ToastContextValue = {
+  toasts: ToastItem[];
+  dismissToast: (toastId: number) => void;
+  showError: (message: string) => void;
+  showSuccess: (message: string) => void;
+};
+
+const SUCCESS_DURATION_MS = 3000;
+const ERROR_DURATION_MS = 5000;
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export const ToastProvider = ({ children }: { children: ReactNode }) => {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const nextToastIdRef = useRef(0);
+  const timeoutIdsRef = useRef<Map<number, number>>(new Map());
+
+  const dismissToast = (toastId: number): void => {
+    const timeoutId = timeoutIdsRef.current.get(toastId);
+
+    if (typeof timeoutId === "number") {
+      window.clearTimeout(timeoutId);
+      timeoutIdsRef.current.delete(toastId);
+    }
+
+    setToasts((currentToasts) =>
+      currentToasts.filter((toast) => toast.id !== toastId)
+    );
+  };
+
+  const enqueueToast = (
+    type: ToastType,
+    message: string,
+    duration: number
+  ): void => {
+    const normalizedMessage = message.trim();
+
+    if (normalizedMessage.length === 0) {
+      return;
+    }
+
+    nextToastIdRef.current += 1;
+
+    const nextToast: ToastItem = {
+      id: nextToastIdRef.current,
+      type,
+      message: normalizedMessage
+    };
+
+    setToasts((currentToasts) => [...currentToasts, nextToast]);
+
+    const timeoutId = window.setTimeout(() => {
+      dismissToast(nextToast.id);
+    }, duration);
+
+    timeoutIdsRef.current.set(nextToast.id, timeoutId);
+  };
+
+  const showSuccess = (message: string): void => {
+    enqueueToast("success", message, SUCCESS_DURATION_MS);
+  };
+
+  const showError = (message: string): void => {
+    enqueueToast("error", message, ERROR_DURATION_MS);
+  };
+
+  useEffect(() => {
+    return () => {
+      timeoutIdsRef.current.forEach((timeoutId) => {
+        window.clearTimeout(timeoutId);
+      });
+      timeoutIdsRef.current.clear();
+    };
+  }, []);
+
+  return (
+    <ToastContext.Provider
+      value={{
+        toasts,
+        dismissToast,
+        showError,
+        showSuccess
+      }}
+    >
+      {children}
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = (): ToastContextValue => {
+  const context = useContext(ToastContext);
+
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+
+  return context;
+};

--- a/apps/web/src/pages/ApplicationDetailPage.tsx
+++ b/apps/web/src/pages/ApplicationDetailPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 import ErrorState from "../components/ui/ErrorState";
 import LoadingState from "../components/ui/LoadingState";
+import { useToast } from "../context/ToastContext";
 import {
   getApplicationById,
   getApplicationEmailLogs,
@@ -203,6 +204,18 @@ const getEmailActionErrorMessage = (error: unknown): string => {
   }
 };
 
+const getActionErrorMessage = (fallbackMessage: string, error: unknown): string => {
+  if (!(error instanceof Error) || error.message.trim().length === 0) {
+    return fallbackMessage;
+  }
+
+  if (error.message === fallbackMessage) {
+    return fallbackMessage;
+  }
+
+  return `${fallbackMessage} ${error.message}`;
+};
+
 const getApplicationFamilyTitle = (
   application: ApplicationDetail | null
 ): string => {
@@ -290,22 +303,17 @@ const ApplicationDetailPage = ({
 }: {
   applicationId: string;
 }) => {
+  const { showError, showSuccess } = useToast();
   const [application, setApplication] = useState<ApplicationDetail | null>(null);
   const [emailLogs, setEmailLogs] = useState<ApplicationEmailLog[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [selectedStatus, setSelectedStatus] = useState<ApplicationStatus>("RECEIVED");
-  const [statusActionError, setStatusActionError] = useState<string | null>(null);
-  const [statusActionSuccess, setStatusActionSuccess] = useState<string | null>(null);
   const [isStatusSubmitting, setIsStatusSubmitting] = useState(false);
-  const [priorityActionError, setPriorityActionError] = useState<string | null>(null);
-  const [priorityActionSuccess, setPriorityActionSuccess] = useState<string | null>(null);
   const [isPrioritySubmitting, setIsPrioritySubmitting] = useState(false);
   const [selectedDecisionStatus, setSelectedDecisionStatus] =
     useState<ApplicationDecisionStatus>("ACCEPTED");
   const [decisionNote, setDecisionNote] = useState("");
-  const [decisionActionError, setDecisionActionError] = useState<string | null>(null);
-  const [decisionActionSuccess, setDecisionActionSuccess] = useState<string | null>(null);
   const [isDecisionSubmitting, setIsDecisionSubmitting] = useState(false);
   const [selectedEmailType, setSelectedEmailType] =
     useState<ApplicationEmailType>("ACCEPTANCE");
@@ -313,8 +321,6 @@ const ApplicationDetailPage = ({
   const [emailBody, setEmailBody] = useState(emailTemplates.ACCEPTANCE.body);
   const [isEmailSubjectDirty, setIsEmailSubjectDirty] = useState(false);
   const [isEmailBodyDirty, setIsEmailBodyDirty] = useState(false);
-  const [emailActionError, setEmailActionError] = useState<string | null>(null);
-  const [emailActionSuccess, setEmailActionSuccess] = useState<string | null>(null);
   const [isEmailSubmitting, setIsEmailSubmitting] = useState(false);
 
   const resetEmailForm = (): void => {
@@ -327,8 +333,6 @@ const ApplicationDetailPage = ({
 
   const handleEmailTypeChange = (emailType: ApplicationEmailType): void => {
     setSelectedEmailType(emailType);
-    setEmailActionError(null);
-    setEmailActionSuccess(null);
 
     if (emailType === "CUSTOM") {
       setEmailSubject("");
@@ -359,11 +363,7 @@ const ApplicationDetailPage = ({
         setEmailLogs(emailLogsData);
         setSelectedDecisionStatus(getDecisionSelection(applicationData.status));
         setDecisionNote(applicationData.decisionNote ?? "");
-        setDecisionActionError(null);
-        setDecisionActionSuccess(null);
         resetEmailForm();
-        setEmailActionError(null);
-        setEmailActionSuccess(null);
       } catch (loadError) {
         if (isAbortError(loadError) || controller.signal.aborted) {
           return;
@@ -412,21 +412,6 @@ const ApplicationDetailPage = ({
     }
   }, [selectedEmailType, isEmailSubjectDirty, isEmailBodyDirty]);
 
-  useEffect(() => {
-    if (!emailActionSuccess && !emailActionError) {
-      return;
-    }
-
-    const timeoutId = window.setTimeout(() => {
-      setEmailActionSuccess(null);
-      setEmailActionError(null);
-    }, 3000);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [emailActionSuccess, emailActionError]);
-
   const handleStatusSubmit = async (
     event: React.FormEvent<HTMLFormElement>
   ): Promise<void> => {
@@ -437,8 +422,6 @@ const ApplicationDetailPage = ({
     }
 
     setIsStatusSubmitting(true);
-    setStatusActionError(null);
-    setStatusActionSuccess(null);
 
     try {
       const updatedApplication = await updateApplicationStatus(
@@ -459,12 +442,10 @@ const ApplicationDetailPage = ({
       if (isDecisionStatus(updatedApplication.status)) {
         setSelectedDecisionStatus(updatedApplication.status);
       }
-      setStatusActionSuccess("Le statut a bien été mis à jour.");
+      showSuccess("Le statut a bien été mis à jour.");
     } catch (updateError) {
-      setStatusActionError(
-        updateError instanceof Error
-          ? updateError.message
-          : "Impossible de mettre à jour le statut."
+      showError(
+        getActionErrorMessage("Impossible de mettre à jour le statut.", updateError)
       );
     } finally {
       setIsStatusSubmitting(false);
@@ -479,8 +460,6 @@ const ApplicationDetailPage = ({
     const nextPriorityValue = !application.isPriority;
 
     setIsPrioritySubmitting(true);
-    setPriorityActionError(null);
-    setPriorityActionSuccess(null);
 
     try {
       const updatedApplication = await updateApplicationPriority(
@@ -498,16 +477,17 @@ const ApplicationDetailPage = ({
           isPriority: updatedApplication.isPriority
         };
       });
-      setPriorityActionSuccess(
+      showSuccess(
         nextPriorityValue
           ? "La demande est maintenant prioritaire."
           : "La priorité a été retirée."
       );
     } catch (updateError) {
-      setPriorityActionError(
-        updateError instanceof Error
-          ? updateError.message
-          : "Impossible de mettre à jour la priorité."
+      showError(
+        getActionErrorMessage(
+          "Impossible de mettre à jour la priorité.",
+          updateError
+        )
       );
     } finally {
       setIsPrioritySubmitting(false);
@@ -524,8 +504,6 @@ const ApplicationDetailPage = ({
     }
 
     setIsDecisionSubmitting(true);
-    setDecisionActionError(null);
-    setDecisionActionSuccess(null);
 
     const normalizedDecisionNote = decisionNote.trim();
 
@@ -549,12 +527,13 @@ const ApplicationDetailPage = ({
       });
       setSelectedDecisionStatus(updatedApplication.status);
       setDecisionNote(updatedApplication.decisionNote ?? "");
-      setDecisionActionSuccess("La décision finale a bien été enregistrée.");
+      showSuccess("La décision finale a bien été enregistrée.");
     } catch (updateError) {
-      setDecisionActionError(
-        updateError instanceof Error
-          ? updateError.message
-          : "Impossible d'enregistrer la décision finale."
+      showError(
+        getActionErrorMessage(
+          "Impossible d'enregistrer la décision finale.",
+          updateError
+        )
       );
     } finally {
       setIsDecisionSubmitting(false);
@@ -574,20 +553,16 @@ const ApplicationDetailPage = ({
     const normalizedBody = emailBody.trim();
 
     if (normalizedSubject.length === 0) {
-      setEmailActionSuccess(null);
-      setEmailActionError("Le sujet est obligatoire.");
+      showError("Le sujet est obligatoire.");
       return;
     }
 
     if (normalizedBody.length === 0) {
-      setEmailActionSuccess(null);
-      setEmailActionError("Le message est obligatoire.");
+      showError("Le message est obligatoire.");
       return;
     }
 
     setIsEmailSubmitting(true);
-    setEmailActionError(null);
-    setEmailActionSuccess(null);
 
     const payload: ApplicationEmailSendPayload = {
       emailType: selectedEmailType,
@@ -600,9 +575,9 @@ const ApplicationDetailPage = ({
 
       setEmailLogs((currentEmailLogs) => [createdEmailLog, ...currentEmailLogs]);
       resetEmailForm();
-      setEmailActionSuccess("L'email a été envoyé et enregistré dans l'historique.");
+      showSuccess("L'email a été envoyé et enregistré dans l'historique.");
     } catch (sendError) {
-      setEmailActionError(getEmailActionErrorMessage(sendError));
+      showError(getEmailActionErrorMessage(sendError));
     } finally {
       setIsEmailSubmitting(false);
     }
@@ -696,11 +671,9 @@ const ApplicationDetailPage = ({
                   <select
                     id="application-status"
                     value={selectedStatus}
-                    onChange={(event) => {
-                      setSelectedStatus(event.target.value as ApplicationStatus);
-                      setStatusActionError(null);
-                      setStatusActionSuccess(null);
-                    }}
+                    onChange={(event) =>
+                      setSelectedStatus(event.target.value as ApplicationStatus)
+                    }
                     disabled={isStatusSubmitting}
                     className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-900 outline-none transition focus:border-primary/40 focus:bg-white"
                   >
@@ -728,19 +701,6 @@ const ApplicationDetailPage = ({
                 >
                   {isStatusSubmitting ? "Mise à jour..." : "Mettre à jour le statut"}
                 </button>
-
-                <div className="space-y-2" aria-live="polite">
-                  {statusActionSuccess ? (
-                    <p className="rounded-2xl border border-success/20 bg-success/10 px-4 py-3 text-sm text-success">
-                      {statusActionSuccess}
-                    </p>
-                  ) : null}
-                  {statusActionError ? (
-                    <p className="rounded-2xl border border-danger/20 bg-danger/10 px-4 py-3 text-sm text-danger">
-                      {statusActionError}
-                    </p>
-                  ) : null}
-                </div>
               </form>
 
               <div className="mt-6 border-t border-slate-200 pt-6">
@@ -774,19 +734,6 @@ const ApplicationDetailPage = ({
                         ? "Désactiver la priorité"
                         : "Activer la priorité"}
                   </button>
-
-                  <div className="space-y-2" aria-live="polite">
-                    {priorityActionSuccess ? (
-                      <p className="rounded-2xl border border-success/20 bg-success/10 px-4 py-3 text-sm text-success">
-                        {priorityActionSuccess}
-                      </p>
-                    ) : null}
-                    {priorityActionError ? (
-                      <p className="rounded-2xl border border-danger/20 bg-danger/10 px-4 py-3 text-sm text-danger">
-                        {priorityActionError}
-                      </p>
-                    ) : null}
-                  </div>
                 </div>
               </div>
 
@@ -815,13 +762,11 @@ const ApplicationDetailPage = ({
                     <select
                       id="application-decision-status"
                       value={selectedDecisionStatus}
-                      onChange={(event) => {
+                      onChange={(event) =>
                         setSelectedDecisionStatus(
                           event.target.value as ApplicationDecisionStatus
-                        );
-                        setDecisionActionError(null);
-                        setDecisionActionSuccess(null);
-                      }}
+                        )
+                      }
                       disabled={isDecisionSubmitting}
                       className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-900 outline-none transition focus:border-primary/40 focus:bg-white"
                     >
@@ -843,11 +788,7 @@ const ApplicationDetailPage = ({
                     <textarea
                       id="application-decision-note"
                       value={decisionNote}
-                      onChange={(event) => {
-                        setDecisionNote(event.target.value);
-                        setDecisionActionError(null);
-                        setDecisionActionSuccess(null);
-                      }}
+                      onChange={(event) => setDecisionNote(event.target.value)}
                       disabled={isDecisionSubmitting}
                       rows={4}
                       className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-primary/40 focus:bg-white"
@@ -879,19 +820,6 @@ const ApplicationDetailPage = ({
                       ? "Enregistrement..."
                       : "Enregistrer la décision finale"}
                   </button>
-
-                  <div className="space-y-2" aria-live="polite">
-                    {decisionActionSuccess ? (
-                      <p className="rounded-2xl border border-success/20 bg-success/10 px-4 py-3 text-sm text-success">
-                        {decisionActionSuccess}
-                      </p>
-                    ) : null}
-                    {decisionActionError ? (
-                      <p className="rounded-2xl border border-danger/20 bg-danger/10 px-4 py-3 text-sm text-danger">
-                        {decisionActionError}
-                      </p>
-                    ) : null}
-                  </div>
                 </form>
               </div>
 
@@ -947,8 +875,6 @@ const ApplicationDetailPage = ({
                       onChange={(event) => {
                         setEmailSubject(event.target.value);
                         setIsEmailSubjectDirty(true);
-                        setEmailActionError(null);
-                        setEmailActionSuccess(null);
                       }}
                       disabled={isEmailSubmitting}
                       className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-primary/40 focus:bg-white"
@@ -973,8 +899,6 @@ const ApplicationDetailPage = ({
                       onChange={(event) => {
                         setEmailBody(event.target.value);
                         setIsEmailBodyDirty(true);
-                        setEmailActionError(null);
-                        setEmailActionSuccess(null);
                       }}
                       disabled={isEmailSubmitting}
                       rows={5}
@@ -994,19 +918,6 @@ const ApplicationDetailPage = ({
                   >
                     {isEmailSubmitting ? "Envoi en cours..." : "Envoyer l'email"}
                   </button>
-
-                  <div className="space-y-2" aria-live="polite">
-                    {emailActionSuccess ? (
-                      <p className="rounded-2xl border border-success/20 bg-success/10 px-4 py-3 text-sm text-success">
-                        {emailActionSuccess}
-                      </p>
-                    ) : null}
-                    {emailActionError ? (
-                      <p className="rounded-2xl border border-danger/20 bg-danger/10 px-4 py-3 text-sm text-danger">
-                        {emailActionError}
-                      </p>
-                    ) : null}
-                  </div>
                 </form>
               </div>
             </SectionCard>


### PR DESCRIPTION
## Objectif

Mettre en place un système global de feedback utilisateur via des toasts pour uniformiser les messages de succès et d’erreur dans l’application frontend.

## Contenu

- création d’un système global de toasts avec :
  - `showSuccess(message)`
  - `showError(message)`
- auto-dismiss :
  - succès : 3 secondes
  - erreur : 5 secondes
- fermeture manuelle possible
- affichage global en haut à droite
- intégration des toasts sur les actions métier de la page détail :
  - mise à jour du statut
  - mise à jour de la priorité
  - décision finale
  - envoi d’email

## Architecture ajoutée

- `apps/web/src/context/ToastContext.tsx`
- `apps/web/src/components/ui/Toast.tsx`
- `apps/web/src/components/ui/ToastViewport.tsx`

## Intégration

- montage du provider et du viewport globaux dans `App.tsx`
- suppression des anciens messages inline de succès / erreur dans `ApplicationDetailPage.tsx`
- unification du feedback utilisateur visible

## Vérifications

- [x] `npm exec -w apps/web -- tsc -b`
- [x] `npm run build -w apps/web`
- [x] `npm run dev:web`
- [x] routes `/`, `/applications` et `/applications/:id` servies correctement
- [x] aucune modification backend
- [x] aucune modification Prisma / migrations / seeds / .env

## Notes

- une validation visuelle manuelle reste utile pour confirmer le rendu exact des toasts
- base solide pour généraliser ensuite les feedbacks à toute l’application