### PR TITLE
feat(ui): centralize and improve status badges

### DIFF
--- a/apps/web/src/components/ui/PriorityBadge.tsx
+++ b/apps/web/src/components/ui/PriorityBadge.tsx
@@ -1,0 +1,25 @@
+type PriorityBadgeProps = {
+  isPriority: boolean;
+};
+
+const PriorityBadge = ({ isPriority }: PriorityBadgeProps) => {
+  if (!isPriority) {
+    return null;
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-secondary/20 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-secondaryDark ring-1 ring-secondary/30">
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 16 16"
+        className="h-3.5 w-3.5 flex-none"
+        fill="currentColor"
+      >
+        <path d="m8 2.15 1.62 3.28 3.62.52-2.62 2.55.62 3.6L8 10.4l-3.24 1.7.62-3.6L2.76 5.95l3.62-.52L8 2.15Z" />
+      </svg>
+      <span>Prioritaire</span>
+    </span>
+  );
+};
+
+export default PriorityBadge;

--- a/apps/web/src/components/ui/StatusBadge.tsx
+++ b/apps/web/src/components/ui/StatusBadge.tsx
@@ -1,0 +1,121 @@
+import type { JSX } from "react";
+import type { ApplicationStatus } from "../../types/application";
+
+type StatusBadgeProps = {
+  status: ApplicationStatus;
+};
+
+type StatusBadgeConfig = {
+  badgeClassName: string;
+  label: string;
+  Icon: () => JSX.Element;
+};
+
+const MailIcon = () => {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      className="h-3.5 w-3.5 flex-none"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="2" y="3.25" width="12" height="9.5" rx="2" />
+      <path d="M3.25 5 8 8.5 12.75 5" />
+    </svg>
+  );
+};
+
+const ReviewIcon = () => {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      className="h-3.5 w-3.5 flex-none"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="8" cy="8" r="5.5" />
+      <path d="M8 5.25v3.1l2.05 1.25" />
+    </svg>
+  );
+};
+
+const AcceptedIcon = () => {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      className="h-3.5 w-3.5 flex-none"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="m3.75 8.2 2.55 2.55 6-6" />
+    </svg>
+  );
+};
+
+const RefusedIcon = () => {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      className="h-3.5 w-3.5 flex-none"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="m5 5 6 6" />
+      <path d="m11 5-6 6" />
+    </svg>
+  );
+};
+
+const statusBadgeConfig: Record<ApplicationStatus, StatusBadgeConfig> = {
+  RECEIVED: {
+    badgeClassName: "bg-slate-100 text-slate-700 ring-slate-200",
+    label: "Reçue",
+    Icon: MailIcon
+  },
+  IN_REVIEW: {
+    badgeClassName: "bg-info/15 text-info ring-info/20",
+    label: "En revue",
+    Icon: ReviewIcon
+  },
+  ACCEPTED: {
+    badgeClassName: "bg-success/15 text-success ring-success/20",
+    label: "Acceptée",
+    Icon: AcceptedIcon
+  },
+  REFUSED: {
+    badgeClassName: "bg-danger/15 text-danger ring-danger/20",
+    label: "Refusée",
+    Icon: RefusedIcon
+  }
+};
+
+const StatusBadge = ({ status }: StatusBadgeProps) => {
+  const { badgeClassName, label, Icon } = statusBadgeConfig[status];
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] ring-1 ${badgeClassName}`}
+    >
+      <Icon />
+      <span>{label}</span>
+    </span>
+  );
+};
+
+export default StatusBadge;

--- a/apps/web/src/pages/ApplicationDetailPage.tsx
+++ b/apps/web/src/pages/ApplicationDetailPage.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 
 import ErrorState from "../components/ui/ErrorState";
 import LoadingState from "../components/ui/LoadingState";
+import PriorityBadge from "../components/ui/PriorityBadge";
+import StatusBadge from "../components/ui/StatusBadge";
 import { useToast } from "../context/ToastContext";
 import {
   getApplicationById,
@@ -21,20 +23,6 @@ import type {
   ApplicationGender,
   ApplicationStatus
 } from "../types/application";
-
-const statusLabels: Record<ApplicationStatus, string> = {
-  RECEIVED: "Reçue",
-  IN_REVIEW: "En revue",
-  ACCEPTED: "Acceptée",
-  REFUSED: "Refusée"
-};
-
-const statusStyles: Record<ApplicationStatus, string> = {
-  RECEIVED: "bg-slate-100 text-slate-700 ring-slate-200",
-  IN_REVIEW: "bg-info/15 text-info ring-info/20",
-  ACCEPTED: "bg-success/15 text-success ring-success/20",
-  REFUSED: "bg-danger/15 text-danger ring-danger/20"
-};
 
 const emailTypeLabels: Record<ApplicationEmailType, string> = {
   ACCEPTANCE: "Acceptation",
@@ -257,20 +245,6 @@ const DetailField = ({
       </p>
       <p className="mt-2 text-sm font-semibold text-slate-900">{value}</p>
     </div>
-  );
-};
-
-const StatusBadge = ({
-  status
-}: {
-  status: ApplicationStatus;
-}) => {
-  return (
-    <span
-      className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ring-1 ${statusStyles[status]}`}
-    >
-      {statusLabels[status]}
-    </span>
   );
 };
 
