### PR TITLE
refactor(api): centralize route assembly

### DIFF
--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -1,0 +1,15 @@
+import { Router } from "express";
+
+import applicationRoutes from "./application.routes";
+import dashboardRoutes from "./dashboard.routes";
+import levelRoutes from "./level.routes";
+import schoolYearRoutes from "./school-year.routes";
+
+const apiRouter = Router();
+
+apiRouter.use(applicationRoutes);
+apiRouter.use(dashboardRoutes);
+apiRouter.use(levelRoutes);
+apiRouter.use(schoolYearRoutes);
+
+export default apiRouter;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -3,19 +3,13 @@ import express from "express";
 
 import { config } from "./config/env";
 import { errorHandler, notFoundHandler } from "./middlewares/error-handler";
-import applicationRoutes from "./routes/application.routes";
-import dashboardRoutes from "./routes/dashboard.routes";
-import levelRoutes from "./routes/level.routes";
-import schoolYearRoutes from "./routes/school-year.routes";
+import apiRouter from "./routes";
 
 const app = express();
 
 app.use(cors());
 app.use(express.json());
-app.use("/api", applicationRoutes);
-app.use("/api", dashboardRoutes);
-app.use("/api", levelRoutes);
-app.use("/api", schoolYearRoutes);
+app.use("/api", apiRouter);
 
 app.get("/health", (_req, res) => {
   res.json({


### PR DESCRIPTION
## Objectif

Améliorer légèrement l’organisation du backend sans faire de refactor massif risqué.

## Contenu

- ajout d’un point d’assemblage des routes dans `src/routes/index.ts`
- simplification de `server.ts` pour monter un seul `apiRouter` sous `/api`
- conservation de la structure existante déjà globalement saine :
  - `config/`
  - `controllers/`
  - `lib/`
  - `middlewares/`
  - `routes/`
  - `prisma/`

## Choix assumé

Après audit, la structure backend était déjà proche de la cible.
Aucune réorganisation lourde n’était justifiée.

Cette PR applique donc une amélioration minimale mais utile :
- meilleure lisibilité
- point d’entrée API plus clair
- aucune sur-architecture

## Fichiers concernés

- `apps/api/src/server.ts`
- `apps/api/src/routes/index.ts`

## Vérifications

- [x] `npx tsc --noEmit -p apps/api/tsconfig.json`
- [x] `npm run dev:api`
- [x] `GET /api/levels` → 200
- [x] `GET /api/school-years` → 200
- [x] `GET /api/applications` → 200
- [x] `GET /api/dashboard/stats` → 200

## Notes

- aucune modification frontend
- aucune modification Prisma / migrations / seeds / .env
- aucune régression observée