### PR TITLE
feat(ui): improve navigation with shared breadcrumb

### DIFF
--- a/apps/web/src/components/ui/Breadcrumb.tsx
+++ b/apps/web/src/components/ui/Breadcrumb.tsx
@@ -1,0 +1,52 @@
+type BreadcrumbItem = {
+  label: string;
+  href?: string;
+};
+
+type BreadcrumbProps = {
+  items: BreadcrumbItem[];
+};
+
+const Breadcrumb = ({ items }: BreadcrumbProps) => {
+  return (
+    <nav aria-label="Fil d'Ariane">
+      <ol className="flex flex-wrap items-center gap-2 text-sm">
+        {items.map((item, index) => {
+          const isCurrentPage = index === items.length - 1;
+
+          return (
+            <li key={`${item.label}-${index}`} className="flex items-center gap-2">
+              {index > 0 ? (
+                <span aria-hidden="true" className="text-slate-400">
+                  /
+                </span>
+              ) : null}
+
+              {item.href && !isCurrentPage ? (
+                <a
+                  href={item.href}
+                  className="font-medium text-slate-500 transition hover:text-primaryDark"
+                >
+                  {item.label}
+                </a>
+              ) : (
+                <span
+                  aria-current={isCurrentPage ? "page" : undefined}
+                  className={
+                    isCurrentPage
+                      ? "font-semibold text-slate-900"
+                      : "font-medium text-slate-500"
+                  }
+                >
+                  {item.label}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+};
+
+export default Breadcrumb;

--- a/apps/web/src/pages/ApplicationDetailPage.tsx
+++ b/apps/web/src/pages/ApplicationDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import Breadcrumb from "../components/ui/Breadcrumb";
 import ErrorState from "../components/ui/ErrorState";
 import LoadingState from "../components/ui/LoadingState";
 import PriorityBadge from "../components/ui/PriorityBadge";
@@ -1069,22 +1070,20 @@ const ApplicationDetailShell = ({
     <div className="relative mx-auto max-w-7xl">
       <div className="absolute inset-x-0 top-0 -z-10 h-56 rounded-[2rem] bg-gradient-to-r from-secondary/15 via-white/30 to-primary/10 blur-3xl" />
       <header className="mb-8 rounded-[2rem] border border-white/80 bg-white/85 p-6 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] backdrop-blur sm:p-8">
-        <div className="flex flex-wrap gap-2">
-          <a
-            href="/"
-            className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary/25 hover:text-primaryDark"
-          >
-            Dashboard
-          </a>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <Breadcrumb
+            items={[
+              { label: "Accueil", href: "/" },
+              { label: "Demandes", href: "/applications" },
+              { label: "Détail" }
+            ]}
+          />
           <a
             href="/applications"
-            className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary/25 hover:text-primaryDark"
+            className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
           >
-            Demandes
+            Retour aux demandes
           </a>
-          <span className="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white">
-            Détail
-          </span>
         </div>
 
         <div className="mt-4 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">

--- a/apps/web/src/pages/ApplicationsPage.tsx
+++ b/apps/web/src/pages/ApplicationsPage.tsx
@@ -1,5 +1,6 @@
 import { useDeferredValue, useEffect, useState } from "react";
 
+import Breadcrumb from "../components/ui/Breadcrumb";
 import EmptyState from "../components/ui/EmptyState";
 import ErrorState from "../components/ui/ErrorState";
 import LoadingState from "../components/ui/LoadingState";
@@ -539,17 +540,12 @@ const ApplicationsShell = ({ children }: { children: React.ReactNode }) => {
     <div className="relative mx-auto max-w-7xl">
       <div className="absolute inset-x-0 top-0 -z-10 h-56 rounded-[2rem] bg-gradient-to-r from-secondary/15 via-white/30 to-primary/10 blur-3xl" />
       <header className="mb-8 rounded-[2rem] border border-white/80 bg-white/85 p-6 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] backdrop-blur sm:p-8">
-        <div className="flex flex-wrap gap-2">
-          <a
-            href="/"
-            className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary/25 hover:text-primaryDark"
-          >
-            Dashboard
-          </a>
-          <span className="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white">
-            Demandes
-          </span>
-        </div>
+        <Breadcrumb
+          items={[
+            { label: "Accueil", href: "/" },
+            { label: "Demandes" }
+          ]}
+        />
 
         <div className="mt-4 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div>

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import Breadcrumb from "../components/ui/Breadcrumb";
 import EmptyState from "../components/ui/EmptyState";
 import ErrorState from "../components/ui/ErrorState";
 import LoadingState from "../components/ui/LoadingState";
@@ -350,21 +351,16 @@ const DashboardShell = ({ children }: { children: React.ReactNode }) => {
     <div className="relative mx-auto max-w-7xl">
       <div className="absolute inset-x-0 top-0 -z-10 h-56 rounded-[2rem] bg-gradient-to-r from-secondary/15 via-white/30 to-primary/10 blur-3xl" />
       <header className="mb-8 rounded-[2rem] border border-white/80 bg-white/85 p-6 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] backdrop-blur sm:p-8">
-        <p className="text-sm font-semibold uppercase tracking-[0.24em] text-primaryLight">
+        <Breadcrumb
+          items={[
+            { label: "Accueil", href: "/" },
+            { label: "Dashboard" }
+          ]}
+        />
+        <p className="mt-4 text-sm font-semibold uppercase tracking-[0.24em] text-primaryLight">
           Dashboard Admin
         </p>
-        <div className="mt-4 flex flex-wrap gap-2">
-          <span className="rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white">
-            Dashboard
-          </span>
-          <a
-            href="/applications"
-            className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary/25 hover:text-primaryDark"
-          >
-            Demandes
-          </a>
-        </div>
-        <div className="mt-3 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="mt-4 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
           <div>
             <h1 className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
               Vue d&apos;ensemble des demandes d&apos;inscription
@@ -375,8 +371,18 @@ const DashboardShell = ({ children }: { children: React.ReactNode }) => {
               prioritaires.
             </p>
           </div>
-          <div className="rounded-2xl border border-primary/10 bg-primary/5 px-4 py-3 text-sm text-primaryDark">
-            Source : <span className="font-semibold">GET /api/dashboard/stats</span>
+
+          <div className="flex flex-col items-start gap-3 lg:items-end">
+            <a
+              href="/applications"
+              className="inline-flex items-center rounded-full bg-primary px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-primaryDark"
+            >
+              Ouvrir les demandes
+            </a>
+
+            <div className="rounded-2xl border border-primary/10 bg-primary/5 px-4 py-3 text-sm text-primaryDark">
+              Source : <span className="font-semibold">GET /api/dashboard/stats</span>
+            </div>
           </div>
         </div>
       </header>


### PR DESCRIPTION
## Objectif

Harmoniser la navigation frontend pour rendre le parcours Dashboard / Demandes / Détail plus clair et plus cohérent.

## Contenu

- création d’un composant partagé `Breadcrumb`
- intégration du breadcrumb dans :
  - `DashboardPage`
  - `ApplicationsPage`
  - `ApplicationDetailPage`
- simplification des headers
- suppression des pastilles de navigation redondantes
- ajout d’un vrai lien de retour vers la liste sur la page détail
- rétablissement d’un accès clair aux demandes depuis le dashboard

## Structure de navigation

### Dashboard
- Accueil / Dashboard

### Demandes
- Accueil / Demandes

### Détail
- Accueil / Demandes / Détail

## Fichiers concernés

- `apps/web/src/components/ui/Breadcrumb.tsx`
- `apps/web/src/pages/DashboardPage.tsx`
- `apps/web/src/pages/ApplicationsPage.tsx`
- `apps/web/src/pages/ApplicationDetailPage.tsx`

## Vérifications

- [x] `npm exec -w apps/web -- tsc -b`
- [x] `npm run build -w apps/web`
- [x] `npm run dev:web`
- [x] routes `/`, `/applications` et `/applications/:id` servies correctement
- [x] accès aux demandes rétabli depuis le dashboard
- [x] navigation plus cohérente entre dashboard, liste et détail

## Notes

- aucune modification du backend
- amélioration UX de navigation pour le MVP
- une vérification visuelle manuelle reste utile pour confirmer le niveau exact de clarté des headers