### PR TITLE
feat(auth): add admin login endpoint with env-based credentials and t…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,5 @@ DATABASE_URL="postgresql://ece:ecepassword@localhost:5432/ece_db?schema=public"
 # SMTP_PORT=587
 # SMTP_USER=notifications@example.com
 # SMTP_PASS=change-me
-# ADMIN_EMAIL=admin@example.com
-# ADMIN_PASSWORD=change-me
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=change-me

--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -1,0 +1,34 @@
+import type { Request, Response } from "express";
+
+import { ADMIN_ROLE, createAdminToken, isValidAdminLogin } from "../lib/admin-auth";
+import { badRequest, unauthorized } from "../lib/errors";
+
+type LoginRequestBody = {
+  email?: unknown;
+  password?: unknown;
+};
+
+const isNonEmptyString = (value: unknown): value is string => {
+  return typeof value === "string" && value.trim().length > 0;
+};
+
+export const loginAdmin = (req: Request, res: Response): void => {
+  const body = req.body as LoginRequestBody | undefined;
+  const email = body?.email;
+  const password = body?.password;
+
+  if (!isNonEmptyString(email) || !isNonEmptyString(password)) {
+    throw badRequest("Email and password are required");
+  }
+
+  if (!isValidAdminLogin({ email, password })) {
+    throw unauthorized("Invalid credentials");
+  }
+
+  res.status(200).json({
+    token: createAdminToken(),
+    user: {
+      role: ADMIN_ROLE
+    }
+  });
+};

--- a/apps/api/src/lib/admin-auth.ts
+++ b/apps/api/src/lib/admin-auth.ts
@@ -1,0 +1,67 @@
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+
+import { config } from "../config/env";
+import { AppError } from "./errors";
+
+const ADMIN_ROLE = "admin" as const;
+
+const normalizeEmail = (email: string): string => {
+  return email.trim().toLowerCase();
+};
+
+const safeCompare = (left: string, right: string): boolean => {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(leftBuffer, rightBuffer);
+};
+
+const getConfiguredAdminCredentials = (): { email: string; password: string } => {
+  const { email, password } = config.admin;
+
+  if (!email || !password) {
+    throw new AppError("Admin credentials are not configured", 500);
+  }
+
+  return {
+    email: normalizeEmail(email),
+    password
+  };
+};
+
+export const isValidAdminLogin = (input: {
+  email: string;
+  password: string;
+}): boolean => {
+  const adminCredentials = getConfiguredAdminCredentials();
+
+  return (
+    safeCompare(normalizeEmail(input.email), adminCredentials.email) &&
+    safeCompare(input.password, adminCredentials.password)
+  );
+};
+
+export const createAdminToken = (): string => {
+  const adminCredentials = getConfiguredAdminCredentials();
+  const payload = {
+    email: adminCredentials.email,
+    role: ADMIN_ROLE,
+    iat: Date.now(),
+    nonce: randomBytes(16).toString("hex")
+  };
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = createHmac(
+    "sha256",
+    `${adminCredentials.email}:${adminCredentials.password}`
+  )
+    .update(encodedPayload)
+    .digest("base64url");
+
+  return `admin.${encodedPayload}.${signature}`;
+};
+
+export { ADMIN_ROLE };

--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -18,6 +18,10 @@ export const badRequest = (message: string): AppError => {
   return new AppError(message, 400);
 };
 
+export const unauthorized = (message: string): AppError => {
+  return new AppError(message, 401);
+};
+
 export const notFound = (message: string): AppError => {
   return new AppError(message, 404);
 };

--- a/apps/api/src/routes/auth.routes.ts
+++ b/apps/api/src/routes/auth.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+
+import { loginAdmin } from "../controllers/auth.controller";
+
+const router = Router();
+
+router.post("/auth/login", loginAdmin);
+
+export default router;

--- a/apps/api/src/routes/index.ts
+++ b/apps/api/src/routes/index.ts
@@ -1,12 +1,14 @@
 import { Router } from "express";
 
 import applicationRoutes from "./application.routes";
+import authRoutes from "./auth.routes";
 import dashboardRoutes from "./dashboard.routes";
 import levelRoutes from "./level.routes";
 import schoolYearRoutes from "./school-year.routes";
 
 const apiRouter = Router();
 
+apiRouter.use(authRoutes);
 apiRouter.use(applicationRoutes);
 apiRouter.use(dashboardRoutes);
 apiRouter.use(levelRoutes);


### PR DESCRIPTION
## 🎯 Feature — Auth admin login (MVP)

### Ajout

Implémentation d’un endpoint d’authentification administrateur :

- POST /api/auth/login
- Input : email + password
- Validation simple via variables d’environnement
- Génération d’un token via crypto (sans JWT complexe)
- Retour :
  {
    token,
    user: { role: "admin" }
  }

### Sécurité

- Comparaison timing-safe
- Credentials non hardcodés (env)
- Erreurs standardisées

### Gestion erreurs

- 400 : payload invalide
- 401 : credentials invalides
- 500 : configuration manquante

### Structure

- auth.controller
- auth.routes
- utilitaire admin-auth
- intégration dans router principal

### Tests

- login valide → 200
- mauvais password → 401
- mauvais email → 401
- payload incomplet → 400
- routes existantes OK

### Notes

Variables requises :
- ADMIN_EMAIL
- ADMIN_PASSWORD