@@ -710,15 +684,10 @@ const ApplicationDetailPage = ({
                       Priorité actuelle
                     </p>
                     <div className="mt-2 flex flex-wrap items-center gap-2">
-                      {application.isPriority ? (
-                        <span className="rounded-full bg-secondary/20 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-secondaryDark">
-                          Prioritaire
-                        </span>
-                      ) : (
-                        <span className="rounded-full bg-slate-100 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-slate-700">
-                          Standard
-                        </span>
-                      )}
+                      <PriorityBadge isPriority={application.isPriority} />
+                      {!application.isPriority ? (
+                        <span className="text-sm text-slate-600">Aucune priorité</span>
+                      ) : null}
                     </div>
                   </div>
 
@@ -1135,16 +1104,8 @@ const ApplicationDetailShell = ({
           <div className="flex flex-wrap items-center gap-2">
             {application ? (
               <>
-                {application.isPriority ? (
-                  <span className="rounded-full bg-secondary/20 px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-secondaryDark">
-                    Prioritaire
-                  </span>
-                ) : null}
-                <span
-                  className={`rounded-full px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] ring-1 ${statusStyles[application.status]}`}
-                >
-                  {statusLabels[application.status]}
-                </span>
+                <PriorityBadge isPriority={application.isPriority} />
+                <StatusBadge status={application.status} />
               </>
             ) : (
               <span className="rounded-full border border-primary/10 bg-primary/5 px-4 py-2 text-sm text-primaryDark">

--- a/apps/web/src/pages/ApplicationsPage.tsx
+++ b/apps/web/src/pages/ApplicationsPage.tsx
@@ -3,6 +3,8 @@ import { useDeferredValue, useEffect, useState } from "react";
 import EmptyState from "../components/ui/EmptyState";
 import ErrorState from "../components/ui/ErrorState";
 import LoadingState from "../components/ui/LoadingState";
+import PriorityBadge from "../components/ui/PriorityBadge";
+import StatusBadge from "../components/ui/StatusBadge";
 import { getApplications, getSchoolYears } from "../lib/api";
 import type {
   ApplicationFilterParams,
@@ -43,20 +45,6 @@ const sortOptions: ApplicationsSortOption[] = [
   { value: "createdAtAsc", label: "Plus anciennes d'abord" },
   { value: "priorityDesc", label: "Prioritaires d'abord" }
 ];
-
-const statusLabels: Record<ApplicationStatus, string> = {
-  RECEIVED: "Reçue",
-  IN_REVIEW: "En revue",
-  ACCEPTED: "Acceptée",
-  REFUSED: "Refusée"
-};
-
-const statusStyles: Record<ApplicationStatus, string> = {
-  RECEIVED: "bg-slate-100 text-slate-700 ring-slate-200",
-  IN_REVIEW: "bg-info/15 text-info ring-info/20",
-  ACCEPTED: "bg-success/15 text-success ring-success/20",
-  REFUSED: "bg-danger/15 text-danger ring-danger/20"
-};
 
 const createdAtFormatter = new Intl.DateTimeFormat("fr-FR", {
   dateStyle: "medium",
@@ -459,16 +447,8 @@ const ApplicationsPage = () => {
                     <h2 className="text-2xl font-semibold text-slate-900">
                       Famille {getFamilyDisplayName(application)}
                     </h2>
-                    {application.isPriority ? (
-                      <span className="rounded-full bg-secondary/20 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-secondaryDark">
-                        Prioritaire
-                      </span>
-                    ) : null}
-                    <span
-                      className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ring-1 ${statusStyles[application.status]}`}
-                    >
-                      {statusLabels[application.status]}
-                    </span>
+                    <PriorityBadge isPriority={application.isPriority} />
+                    <StatusBadge status={application.status} />
                   </div>
 
                   <p className="mt-2 text-sm text-slate-500">

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -3,6 +3,8 @@ import { useEffect, useState } from "react";
 import EmptyState from "../components/ui/EmptyState";
 import ErrorState from "../components/ui/ErrorState";
 import LoadingState from "../components/ui/LoadingState";
+import PriorityBadge from "../components/ui/PriorityBadge";
+import StatusBadge from "../components/ui/StatusBadge";
 import { fetchDashboardStats } from "../lib/api";
 import type {
   DashboardApplicationStatus,
@@ -43,20 +45,6 @@ const statusCards: StatusCardConfig[] = [
     valueClassName: "text-danger"
   }
 ];
-
-const priorityStatusStyles: Record<DashboardApplicationStatus, string> = {
-  RECEIVED: "bg-slate-100 text-slate-700 ring-slate-200",
-  IN_REVIEW: "bg-info/15 text-info ring-info/20",
-  ACCEPTED: "bg-success/15 text-success ring-success/20",
-  REFUSED: "bg-danger/15 text-danger ring-danger/20"
-};
-
-const priorityStatusLabels: Record<DashboardApplicationStatus, string> = {
-  RECEIVED: "Reçue",
-  IN_REVIEW: "En revue",
-  ACCEPTED: "Acceptée",
-  REFUSED: "Refusée"
-};
 
 const createdAtFormatter = new Intl.DateTimeFormat("fr-FR", {
   dateStyle: "medium",
@@ -315,20 +303,14 @@ const DashboardPage = () => {
                           <h3 className="text-lg font-semibold text-slate-900">
                             Famille {getFamilyDisplayName(application)}
                           </h3>
-                          <span className="rounded-full bg-secondary/20 px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-secondaryDark">
-                            Prioritaire
-                          </span>
+                          <PriorityBadge isPriority={application.isPriority} />
                         </div>
                         <p className="mt-2 text-sm text-slate-500">
                           {application.schoolYear.label}
                           {application.schoolYear.isActive ? " · année active" : ""}
                         </p>
                       </div>
-                      <span
-                        className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ring-1 ${priorityStatusStyles[application.status]}`}
-                      >
-                        {priorityStatusLabels[application.status]}
-                      </span>
+                      <StatusBadge status={application.status} />
                     </div>
 
                     <p className="mt-4 text-sm leading-6 text-slate-600">

--- a/apps/web/src/types/dashboard.ts
+++ b/apps/web/src/types/dashboard.ts
@@ -1,8 +1,6 @@
-export type DashboardApplicationStatus =
-  | "RECEIVED"
-  | "IN_REVIEW"
-  | "ACCEPTED"
-  | "REFUSED";
+import type { ApplicationStatus } from "./application";
+
+export type DashboardApplicationStatus = ApplicationStatus;
 
 export type DashboardStats = {
   totalApplications: number;


### PR DESCRIPTION
## Objectif

Centraliser et améliorer les badges métier côté frontend pour obtenir un rendu cohérent et plus lisible dans toute l’application.

## Contenu

- création de composants UI partagés :
  - `StatusBadge`
  - `PriorityBadge`
- centralisation du mapping visuel des statuts
- ajout d’une petite icône discrète pour chaque statut
- affichage d’un badge priorité uniquement si `isPriority = true`
- suppression des styles dupliqués et des badges codés en dur

## Intégration

Remplacement des badges existants dans :
- `DashboardPage`
- `ApplicationsPage`
- `ApplicationDetailPage`

## Harmonisation visuelle

- même taille
- même spacing
- même logique visuelle
- même casse
- alignement cohérent icône + texte

## Technique

- React + TypeScript
- aucune modification backend
- aucune modification Prisma / migrations / seeds / .env
- alignement du typage `dashboard.ts` avec `ApplicationStatus`

## Vérifications

- [x] `npm exec -w apps/web -- tsc -b`
- [x] `npm run build -w apps/web`
- [x] `npm run dev:web`
- [x] routes `/`, `/applications` et `/applications/:id` servies correctement
- [x] aucune régression technique constatée

## Notes

- une vérification visuelle manuelle reste utile pour confirmer le rendu final sur dashboard, liste et détail
- amélioration UX légère mais très visible pour le MVP