### PR TITLE
feat(auth): add AuthContext with persistent session and localStorage …

### DIFF
--- a/apps/web/src/context/AuthContext.tsx
+++ b/apps/web/src/context/AuthContext.tsx
@@ -1,0 +1,163 @@
+import { createContext, useEffect, useState } from "react";
+import type { ReactNode } from "react";
+
+import { loginAdmin } from "../lib/api";
+import type { AuthUser } from "../lib/api";
+
+const AUTH_TOKEN_STORAGE_KEY = "auth_token";
+const AUTH_USER_STORAGE_KEY = "auth_user";
+
+type AuthSession = {
+  token: string | null;
+  user: AuthUser | null;
+};
+
+export type AuthContextValue = {
+  isAuthenticated: boolean;
+  isLoadingAuth: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+  token: string | null;
+  user: AuthUser | null;
+};
+
+const createEmptyAuthSession = (): AuthSession => ({
+  token: null,
+  user: null
+});
+
+const readStorageItem = (key: string): string | null => {
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+};
+
+const writeStorageItem = (key: string, value: string): void => {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Ignore storage write failures and keep the in-memory session state.
+  }
+};
+
+const removeStorageItem = (key: string): void => {
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    // Ignore storage cleanup failures.
+  }
+};
+
+const isAuthUser = (value: unknown): value is AuthUser => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as { role?: unknown };
+
+  return candidate.role === "admin";
+};
+
+const clearStoredAuthSession = (): void => {
+  removeStorageItem(AUTH_TOKEN_STORAGE_KEY);
+  removeStorageItem(AUTH_USER_STORAGE_KEY);
+};
+
+const persistAuthSession = (session: AuthSession): void => {
+  if (!session.token) {
+    clearStoredAuthSession();
+    return;
+  }
+
+  writeStorageItem(AUTH_TOKEN_STORAGE_KEY, session.token);
+
+  if (session.user) {
+    writeStorageItem(AUTH_USER_STORAGE_KEY, JSON.stringify(session.user));
+    return;
+  }
+
+  removeStorageItem(AUTH_USER_STORAGE_KEY);
+};
+
+const readStoredAuthSession = (): AuthSession => {
+  const storedToken = readStorageItem(AUTH_TOKEN_STORAGE_KEY);
+  const token =
+    typeof storedToken === "string" && storedToken.trim().length > 0
+      ? storedToken
+      : null;
+
+  if (!token) {
+    clearStoredAuthSession();
+    return createEmptyAuthSession();
+  }
+
+  const storedUser = readStorageItem(AUTH_USER_STORAGE_KEY);
+
+  if (!storedUser) {
+    return {
+      token,
+      user: null
+    };
+  }
+
+  try {
+    const parsedUser = JSON.parse(storedUser) as unknown;
+
+    if (isAuthUser(parsedUser)) {
+      return {
+        token,
+        user: parsedUser
+      };
+    }
+  } catch {
+    // Ignore invalid JSON and clear the stored user below.
+  }
+
+  removeStorageItem(AUTH_USER_STORAGE_KEY);
+
+  return {
+    token,
+    user: null
+  };
+};
+
+export const AuthContext = createContext<AuthContextValue | null>(null);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [session, setSession] = useState<AuthSession>(createEmptyAuthSession);
+  const [isLoadingAuth, setIsLoadingAuth] = useState(true);
+
+  useEffect(() => {
+    setSession(readStoredAuthSession());
+    setIsLoadingAuth(false);
+  }, []);
+
+  const login = async (email: string, password: string): Promise<void> => {
+    const nextSession = await loginAdmin(email, password);
+
+    persistAuthSession(nextSession);
+    setSession(nextSession);
+  };
+
+  const logout = (): void => {
+    clearStoredAuthSession();
+    setSession(createEmptyAuthSession());
+  };
+
+  return (
+    <AuthContext.Provider
+      value={{
+        isAuthenticated: session.token !== null,
+        isLoadingAuth,
+        login,
+        logout,
+        token: session.token,
+        user: session.user
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -1,0 +1,14 @@
+import { useContext } from "react";
+
+import { AuthContext } from "../context/AuthContext";
+import type { AuthContextValue } from "../context/AuthContext";
+
+export const useAuth = (): AuthContextValue => {
+  const context = useContext(AuthContext);
+
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+
+  return context;
+};

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -15,6 +15,15 @@ import type { DashboardStats } from "../types/dashboard";
 
 const API_BASE_URL = (import.meta.env.VITE_API_URL ?? "").replace(/\/$/, "");
 
+export type AuthUser = {
+  role: "admin";
+};
+
+export type LoginAdminResponse = {
+  token: string;
+  user: AuthUser;
+};
+
 const buildApiUrl = (path: string): string => {
   return `${API_BASE_URL}${path}`;
 };
@@ -72,6 +81,25 @@ export const fetchDashboardStats = async (
   init?: RequestInit
 ): Promise<DashboardStats> => {
   return fetchJson<DashboardStats>("/api/dashboard/stats", init);
+};
+
+export const loginAdmin = async (
+  email: string,
+  password: string,
+  init?: RequestInit
+): Promise<LoginAdminResponse> => {
+  return fetchJson<LoginAdminResponse>("/api/auth/login", {
+    ...init,
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...init?.headers
+    },
+    body: JSON.stringify({
+      email,
+      password
+    })
+  });
 };
 
 export const getApplications = async (

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,10 +1,14 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
 
-createRoot(document.getElementById('root')!).render(
+import App from "./App.tsx";
+import { AuthProvider } from "./context/AuthContext";
+import "./index.css";
+
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>,
-)
+);


### PR DESCRIPTION
## 🎯 Feature — AuthContext frontend (session persistante)

### Ajout

Mise en place d’une gestion de session côté frontend via un AuthContext global.

### Fonctionnalités

- AuthContext global avec :
  - login(email, password)
  - logout()
  - isAuthenticated
  - token
  - user
  - isLoadingAuth

- Persistance session :
  - stockage dans localStorage (auth_token, auth_user)
  - restauration automatique au refresh

- Hook dédié :
  - useAuth() pour consommer le contexte facilement

- Client API :
  - ajout loginAdmin() pour appeler POST /api/auth/login

### Comportement

- login :
  - appel API backend
  - stockage token + user
  - mise à jour du contexte

- logout :
  - suppression localStorage
  - reset du contexte

- initialisation :
  - lecture localStorage
  - gestion des cas invalides (JSON corrompu)

### Contraintes respectées

- React + TypeScript
- code simple et lisible
- aucune modification backend
- aucune régression frontend

### Tests effectués

- build OK
- dev server OK
- localStorage :
  - stockage OK
  - suppression OK
  - persistance après refresh OK
  - gestion JSON invalide OK

### Suite

Préparation pour :
➡️ protection des routes (prochaine étape)
➡️ intégration page login