### PR TITLE
feat(auth): protect admin routes with PrivateRoute

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,8 +1,10 @@
+import PrivateRoute from "./components/auth/PrivateRoute";
 import ToastViewport from "./components/ui/ToastViewport";
 import { ToastProvider } from "./context/ToastContext";
 import ApplicationDetailPage from "./pages/ApplicationDetailPage";
 import ApplicationsPage from "./pages/ApplicationsPage";
 import DashboardPage from "./pages/DashboardPage";
+import LoginPage from "./pages/LoginPage";
 
 const normalizePathname = (pathname: string): string => {
   const normalizedPathname = pathname.replace(/\/+$/, "");
@@ -65,16 +67,32 @@ const AppContent = () => {
   const pathname = normalizePathname(window.location.pathname);
   const applicationId = getApplicationDetailId(pathname);
 
+  if (pathname === "/login") {
+    return <LoginPage />;
+  }
+
   if (pathname === "/") {
-    return <DashboardPage />;
+    return (
+      <PrivateRoute>
+        <DashboardPage />
+      </PrivateRoute>
+    );
   }
 
   if (pathname === "/applications") {
-    return <ApplicationsPage />;
+    return (
+      <PrivateRoute>
+        <ApplicationsPage />
+      </PrivateRoute>
+    );
   }
 
   if (applicationId) {
-    return <ApplicationDetailPage applicationId={applicationId} />;
+    return (
+      <PrivateRoute>
+        <ApplicationDetailPage applicationId={applicationId} />
+      </PrivateRoute>
+    );
   }
 
   return <NotFoundPage />;

--- a/apps/web/src/components/auth/PrivateRoute.tsx
+++ b/apps/web/src/components/auth/PrivateRoute.tsx
@@ -1,0 +1,71 @@
+import { useEffect } from "react";
+import type { ReactNode } from "react";
+
+import { useAuth } from "../../hooks/useAuth";
+
+type PrivateRouteProps = {
+  children: ReactNode;
+  redirectTo?: string;
+};
+
+const AuthLoadingState = () => {
+  return (
+    <main className="min-h-screen bg-background px-4 py-10 text-slate-900 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-4xl rounded-[2rem] border border-white/80 bg-white/90 p-8 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] backdrop-blur">
+        <p className="text-sm font-semibold uppercase tracking-[0.24em] text-primaryLight">
+          Authentification
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-900">
+          Vérification de la session
+        </h1>
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+          Chargement de votre session administrateur...
+        </p>
+      </div>
+    </main>
+  );
+};
+
+const RedirectingState = () => {
+  return (
+    <main className="min-h-screen bg-background px-4 py-10 text-slate-900 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-4xl rounded-[2rem] border border-white/80 bg-white/90 p-8 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] backdrop-blur">
+        <p className="text-sm font-semibold uppercase tracking-[0.24em] text-primaryLight">
+          Authentification
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-900">
+          Redirection en cours
+        </h1>
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+          Cette page est réservée à l&apos;administration. Redirection vers la
+          page de connexion...
+        </p>
+      </div>
+    </main>
+  );
+};
+
+const PrivateRoute = ({
+  children,
+  redirectTo = "/login"
+}: PrivateRouteProps) => {
+  const { isAuthenticated, isLoadingAuth } = useAuth();
+
+  useEffect(() => {
+    if (!isLoadingAuth && !isAuthenticated) {
+      window.location.replace(redirectTo);
+    }
+  }, [isAuthenticated, isLoadingAuth, redirectTo]);
+
+  if (isLoadingAuth) {
+    return <AuthLoadingState />;
+  }
+
+  if (!isAuthenticated) {
+    return <RedirectingState />;
+  }
+
+  return <>{children}</>;
+};
+
+export default PrivateRoute;

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -1,0 +1,68 @@
+import { useEffect } from "react";
+
+import { useAuth } from "../hooks/useAuth";
+
+const LoginPage = () => {
+  const { isAuthenticated, isLoadingAuth } = useAuth();
+
+  useEffect(() => {
+    if (!isLoadingAuth && isAuthenticated) {
+      window.location.replace("/");
+    }
+  }, [isAuthenticated, isLoadingAuth]);
+
+  if (isLoadingAuth) {
+    return (
+      <main className="min-h-screen bg-background px-4 py-10 text-slate-900 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-4xl rounded-[2rem] border border-white/80 bg-white/90 p-8 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] backdrop-blur">
+          <p className="text-sm font-semibold uppercase tracking-[0.24em] text-primaryLight">
+            Authentification
+          </p>
+          <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-900">
+            Chargement
+          </h1>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+            Vérification de votre session...
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  if (isAuthenticated) {
+    return (
+      <main className="min-h-screen bg-background px-4 py-10 text-slate-900 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-4xl rounded-[2rem] border border-white/80 bg-white/90 p-8 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] backdrop-blur">
+          <p className="text-sm font-semibold uppercase tracking-[0.24em] text-primaryLight">
+            Authentification
+          </p>
+          <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-900">
+            Session active
+          </h1>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+            Redirection vers le dashboard...
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-background px-4 py-10 text-slate-900 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-4xl rounded-[2rem] border border-white/80 bg-white/90 p-8 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] backdrop-blur">
+        <p className="text-sm font-semibold uppercase tracking-[0.24em] text-primaryLight">
+          Authentification
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-900">
+          Login page
+        </h1>
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+          Cette page de connexion est un placeholder temporaire. La vraie page
+          login sera branchée dans l&apos;étape suivante.
+        </p>
+      </div>
+    </main>
+  );
+};
+
+export default LoginPage;


### PR DESCRIPTION
## Objectif

Protéger les pages admin existantes côté frontend en fonction de l’état d’authentification déjà disponible dans l’application.

## Contenu

- ajout d’un composant `PrivateRoute`
- attente de l’initialisation auth avant décision de redirection
- redirection vers `/login` si l’utilisateur n’est pas connecté
- protection des routes admin existantes :
  - `/`
  - `/applications`
  - `/applications/:id`
- ajout d’une route publique `/login` avec placeholder temporaire
- redirection de `/login` vers `/` si une session existe déjà

## Choix technique

Le projet utilise actuellement un routage maison basé sur `window.location`.
Cette PR respecte cette architecture existante et n’introduit pas `react-router-dom`, conformément à l’objectif de stabilité et de non-refonte du routing.

## Fichiers concernés

- `apps/web/src/components/PrivateRoute.tsx`
- `apps/web/src/pages/LoginPage.tsx`
- `apps/web/src/App.tsx`

## Vérifications

- [x] `npm exec -w apps/web -- tsc -b`
- [x] `npm run build -w apps/web`
- [x] `npm run dev:web`
- [x] routes protégées redirigent vers `/login` si non connecté
- [x] routes accessibles si session présente
- [x] refresh conserve l’accès si session persistée
- [x] aucune modification backend

## Notes

- la page `/login` est volontairement un placeholder temporaire
- la prochaine étape consistera à brancher la vraie page login conforme à la maquette