### PR TITLE
feat(api): add centralized Express error handling

### DIFF
--- a/apps/api/src/controllers/application.controller.ts
+++ b/apps/api/src/controllers/application.controller.ts
@@ -6,6 +6,7 @@ import {
 } from "@prisma/client";
 import type { Request, Response } from "express";
 
+import { badRequest, notFound } from "../lib/errors";
 import { prisma } from "../prisma/client";
 
 const getQueryParam = (value: unknown): string | undefined => {
@@ -52,324 +53,275 @@ const isApplicationEmailType = (value: string): value is ApplicationEmailType =>
 };
 
 export const getApplications = async (req: Request, res: Response): Promise<void> => {
-  try {
-    const status = getQueryParam(req.query.status);
-    const schoolYearId = getQueryParam(req.query.schoolYearId);
-    const isPriority = getQueryParam(req.query.isPriority);
-    const search = getQueryParam(req.query.search);
-    const where: Prisma.ApplicationWhereInput = {};
+  const status = getQueryParam(req.query.status);
+  const schoolYearId = getQueryParam(req.query.schoolYearId);
+  const isPriority = getQueryParam(req.query.isPriority);
+  const search = getQueryParam(req.query.search);
+  const where: Prisma.ApplicationWhereInput = {};
 
-    if (status) {
-      if (!isApplicationStatus(status)) {
-        res.status(400).json({ message: "Invalid application status" });
-        return;
-      }
-
-      where.status = status;
+  if (status) {
+    if (!isApplicationStatus(status)) {
+      throw badRequest("Invalid application status");
     }
 
-    if (schoolYearId) {
-      where.schoolYearId = schoolYearId;
-    }
-
-    if (isPriority) {
-      if (isPriority !== "true" && isPriority !== "false") {
-        res.status(400).json({ message: "Invalid priority filter" });
-        return;
-      }
-
-      where.isPriority = isPriority === "true";
-    }
-
-    if (search) {
-      where.OR = [
-        {
-          family: {
-            is: {
-              contactEmail: {
-                contains: search,
-                mode: "insensitive"
-              }
-            }
-          }
-        },
-        {
-          family: {
-            is: {
-              fatherLastName: {
-                contains: search,
-                mode: "insensitive"
-              }
-            }
-          }
-        },
-        {
-          family: {
-            is: {
-              motherLastName: {
-                contains: search,
-                mode: "insensitive"
-              }
-            }
-          }
-        },
-        {
-          students: {
-            some: {
-              firstName: {
-                contains: search,
-                mode: "insensitive"
-              }
-            }
-          }
-        },
-        {
-          students: {
-            some: {
-              lastName: {
-                contains: search,
-                mode: "insensitive"
-              }
-            }
-          }
-        }
-      ];
-    }
-
-    const applications = await prisma.application.findMany({
-      where,
-      orderBy: { createdAt: "desc" },
-      include: {
-        family: true,
-        schoolYear: true,
-        students: {
-          include: {
-            level: true
-          }
-        }
-      }
-    });
-
-    res.status(200).json(applications);
-  } catch (error) {
-    console.error("Failed to fetch applications:", error);
-    res.status(500).json({ message: "Internal server error" });
+    where.status = status;
   }
+
+  if (schoolYearId) {
+    where.schoolYearId = schoolYearId;
+  }
+
+  if (isPriority) {
+    if (isPriority !== "true" && isPriority !== "false") {
+      throw badRequest("Invalid priority filter");
+    }
+
+    where.isPriority = isPriority === "true";
+  }
+
+  if (search) {
+    where.OR = [
+      {
+        family: {
+          is: {
+            contactEmail: {
+              contains: search,
+              mode: "insensitive"
+            }
+          }
+        }
+      },
+      {
+        family: {
+          is: {
+            fatherLastName: {
+              contains: search,
+              mode: "insensitive"
+            }
+          }
+        }
+      },
+      {
+        family: {
+          is: {
+            motherLastName: {
+              contains: search,
+              mode: "insensitive"
+            }
+          }
+        }
+      },
+      {
+        students: {
+          some: {
+            firstName: {
+              contains: search,
+              mode: "insensitive"
+            }
+          }
+        }
+      },
+      {
+        students: {
+          some: {
+            lastName: {
+              contains: search,
+              mode: "insensitive"
+            }
+          }
+        }
+      }
+    ];
+  }
+
+  const applications = await prisma.application.findMany({
+    where,
+    orderBy: { createdAt: "desc" },
+    include: {
+      family: true,
+      schoolYear: true,
+      students: {
+        include: {
+          level: true
+        }
+      }
+    }
+  });
+
+  res.status(200).json(applications);
 };
 
 export const getApplicationById = async (req: Request, res: Response): Promise<void> => {
-  try {
-    const applicationId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const applicationId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
 
-    const application = await prisma.application.findUnique({
-      where: { id: applicationId },
-      include: {
-        family: true,
-        schoolYear: true,
-        students: {
-          include: {
-            level: true
-          }
-        },
-        emailLogs: {
-          orderBy: { createdAt: "desc" }
+  const application = await prisma.application.findUnique({
+    where: { id: applicationId },
+    include: {
+      family: true,
+      schoolYear: true,
+      students: {
+        include: {
+          level: true
         }
+      },
+      emailLogs: {
+        orderBy: { createdAt: "desc" }
       }
-    });
-
-    if (!application) {
-      res.status(404).json({ message: "Application not found" });
-      return;
     }
+  });
 
-    res.status(200).json(application);
-  } catch (error) {
-    console.error("Failed to fetch application:", error);
-    res.status(500).json({ message: "Internal server error" });
+  if (!application) {
+    throw notFound("Application not found");
   }
+
+  res.status(200).json(application);
 };
 
 export const getApplicationEmailLogs = async (
   req: Request,
   res: Response
 ): Promise<void> => {
-  try {
-    const applicationId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const applicationId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
 
-    const existingApplication = await prisma.application.findUnique({
-      where: { id: applicationId },
-      select: { id: true }
-    });
+  const existingApplication = await prisma.application.findUnique({
+    where: { id: applicationId },
+    select: { id: true }
+  });
 
-    if (!existingApplication) {
-      res.status(404).json({ message: "Application not found" });
-      return;
-    }
-
-    const emailLogs = await prisma.applicationEmailLog.findMany({
-      where: { applicationId },
-      orderBy: { createdAt: "desc" }
-    });
-
-    res.status(200).json(emailLogs);
-  } catch (error) {
-    console.error("Failed to fetch application email logs:", error);
-    res.status(500).json({ message: "Internal server error" });
+  if (!existingApplication) {
+    throw notFound("Application not found");
   }
+
+  const emailLogs = await prisma.applicationEmailLog.findMany({
+    where: { applicationId },
+    orderBy: { createdAt: "desc" }
+  });
+
+  res.status(200).json(emailLogs);
 };
 
 export const updateApplicationStatus = async (req: Request, res: Response): Promise<void> => {
-  try {
-    const applicationId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
-    const status = getQueryParam(req.body?.status);
+  const applicationId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const status = getQueryParam(req.body?.status);
 
-    if (!status || !isApplicationStatus(status)) {
-      res.status(400).json({ message: "Invalid application status" });
-      return;
-    }
-
-    const existingApplication = await prisma.application.findUnique({
-      where: { id: applicationId },
-      select: { id: true }
-    });
-
-    if (!existingApplication) {
-      res.status(404).json({ message: "Application not found" });
-      return;
-    }
-
-    const updatedApplication = await prisma.application.update({
-      where: { id: applicationId },
-      data: { status }
-    });
-
-    res.status(200).json(updatedApplication);
-  } catch (error) {
-    console.error("Failed to update application status:", error);
-    res.status(500).json({ message: "Internal server error" });
+  if (!status || !isApplicationStatus(status)) {
+    throw badRequest("Invalid application status");
   }
+
+  const existingApplication = await prisma.application.findUnique({
+    where: { id: applicationId },
+    select: { id: true }
+  });
+
+  if (!existingApplication) {
+    throw notFound("Application not found");
+  }
+
+  const updatedApplication = await prisma.application.update({
+    where: { id: applicationId },
+    data: { status }
+  });
+
+  res.status(200).json(updatedApplication);
 };
 
 export const updateApplicationPriority = async (req: Request, res: Response): Promise<void> => {
-  try {
-    const applicationId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
-    const isPriority = req.body?.isPriority;
+  const applicationId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const isPriority = req.body?.isPriority;
 
-    if (typeof isPriority !== "boolean") {
-      res.status(400).json({ message: "Invalid priority value" });
-      return;
-    }
-
-    const existingApplication = await prisma.application.findUnique({
-      where: { id: applicationId },
-      select: { id: true }
-    });
-
-    if (!existingApplication) {
-      res.status(404).json({ message: "Application not found" });
-      return;
-    }
-
-    const updatedApplication = await prisma.application.update({
-      where: { id: applicationId },
-      data: { isPriority }
-    });
-
-    res.status(200).json(updatedApplication);
-  } catch (error) {
-    console.error("Failed to update application priority:", error);
-    res.status(500).json({ message: "Internal server error" });
+  if (typeof isPriority !== "boolean") {
+    throw badRequest("Invalid priority value");
   }
+
+  const existingApplication = await prisma.application.findUnique({
+    where: { id: applicationId },
+    select: { id: true }
+  });
+
+  if (!existingApplication) {
+    throw notFound("Application not found");
+  }
+
+  const updatedApplication = await prisma.application.update({
+    where: { id: applicationId },
+    data: { isPriority }
+  });
+
+  res.status(200).json(updatedApplication);
 };
 
 export const updateApplicationDecision = async (req: Request, res: Response): Promise<void> => {
-  try {
-    const applicationId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
-    const status = getQueryParam(req.body?.status);
-    const decisionNote = typeof req.body?.decisionNote === "string" ? req.body.decisionNote : null;
+  const applicationId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const status = getQueryParam(req.body?.status);
+  const decisionNote = typeof req.body?.decisionNote === "string" ? req.body.decisionNote : null;
 
-    if (!status || !isApplicationDecisionStatus(status)) {
-      res.status(400).json({ message: "Invalid application decision status" });
-      return;
-    }
-
-    const existingApplication = await prisma.application.findUnique({
-      where: { id: applicationId },
-      select: { id: true }
-    });
-
-    if (!existingApplication) {
-      res.status(404).json({ message: "Application not found" });
-      return;
-    }
-
-    const updatedApplication = await prisma.application.update({
-      where: { id: applicationId },
-      data: {
-        status,
-        decisionAt: new Date(),
-        decisionNote
-      }
-    });
-
-    res.status(200).json(updatedApplication);
-  } catch (error) {
-    console.error("Failed to update application decision:", error);
-    res.status(500).json({ message: "Internal server error" });
+  if (!status || !isApplicationDecisionStatus(status)) {
+    throw badRequest("Invalid application decision status");
   }
+
+  const existingApplication = await prisma.application.findUnique({
+    where: { id: applicationId },
+    select: { id: true }
+  });
+
+  if (!existingApplication) {
+    throw notFound("Application not found");
+  }
+
+  const updatedApplication = await prisma.application.update({
+    where: { id: applicationId },
+    data: {
+      status,
+      decisionAt: new Date(),
+      decisionNote
+    }
+  });
+
+  res.status(200).json(updatedApplication);
 };
 
 export const sendApplicationEmail = async (req: Request, res: Response): Promise<void> => {
-  try {
-    const applicationId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
-    const emailType = getQueryParam(req.body?.emailType);
-    const subject = getQueryParam(req.body?.subject);
-    const body = getQueryParam(req.body?.body);
+  const applicationId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const emailType = getQueryParam(req.body?.emailType);
+  const subject = getQueryParam(req.body?.subject);
+  const body = getQueryParam(req.body?.body);
 
-    if (!emailType || !isApplicationEmailType(emailType)) {
-      res.status(400).json({ message: "Invalid email type" });
-      return;
-    }
-
-    if (!subject || !body) {
-      res.status(400).json({ message: "Invalid email payload" });
-      return;
-    }
-
-    const application = await prisma.application.findUnique({
-      where: { id: applicationId },
-      include: {
-        family: true
-      }
-    });
-
-    if (!application) {
-      res.status(404).json({ message: "Application not found" });
-      return;
-    }
-
-    const recipientEmail = application.family.contactEmail.trim();
-
-    if (!recipientEmail) {
-      res.status(400).json({ message: "Missing recipient email" });
-      return;
-    }
-
-    const emailLog = await prisma.applicationEmailLog.create({
-      data: {
-        applicationId: application.id,
-        emailType,
-        recipientEmail,
-        subject,
-        bodySnapshot: body,
-        sentAt: new Date(),
-        sendStatus: EmailSendStatus.SENT
-      }
-    });
-
-    res.status(201).json(emailLog);
-  } catch (error) {
-    console.error("Failed to send application email:", error);
-    res.status(500).json({ message: "Internal server error" });
+  if (!emailType || !isApplicationEmailType(emailType)) {
+    throw badRequest("Invalid email type");
   }
+
+  if (!subject || !body) {
+    throw badRequest("Invalid email payload");
+  }
+
+  const application = await prisma.application.findUnique({
+    where: { id: applicationId },
+    include: {
+      family: true
+    }
+  });
+
+  if (!application) {
+    throw notFound("Application not found");
+  }
+
+  const recipientEmail = application.family.contactEmail.trim();
+
+  if (!recipientEmail) {
+    throw badRequest("Missing recipient email");
+  }
+
+  const emailLog = await prisma.applicationEmailLog.create({
+    data: {
+      applicationId: application.id,
+      emailType,
+      recipientEmail,
+      subject,
+      bodySnapshot: body,
+      sentAt: new Date(),
+      sendStatus: EmailSendStatus.SENT
+    }
+  });
+
+  res.status(201).json(emailLog);
 };

--- a/apps/api/src/controllers/dashboard.controller.ts
+++ b/apps/api/src/controllers/dashboard.controller.ts
@@ -11,96 +11,91 @@ type DashboardStatusCounts = {
 };
 
 export const getDashboardStats = async (_req: Request, res: Response): Promise<void> => {
-  try {
-    const [totalApplications, statusCounts, levels, priorityApplications] = await Promise.all([
-      prisma.application.count(),
-      prisma.application.groupBy({
-        by: ["status"],
+  const [totalApplications, statusCounts, levels, priorityApplications] = await Promise.all([
+    prisma.application.count(),
+    prisma.application.groupBy({
+      by: ["status"],
+      _count: {
+        _all: true
+      }
+    }),
+    prisma.level.findMany({
+      select: {
+        code: true,
+        label: true,
+        sortOrder: true,
         _count: {
-          _all: true
+          select: {
+            students: true
+          }
         }
-      }),
-      prisma.level.findMany({
-        select: {
-          code: true,
-          label: true,
-          sortOrder: true,
-          _count: {
-            select: {
-              students: true
-            }
+      },
+      orderBy: {
+        sortOrder: "asc"
+      }
+    }),
+    prisma.application.findMany({
+      where: {
+        isPriority: true
+      },
+      orderBy: {
+        createdAt: "desc"
+      },
+      select: {
+        id: true,
+        status: true,
+        isPriority: true,
+        createdAt: true,
+        family: {
+          select: {
+            contactEmail: true,
+            fatherLastName: true,
+            motherLastName: true
           }
         },
-        orderBy: {
-          sortOrder: "asc"
-        }
-      }),
-      prisma.application.findMany({
-        where: {
-          isPriority: true
+        schoolYear: {
+          select: {
+            label: true,
+            isActive: true
+          }
         },
-        orderBy: {
-          createdAt: "desc"
-        },
-        select: {
-          id: true,
-          status: true,
-          isPriority: true,
-          createdAt: true,
-          family: {
-            select: {
-              contactEmail: true,
-              fatherLastName: true,
-              motherLastName: true
-            }
-          },
-          schoolYear: {
-            select: {
-              label: true,
-              isActive: true
-            }
-          },
-          students: {
-            select: {
-              firstName: true,
-              lastName: true,
-              level: {
-                select: {
-                  code: true,
-                  label: true
-                }
+        students: {
+          select: {
+            firstName: true,
+            lastName: true,
+            level: {
+              select: {
+                code: true,
+                label: true
               }
             }
           }
         }
-      })
-    ]);
+      }
+    })
+  ]);
 
-    const byStatus: DashboardStatusCounts = {
-      [ApplicationStatus.RECEIVED]: 0,
-      [ApplicationStatus.IN_REVIEW]: 0,
-      [ApplicationStatus.ACCEPTED]: 0,
-      [ApplicationStatus.REFUSED]: 0
-    };
+  const byStatus: DashboardStatusCounts = {
+    [ApplicationStatus.RECEIVED]: 0,
+    [ApplicationStatus.IN_REVIEW]: 0,
+    [ApplicationStatus.ACCEPTED]: 0,
+    [ApplicationStatus.REFUSED]: 0
+  };
 
-    for (const statusCount of statusCounts) {
-      byStatus[statusCount.status] = statusCount._count._all;
-    }
-
-    const byLevel = levels.map((level) => ({
-      code: level.code,
-      label: level.label,
-      count: level._count.students
-    }));
-
-    res.status(200).json({
-      totalApplications,
-      byStatus,
-      byLevel,
-      priorityApplications
-    });
-  } catch (error) {
-    console.error("Failed to fetch dashboard stats:", error);
-    res.status(500).json({ message: "Internal server error" });
+  for (const statusCount of statusCounts) {
+    byStatus[statusCount.status] = statusCount._count._all;
   }
+
+  const byLevel = levels.map((level) => ({
+    code: level.code,
+    label: level.label,
+    count: level._count.students
+  }));
+
+  res.status(200).json({
+    totalApplications,
+    byStatus,
+    byLevel,
+    priorityApplications
+  });
 };

--- a/apps/api/src/controllers/level.controller.ts
+++ b/apps/api/src/controllers/level.controller.ts
@@ -1,62 +1,51 @@
 import type { Request, Response } from "express";
 
+import { badRequest, notFound } from "../lib/errors";
 import { prisma } from "../prisma/client";
 
 export const getLevels = async (_req: Request, res: Response): Promise<void> => {
-  try {
-    const levels = await prisma.level.findMany({
-      select: {
-        id: true,
-        code: true,
-        label: true,
-        sortOrder: true,
-        availablePlaces: true
-      },
-      orderBy: { sortOrder: "asc" }
-    });
+  const levels = await prisma.level.findMany({
+    select: {
+      id: true,
+      code: true,
+      label: true,
+      sortOrder: true,
+      availablePlaces: true
+    },
+    orderBy: { sortOrder: "asc" }
+  });
 
-    res.status(200).json(levels);
-  } catch (error) {
-    console.error("Failed to fetch levels:", error);
-    res.status(500).json({ message: "Internal server error" });
-  }
+  res.status(200).json(levels);
 };
 
 export const updateLevelAvailablePlaces = async (
   req: Request,
   res: Response
 ): Promise<void> => {
-  try {
-    const levelId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
-    const availablePlaces = req.body?.availablePlaces;
+  const levelId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const availablePlaces = req.body?.availablePlaces;
 
-    if (
-      typeof availablePlaces !== "number" ||
-      !Number.isInteger(availablePlaces) ||
-      availablePlaces < 0
-    ) {
-      res.status(400).json({ message: "Invalid available places value" });
-      return;
-    }
-
-    const existingLevel = await prisma.level.findUnique({
-      where: { id: levelId },
-      select: { id: true }
-    });
-
-    if (!existingLevel) {
-      res.status(404).json({ message: "Level not found" });
-      return;
-    }
-
-    const updatedLevel = await prisma.level.update({
-      where: { id: levelId },
-      data: { availablePlaces }
-    });
-
-    res.status(200).json(updatedLevel);
-  } catch (error) {
-    console.error("Failed to update level available places:", error);
-    res.status(500).json({ message: "Internal server error" });
+  if (
+    typeof availablePlaces !== "number" ||
+    !Number.isInteger(availablePlaces) ||
+    availablePlaces < 0
+  ) {
+    throw badRequest("Invalid available places value");
   }
+
+  const existingLevel = await prisma.level.findUnique({
+    where: { id: levelId },
+    select: { id: true }
+  });
+
+  if (!existingLevel) {
+    throw notFound("Level not found");
+  }
+
+  const updatedLevel = await prisma.level.update({
+    where: { id: levelId },
+    data: { availablePlaces }
+  });
+
+  res.status(200).json(updatedLevel);
 };

--- a/apps/api/src/controllers/school-year.controller.ts
+++ b/apps/api/src/controllers/school-year.controller.ts
@@ -1,33 +1,69 @@
 import type { Request, Response } from "express";
 
+import { notFound } from "../lib/errors";
 import { prisma } from "../prisma/client";
 
 export const getSchoolYears = async (_req: Request, res: Response): Promise<void> => {
-  try {
-    const schoolYears = await prisma.schoolYear.findMany({
-      select: {
-        id: true,
-        label: true,
-        startYear: true,
-        endYear: true,
-        isActive: true,
-        createdAt: true,
-        updatedAt: true
-      },
-      orderBy: { startYear: "desc" }
-    });
+  const schoolYears = await prisma.schoolYear.findMany({
+    select: {
+      id: true,
+      label: true,
+      startYear: true,
+      endYear: true,
+      isActive: true,
+      createdAt: true,
+      updatedAt: true
+    },
+    orderBy: { startYear: "desc" }
+  });
 
-    res.status(200).json(schoolYears);
-  } catch (error) {
-    console.error("Failed to fetch school years:", error);
-    res.status(500).json({ message: "Internal server error" });
-  }
+  res.status(200).json(schoolYears);
 };
 
 export const getActiveSchoolYear = async (_req: Request, res: Response): Promise<void> => {
-  try {
-    const schoolYear = await prisma.schoolYear.findFirst({
-      where: { isActive: true },
+  const schoolYear = await prisma.schoolYear.findFirst({
+    where: { isActive: true },
+    select: {
+      id: true,
+      label: true,
+      startYear: true,
+      endYear: true,
+      isActive: true,
+      createdAt: true,
+      updatedAt: true
+    },
+    orderBy: { startYear: "desc" }
+  });
+
+  if (!schoolYear) {
+    throw notFound("Active school year not found");
+  }
+
+  res.status(200).json(schoolYear);
+};
+
+export const activateSchoolYear = async (req: Request, res: Response): Promise<void> => {
+  const schoolYearId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+
+  const existingSchoolYear = await prisma.schoolYear.findUnique({
+    where: { id: schoolYearId },
+    select: { id: true }
+  });
+
+  if (!existingSchoolYear) {
+    throw notFound("School year not found");
+  }
+
+  const [, activatedSchoolYear] = await prisma.$transaction([
+    prisma.schoolYear.updateMany({
+      where: {
+        id: { not: schoolYearId }
+      },
+      data: { isActive: false }
+    }),
+    prisma.schoolYear.update({
+      where: { id: schoolYearId },
+      data: { isActive: true },
       select: {
         id: true,
         label: true,
@@ -36,61 +72,9 @@ export const getActiveSchoolYear = async (_req: Request, res: Response): Promise
         isActive: true,
         createdAt: true,
         updatedAt: true
-      },
-      orderBy: { startYear: "desc" }
-    });
+      }
+    })
+  ]);
 
-    if (!schoolYear) {
-      res.status(404).json({ message: "Active school year not found" });
-      return;
-    }
-
-    res.status(200).json(schoolYear);
-  } catch (error) {
-    console.error("Failed to fetch active school year:", error);
-    res.status(500).json({ message: "Internal server error" });
-  }
-};
-
-export const activateSchoolYear = async (req: Request, res: Response): Promise<void> => {
-  try {
-    const schoolYearId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
-
-    const existingSchoolYear = await prisma.schoolYear.findUnique({
-      where: { id: schoolYearId },
-      select: { id: true }
-    });
-
-    if (!existingSchoolYear) {
-      res.status(404).json({ message: "School year not found" });
-      return;
-    }
-
-    const [, activatedSchoolYear] = await prisma.$transaction([
-      prisma.schoolYear.updateMany({
-        where: {
-          id: { not: schoolYearId }
-        },
-        data: { isActive: false }
-      }),
-      prisma.schoolYear.update({
-        where: { id: schoolYearId },
-        data: { isActive: true },
-        select: {
-          id: true,
-          label: true,
-          startYear: true,
-          endYear: true,
-          isActive: true,
-          createdAt: true,
-          updatedAt: true
-        }
-      })
-    ]);
-
-    res.status(200).json(activatedSchoolYear);
-  } catch (error) {
-    console.error("Failed to activate school year:", error);
-    res.status(500).json({ message: "Internal server error" });
-  }
+  res.status(200).json(activatedSchoolYear);
 };

--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -1,0 +1,23 @@
+export class AppError extends Error {
+  readonly statusCode: number;
+
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = "AppError";
+    this.statusCode = statusCode;
+
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export const isAppError = (error: unknown): error is AppError => {
+  return error instanceof AppError;
+};
+
+export const badRequest = (message: string): AppError => {
+  return new AppError(message, 400);
+};
+
+export const notFound = (message: string): AppError => {
+  return new AppError(message, 404);
+};

--- a/apps/api/src/middlewares/error-handler.ts
+++ b/apps/api/src/middlewares/error-handler.ts
@@ -1,0 +1,37 @@
+import type { ErrorRequestHandler, RequestHandler } from "express";
+
+import { AppError, isAppError, notFound } from "../lib/errors";
+
+const isJsonParseError = (
+  error: unknown
+): error is SyntaxError & { status: number; type: string } => {
+  const errorWithMetadata = error as { status?: unknown; type?: unknown };
+
+  return (
+    error instanceof SyntaxError &&
+    typeof errorWithMetadata.status === "number" &&
+    typeof errorWithMetadata.type === "string" &&
+    errorWithMetadata.status === 400 &&
+    errorWithMetadata.type === "entity.parse.failed"
+  );
+};
+
+export const notFoundHandler: RequestHandler = (_req, _res, next) => {
+  next(notFound("Route not found"));
+};
+
+export const errorHandler: ErrorRequestHandler = (error, _req, res, _next) => {
+  const appError = isAppError(error)
+    ? error
+    : isJsonParseError(error)
+      ? new AppError("Invalid JSON payload", 400)
+      : new AppError("Internal server error", 500);
+
+  if (appError.statusCode >= 500) {
+    console.error(error);
+  }
+
+  res.status(appError.statusCode).json({
+    message: appError.message
+  });
+};

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2,6 +2,7 @@ import "dotenv/config";
 import cors from "cors";
 import express from "express";
 
+import { errorHandler, notFoundHandler } from "./middlewares/error-handler";
 import applicationRoutes from "./routes/application.routes";
 import dashboardRoutes from "./routes/dashboard.routes";
 import levelRoutes from "./routes/level.routes";
@@ -23,6 +24,9 @@ app.get("/health", (_req, res) => {
     service: "ece-api"
   });
 });
+
+app.use(notFoundHandler);
+app.use(errorHandler);
 
 app.listen(PORT, () => {
   console.log(`API running on http://localhost:${PORT}`);


### PR DESCRIPTION
## Objectif

Mettre en place une gestion d’erreurs Express centralisée et cohérente, sans casser le frontend existant.

## Contenu

- ajout d’une base d’erreurs métier réutilisable :
  - `AppError`
  - `badRequest`
  - `notFound`
- ajout d’un middleware global d’erreur
- ajout d’un handler 404 pour les routes inconnues
- standardisation des réponses JSON d’erreur au format :
  ```json
  { "message": "..." }