### PR TITLE
feat(ui): refine dashboard and unify level badges across admin

### DIFF
--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -9,7 +9,7 @@ type IconProps = {
 };
 
 type NavigationItem = {
-  key: "dashboard" | "applications" | "imports" | "validation" | "administration";
+  key: "dashboard" | "applications" | "imports";
   label: string;
   to?: string;
   end?: boolean;
@@ -67,28 +67,6 @@ const UploadIcon = ({ className = "h-5 w-5" }: IconProps) => {
   );
 };
 
-const ShieldIcon = ({ className = "h-5 w-5" }: IconProps) => {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className={className}>
-      <path d="M12 3.5 5.5 6v5.5c0 4.2 2.5 7.9 6.5 9 4-1.1 6.5-4.8 6.5-9V6L12 3.5Z" />
-      <path d="m8.5 12 2.1 2.1L15.5 9" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  );
-};
-
-const CogIcon = ({ className = "h-5 w-5" }: IconProps) => {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className={className}>
-      <path d="M12 8.2a3.8 3.8 0 1 0 0 7.6 3.8 3.8 0 0 0 0-7.6Z" />
-      <path
-        d="M19.4 13.1a7.9 7.9 0 0 0 0-2.2l1.6-1.2-1.7-3-1.9.6a7.5 7.5 0 0 0-1.9-1.1l-.3-2.1h-3.4l-.3 2.1a7.5 7.5 0 0 0-1.9 1.1l-1.9-.6-1.7 3 1.6 1.2a7.9 7.9 0 0 0 0 2.2l-1.6 1.2 1.7 3 1.9-.6c.6.5 1.2.9 1.9 1.1l.3 2.1h3.4l.3-2.1c.7-.2 1.3-.6 1.9-1.1l1.9.6 1.7-3-1.6-1.2Z"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-};
-
 const LogoutIcon = ({ className = "h-5 w-5" }: IconProps) => {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className={className}>
@@ -125,16 +103,6 @@ const navigationItems: NavigationItem[] = [
     label: "Import CSV",
     to: "/imports/new",
     icon: UploadIcon
-  },
-  {
-    key: "validation",
-    label: "Validation",
-    icon: ShieldIcon
-  },
-  {
-    key: "administration",
-    label: "Administration",
-    icon: CogIcon
   }
 ];
 
@@ -231,7 +199,7 @@ const AppLayout = () => {
             }}
           >
             <div className="p-4">
-              <nav className="space-y-3" aria-label="Navigation principale">
+              <nav className="mb-[100px] space-y-3" aria-label="Navigation principale">
                 {navigationItems.map((item) => (
                   <SidebarLink key={item.key} item={item} />
                 ))}

--- a/apps/web/src/components/ui/LevelBadge.tsx
+++ b/apps/web/src/components/ui/LevelBadge.tsx
@@ -1,0 +1,51 @@
+import { getLevelVisualStyle } from "../../lib/levelVisuals";
+
+type LevelBadgeSize = "xs" | "sm" | "md";
+
+type LevelBadgeProps = {
+  className?: string;
+  code: string;
+  label?: string;
+  size?: LevelBadgeSize;
+};
+
+const sizeClasses: Record<LevelBadgeSize, string> = {
+  xs: "px-2.5 py-1 text-[0.62rem] tracking-[0.16em]",
+  sm: "px-3 py-1.5 text-[0.66rem] tracking-[0.18em]",
+  md: "px-3.5 py-1.5 text-[0.68rem] tracking-[0.22em]"
+};
+
+const joinClassNames = (...classNames: Array<string | undefined>): string => {
+  return classNames.filter(Boolean).join(" ");
+};
+
+const LevelBadge = ({
+  className,
+  code,
+  label = "",
+  size = "sm"
+}: LevelBadgeProps) => {
+  const visual = getLevelVisualStyle(code, label);
+  const displayCode = code.trim().toUpperCase() || "N/A";
+  const title = label.trim().length > 0 ? `${label} (${displayCode})` : displayCode;
+
+  return (
+    <span
+      title={title}
+      className={joinClassNames(
+        "inline-flex items-center justify-center whitespace-nowrap rounded-full border font-semibold uppercase",
+        sizeClasses[size],
+        className
+      )}
+      style={{
+        backgroundColor: visual.codeBackground,
+        borderColor: visual.borderColor,
+        color: visual.codeTextColor
+      }}
+    >
+      {displayCode}
+    </span>
+  );
+};
+
+export default LevelBadge;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -134,6 +134,7 @@ select {
   position: relative;
   isolation: isolate;
   overflow: hidden;
+  --ui-hover-border-color: rgba(212, 162, 76, 0.9);
   transition:
     transform 260ms cubic-bezier(0.22, 1, 0.36, 1),
     box-shadow 260ms cubic-bezier(0.22, 1, 0.36, 1),
@@ -141,6 +142,19 @@ select {
     background-color 260ms ease,
     filter 260ms ease;
   will-change: transform, box-shadow;
+}
+
+.ui-surface-hover::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow: inset 0 0 0 0 rgba(212, 162, 76, 0);
+  transition:
+    box-shadow 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 260ms ease;
+  opacity: 0.92;
 }
 
 .ui-surface-hover::after {
@@ -173,11 +187,19 @@ select {
   will-change: transform;
 }
 
+.ui-surface-hover--no-accent {
+  --ui-hover-border-color: transparent;
+}
+
 @media (hover: hover) and (pointer: fine) {
   .ui-surface-hover:hover {
     transform: translateY(-6px) scale(1.008);
     box-shadow: 0 26px 46px -32px rgba(15, 23, 42, 0.24);
     filter: saturate(1.02);
+  }
+
+  .ui-surface-hover:hover::before {
+    box-shadow: inset 0 0 0 1.5px var(--ui-hover-border-color);
   }
 
   .ui-surface-hover:hover::after {
@@ -268,6 +290,7 @@ select {
 @media (prefers-reduced-motion: reduce) {
   .ui-animate-in,
   .ui-surface-hover,
+  .ui-surface-hover::before,
   .ui-surface-hover::after,
   .ui-surface-hover__icon,
   .ui-surface-hover__bar,

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -101,6 +101,109 @@ select {
   }
 }
 
+@keyframes ui-surface-enter {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, var(--ui-enter-distance, 22px), 0)
+      scale(var(--ui-enter-scale, 0.985));
+    filter: blur(12px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+    filter: blur(0);
+  }
+}
+
+.ui-animate-in {
+  opacity: 0;
+  transform: translate3d(0, var(--ui-enter-distance, 22px), 0)
+    scale(var(--ui-enter-scale, 0.985));
+  animation: ui-surface-enter 720ms cubic-bezier(0.22, 1, 0.36, 1)
+    var(--ui-enter-delay, 0ms) forwards;
+  will-change: transform, opacity, filter;
+}
+
+.ui-animate-in--subtle {
+  --ui-enter-distance: 14px;
+  --ui-enter-scale: 0.992;
+}
+
+.ui-surface-hover {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  transition:
+    transform 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    border-color 260ms ease,
+    background-color 260ms ease,
+    filter 260ms ease;
+  will-change: transform, box-shadow;
+}
+
+.ui-surface-hover::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background:
+    linear-gradient(
+      135deg,
+      rgba(255, 255, 255, 0.3),
+      rgba(255, 255, 255, 0) 38%,
+      rgba(255, 255, 255, 0.16) 68%,
+      rgba(255, 255, 255, 0) 100%
+    );
+  opacity: 0;
+  transform: scale(0.985);
+  transition:
+    opacity 260ms ease,
+    transform 260ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.ui-surface-hover__icon,
+.ui-surface-hover__bar,
+.ui-surface-hover__chip {
+  transition:
+    transform 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 260ms cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: transform;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ui-surface-hover:hover {
+    transform: translateY(-6px) scale(1.008);
+    box-shadow: 0 26px 46px -32px rgba(15, 23, 42, 0.24);
+    filter: saturate(1.02);
+  }
+
+  .ui-surface-hover:hover::after {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  .ui-surface-hover--soft:hover {
+    transform: translateY(-3px) scale(1.004);
+    box-shadow: 0 18px 32px -28px rgba(15, 23, 42, 0.18);
+  }
+
+  .ui-surface-hover:hover .ui-surface-hover__icon {
+    transform: translateY(-2px) scale(1.08);
+  }
+
+  .ui-surface-hover:hover .ui-surface-hover__bar {
+    transform: scaleY(1.08);
+    box-shadow: 0 12px 24px -14px rgba(15, 23, 42, 0.48);
+  }
+
+  .ui-surface-hover:hover .ui-surface-hover__chip {
+    transform: translateX(2px);
+  }
+}
+
 .login-illustration__halo {
   opacity: 0;
   transform-origin: center;
@@ -163,6 +266,12 @@ select {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .ui-animate-in,
+  .ui-surface-hover,
+  .ui-surface-hover::after,
+  .ui-surface-hover__icon,
+  .ui-surface-hover__bar,
+  .ui-surface-hover__chip,
   .login-illustration__halo,
   .login-illustration__line,
   .login-illustration__dot,
@@ -171,6 +280,8 @@ select {
     animation: none;
     opacity: 1;
     transform: none;
+    filter: none;
+    transition: none;
     stroke-dashoffset: 0;
   }
 }

--- a/apps/web/src/lib/levelVisuals.ts
+++ b/apps/web/src/lib/levelVisuals.ts
@@ -1,0 +1,117 @@
+export type LevelVisualStyle = {
+  barColor: string;
+  cardBackground: string;
+  borderColor: string;
+  codeBackground: string;
+  codeTextColor: string;
+  trackColor: string;
+};
+
+const fallbackLevelVisualStyles: LevelVisualStyle[] = [
+  {
+    barColor: "#2F6B52",
+    cardBackground: "#F7FBF9",
+    borderColor: "rgba(47,107,82,0.10)",
+    codeBackground: "rgba(47,107,82,0.10)",
+    codeTextColor: "#2F6B52",
+    trackColor: "#E8EFF0"
+  },
+  {
+    barColor: "#4E8769",
+    cardBackground: "#F7FBF9",
+    borderColor: "rgba(78,135,105,0.10)",
+    codeBackground: "rgba(78,135,105,0.10)",
+    codeTextColor: "#4E8769",
+    trackColor: "#E8EFF0"
+  },
+  {
+    barColor: "#76AD7A",
+    cardBackground: "#F7FBF8",
+    borderColor: "rgba(118,173,122,0.12)",
+    codeBackground: "rgba(118,173,122,0.12)",
+    codeTextColor: "#4E8769",
+    trackColor: "#E8EFF0"
+  },
+  {
+    barColor: "#A8CF8C",
+    cardBackground: "#FAFCF8",
+    borderColor: "rgba(168,207,140,0.16)",
+    codeBackground: "rgba(168,207,140,0.18)",
+    codeTextColor: "#5D8E4F",
+    trackColor: "#EDF2EA"
+  },
+  {
+    barColor: "#D4A24C",
+    cardBackground: "#FCF8F0",
+    borderColor: "rgba(212,162,76,0.16)",
+    codeBackground: "rgba(212,162,76,0.16)",
+    codeTextColor: "#B8842F",
+    trackColor: "#F3E9D7"
+  },
+  {
+    barColor: "#E2C15A",
+    cardBackground: "#FDF9EF",
+    borderColor: "rgba(226,193,90,0.18)",
+    codeBackground: "rgba(226,193,90,0.18)",
+    codeTextColor: "#B8842F",
+    trackColor: "#F4EBD5"
+  },
+  {
+    barColor: "#CF7560",
+    cardBackground: "#FCF4F2",
+    borderColor: "rgba(207,117,96,0.16)",
+    codeBackground: "rgba(207,117,96,0.14)",
+    codeTextColor: "#B85B4B",
+    trackColor: "#F3E8E6"
+  },
+  {
+    barColor: "#C8574B",
+    cardBackground: "#FCF1EF",
+    borderColor: "rgba(200,87,75,0.16)",
+    codeBackground: "rgba(200,87,75,0.14)",
+    codeTextColor: "#B14B40",
+    trackColor: "#F4E5E1"
+  }
+];
+
+export const getLevelVisualStyle = (
+  levelCode: string,
+  levelLabel = "",
+  fallbackIndex = 0
+): LevelVisualStyle => {
+  const normalized = `${levelCode} ${levelLabel}`.trim().toUpperCase();
+
+  if (normalized.includes("PS") || normalized.includes("MAT")) {
+    return fallbackLevelVisualStyles[0];
+  }
+
+  if (normalized.includes("MS")) {
+    return fallbackLevelVisualStyles[1];
+  }
+
+  if (normalized.includes("GS")) {
+    return fallbackLevelVisualStyles[2];
+  }
+
+  if (normalized.includes("CP")) {
+    return fallbackLevelVisualStyles[3];
+  }
+
+  if (normalized.includes("CE1")) {
+    return fallbackLevelVisualStyles[4];
+  }
+
+  if (normalized.includes("CE2")) {
+    return fallbackLevelVisualStyles[5];
+  }
+
+  if (normalized.includes("CM1")) {
+    return fallbackLevelVisualStyles[6];
+  }
+
+  if (normalized.includes("CM2")) {
+    return fallbackLevelVisualStyles[7];
+  }
+
+  return fallbackLevelVisualStyles[fallbackIndex % fallbackLevelVisualStyles.length];
+};

--- a/apps/web/src/pages/ApplicationDetailPage.tsx
+++ b/apps/web/src/pages/ApplicationDetailPage.tsx
@@ -4,6 +4,7 @@ import { Link, useParams } from "react-router-dom";
 import PageSectionHeader from "../components/layout/PageSectionHeader";
 import Breadcrumb from "../components/ui/Breadcrumb";
 import ErrorState from "../components/ui/ErrorState";
+import LevelBadge from "../components/ui/LevelBadge";
 import LoadingState from "../components/ui/LoadingState";
 import PriorityBadge from "../components/ui/PriorityBadge";
 import StatusBadge from "../components/ui/StatusBadge";
@@ -1023,9 +1024,14 @@ const ApplicationDetailPage = () => {
                         <h3 className="text-lg font-semibold text-slate-900">
                           {student.firstName} {student.lastName}
                         </h3>
-                        <p className="mt-1 text-sm text-slate-500">
-                          {student.level.label} · {student.level.code}
-                        </p>
+                        <div className="mt-2 flex flex-wrap items-center gap-2">
+                          <p className="text-sm text-slate-500">{student.level.label}</p>
+                          <LevelBadge
+                            code={student.level.code}
+                            label={student.level.label}
+                            size="sm"
+                          />
+                        </div>
                       </div>
                       {student.rankInForm ? (
                         <span className="rounded-full bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-slate-700 ring-1 ring-slate-200">

--- a/apps/web/src/pages/ApplicationsPage.tsx
+++ b/apps/web/src/pages/ApplicationsPage.tsx
@@ -5,6 +5,7 @@ import PageSectionHeader from "../components/layout/PageSectionHeader";
 import Breadcrumb from "../components/ui/Breadcrumb";
 import EmptyState from "../components/ui/EmptyState";
 import ErrorState from "../components/ui/ErrorState";
+import LevelBadge from "../components/ui/LevelBadge";
 import LoadingState from "../components/ui/LoadingState";
 import PriorityBadge from "../components/ui/PriorityBadge";
 import StatusBadge from "../components/ui/StatusBadge";
@@ -562,9 +563,16 @@ const ApplicationsPage = () => {
                   application.students.map((student) => (
                     <span
                       key={student.id}
-                      className="rounded-full bg-white px-3 py-1.5 text-xs font-medium text-slate-700 ring-1 ring-slate-200"
+                      className="inline-flex items-center gap-2 rounded-full bg-white px-2.5 py-1.5 text-xs font-medium text-slate-700 ring-1 ring-slate-200"
                     >
-                      {student.firstName} {student.lastName} · {student.level.code}
+                      <span>
+                        {student.firstName} {student.lastName}
+                      </span>
+                      <LevelBadge
+                        code={student.level.code}
+                        label={student.level.label}
+                        size="xs"
+                      />
                     </span>
                   ))
                 )}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -5,10 +5,12 @@ import PageSectionHeader from "../components/layout/PageSectionHeader";
 import Breadcrumb from "../components/ui/Breadcrumb";
 import EmptyState from "../components/ui/EmptyState";
 import ErrorState from "../components/ui/ErrorState";
+import LevelBadge from "../components/ui/LevelBadge";
 import LoadingState from "../components/ui/LoadingState";
 import PriorityBadge from "../components/ui/PriorityBadge";
 import StatusBadge from "../components/ui/StatusBadge";
 import { fetchDashboardStats, getActiveSchoolYear } from "../lib/api";
+import { getLevelVisualStyle } from "../lib/levelVisuals";
 import type { SchoolYearSummary } from "../types/application";
 import type {
   DashboardApplicationStatus,
@@ -41,15 +43,6 @@ type MetricCardProps = {
   surfaceClassName: string;
   value: number;
   valueClassName?: string;
-};
-
-type LevelVisualStyle = {
-  barColor: string;
-  cardBackground: string;
-  borderColor: string;
-  codeBackground: string;
-  codeTextColor: string;
-  trackColor: string;
 };
 
 const PRIORITY_DISPLAY_LIMIT = 3;
@@ -227,18 +220,22 @@ const getPriorityChildrenLabel = (
     .join(" · ");
 };
 
-const getPriorityLevelsLabel = (
+const getPriorityLevels = (
   application: DashboardPriorityApplication
-): string => {
-  const levelLabels = application.students
-    .map((student) => student.level.label.trim())
-    .filter((value) => value.length > 0);
+): Array<{ code: string; label: string }> => {
+  const uniqueLevels = new Map<string, { code: string; label: string }>();
 
-  if (levelLabels.length === 0) {
-    return "Niveau non renseigné";
-  }
+  application.students.forEach((student) => {
+    const code = student.level.code.trim();
+    const label = student.level.label.trim();
+    const key = `${code}::${label}`;
 
-  return Array.from(new Set(levelLabels)).join(" · ");
+    if ((code.length > 0 || label.length > 0) && !uniqueLevels.has(key)) {
+      uniqueLevels.set(key, { code, label });
+    }
+  });
+
+  return Array.from(uniqueLevels.values());
 };
 
 const MetricCard = ({
@@ -273,115 +270,6 @@ const MetricCard = ({
       <p className="mt-3 text-sm leading-6 text-slate-500">{description}</p>
     </article>
   );
-};
-
-const fallbackLevelVisualStyles: LevelVisualStyle[] = [
-  {
-    barColor: "#2F6B52",
-    cardBackground: "#F7FBF9",
-    borderColor: "rgba(47,107,82,0.10)",
-    codeBackground: "rgba(47,107,82,0.10)",
-    codeTextColor: "#2F6B52",
-    trackColor: "#E8EFF0"
-  },
-  {
-    barColor: "#4E8769",
-    cardBackground: "#F7FBF9",
-    borderColor: "rgba(78,135,105,0.10)",
-    codeBackground: "rgba(78,135,105,0.10)",
-    codeTextColor: "#4E8769",
-    trackColor: "#E8EFF0"
-  },
-  {
-    barColor: "#76AD7A",
-    cardBackground: "#F7FBF8",
-    borderColor: "rgba(118,173,122,0.12)",
-    codeBackground: "rgba(118,173,122,0.12)",
-    codeTextColor: "#4E8769",
-    trackColor: "#E8EFF0"
-  },
-  {
-    barColor: "#A8CF8C",
-    cardBackground: "#FAFCF8",
-    borderColor: "rgba(168,207,140,0.16)",
-    codeBackground: "rgba(168,207,140,0.18)",
-    codeTextColor: "#5D8E4F",
-    trackColor: "#EDF2EA"
-  },
-  {
-    barColor: "#D4A24C",
-    cardBackground: "#FCF8F0",
-    borderColor: "rgba(212,162,76,0.16)",
-    codeBackground: "rgba(212,162,76,0.16)",
-    codeTextColor: "#B8842F",
-    trackColor: "#F3E9D7"
-  },
-  {
-    barColor: "#E2C15A",
-    cardBackground: "#FDF9EF",
-    borderColor: "rgba(226,193,90,0.18)",
-    codeBackground: "rgba(226,193,90,0.18)",
-    codeTextColor: "#B8842F",
-    trackColor: "#F4EBD5"
-  },
-  {
-    barColor: "#CF7560",
-    cardBackground: "#FCF4F2",
-    borderColor: "rgba(207,117,96,0.16)",
-    codeBackground: "rgba(207,117,96,0.14)",
-    codeTextColor: "#B85B4B",
-    trackColor: "#F3E8E6"
-  },
-  {
-    barColor: "#C8574B",
-    cardBackground: "#FCF1EF",
-    borderColor: "rgba(200,87,75,0.16)",
-    codeBackground: "rgba(200,87,75,0.14)",
-    codeTextColor: "#B14B40",
-    trackColor: "#F4E5E1"
-  }
-];
-
-const getLevelVisualStyle = (
-  levelCode: string,
-  levelLabel: string,
-  index: number
-): LevelVisualStyle => {
-  const normalized = `${levelCode} ${levelLabel}`.trim().toUpperCase();
-
-  if (normalized.includes("PS") || normalized.includes("MAT")) {
-    return fallbackLevelVisualStyles[0];
-  }
-
-  if (normalized.includes("MS")) {
-    return fallbackLevelVisualStyles[1];
-  }
-
-  if (normalized.includes("GS")) {
-    return fallbackLevelVisualStyles[2];
-  }
-
-  if (normalized.includes("CP")) {
-    return fallbackLevelVisualStyles[3];
-  }
-
-  if (normalized.includes("CE1")) {
-    return fallbackLevelVisualStyles[4];
-  }
-
-  if (normalized.includes("CE2")) {
-    return fallbackLevelVisualStyles[5];
-  }
-
-  if (normalized.includes("CM1")) {
-    return fallbackLevelVisualStyles[6];
-  }
-
-  if (normalized.includes("CM2")) {
-    return fallbackLevelVisualStyles[7];
-  }
-
-  return fallbackLevelVisualStyles[index % fallbackLevelVisualStyles.length];
 };
 
 const isWideLevelCard = (levelCode: string): boolean => {
@@ -573,7 +461,7 @@ const DashboardPage = () => {
       {pageHeader}
 
       <section
-        className="ui-animate-in ui-surface-hover ui-surface-hover--soft overflow-hidden rounded-[32px] border border-white/80 bg-white/92 shadow-[0_24px_50px_-34px_rgba(15,23,42,0.3)]"
+        className="ui-animate-in ui-surface-hover ui-surface-hover--soft ui-surface-hover--no-accent overflow-hidden rounded-[32px] border border-white/80 bg-white/92 shadow-[0_24px_50px_-34px_rgba(15,23,42,0.3)]"
         style={getEnterStyle(190)}
       >
         <div className="p-6 sm:p-8">
@@ -627,7 +515,7 @@ const DashboardPage = () => {
 
       <section className="mt-6 space-y-6">
         <article
-          className="ui-animate-in ui-surface-hover ui-surface-hover--soft rounded-[30px] border border-white/80 bg-white/92 p-6 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] sm:p-8"
+          className="ui-animate-in ui-surface-hover ui-surface-hover--soft ui-surface-hover--no-accent rounded-[30px] border border-white/80 bg-white/92 p-6 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] sm:p-8"
           style={getEnterStyle(430)}
         >
           <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
@@ -694,15 +582,12 @@ const DashboardPage = () => {
                         <p className="text-2xl font-semibold tracking-tight text-slate-900">
                           {level.label}
                         </p>
-                        <span
-                          className="ui-surface-hover__chip mt-3 inline-flex w-fit items-center rounded-full px-3.5 py-1.5 text-[0.68rem] font-semibold uppercase tracking-[0.22em]"
-                          style={{
-                            backgroundColor: visual.codeBackground,
-                            color: visual.codeTextColor
-                          }}
-                        >
-                          {level.code}
-                        </span>
+                        <LevelBadge
+                          code={level.code}
+                          label={level.label}
+                          size="md"
+                          className="ui-surface-hover__chip mt-3"
+                        />
                       </div>
 
                       <div className="shrink-0 text-right">
@@ -735,7 +620,7 @@ const DashboardPage = () => {
         </article>
 
         <article
-          className="ui-animate-in ui-surface-hover ui-surface-hover--soft rounded-[30px] border border-white/80 bg-white/90 p-6 shadow-[0_18px_38px_-30px_rgba(15,23,42,0.24)]"
+          className="ui-animate-in ui-surface-hover ui-surface-hover--soft ui-surface-hover--no-accent rounded-[30px] border border-white/80 bg-white/90 p-6 shadow-[0_18px_38px_-30px_rgba(15,23,42,0.24)]"
           style={getEnterStyle(690)}
         >
           <div className="flex flex-wrap items-center justify-between gap-4">
@@ -764,98 +649,122 @@ const DashboardPage = () => {
                 Aucune demande prioritaire pour le moment.
               </p>
             ) : (
-              visiblePriorityApplications.map((application, index) => (
-                <article
-                  key={application.id}
-                  className="ui-animate-in ui-surface-hover ui-surface-hover--soft rounded-[28px] border border-slate-200/90 bg-slate-50/80 p-5 shadow-[0_14px_28px_-24px_rgba(15,23,42,0.18)]"
-                  style={getEnterStyle(760 + index * 80)}
-                >
-                  <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                    <div className="min-w-0">
-                      <div className="flex flex-wrap items-center gap-2.5">
-                        <h3 className="text-lg font-semibold text-slate-900">
-                          Famille {getFamilyDisplayName(application)}
-                        </h3>
-                        <PriorityBadge isPriority={application.isPriority} />
+              visiblePriorityApplications.map((application, index) => {
+                const priorityLevels = getPriorityLevels(application);
+
+                return (
+                  <article
+                    key={application.id}
+                    className="ui-animate-in ui-surface-hover ui-surface-hover--soft rounded-[28px] border border-slate-200/90 bg-slate-50/80 p-5 shadow-[0_14px_28px_-24px_rgba(15,23,42,0.18)]"
+                    style={getEnterStyle(760 + index * 80)}
+                  >
+                    <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-2.5">
+                          <h3 className="text-lg font-semibold text-slate-900">
+                            Famille {getFamilyDisplayName(application)}
+                          </h3>
+                          <PriorityBadge isPriority={application.isPriority} />
+                        </div>
+                        <p className="mt-2 text-sm text-slate-500">
+                          {application.schoolYear.label}
+                          {application.schoolYear.isActive ? " · année active" : ""}
+                        </p>
                       </div>
-                      <p className="mt-2 text-sm text-slate-500">
-                        {application.schoolYear.label}
-                        {application.schoolYear.isActive ? " · année active" : ""}
-                      </p>
-                    </div>
-                    <div className="flex flex-wrap items-center gap-2">
-                      <StatusBadge status={application.status} />
-                      <Link
-                        to={`/applications/${application.id}`}
-                        className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary/30 hover:text-primary"
-                      >
-                        Voir la demande
-                      </Link>
-                    </div>
-                  </div>
-
-                  <div className="mt-5 grid gap-3 md:grid-cols-2">
-                    <div className="rounded-2xl border border-white bg-white/80 px-4 py-3">
-                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                        Enfants
-                      </p>
-                      <p className="mt-2 text-sm leading-6 text-slate-700">
-                        {getPriorityChildrenLabel(application)}
-                      </p>
-                    </div>
-                    <div className="rounded-2xl border border-white bg-white/80 px-4 py-3">
-                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                        Niveau
-                      </p>
-                      <p className="mt-2 text-sm leading-6 text-slate-700">
-                        {getPriorityLevelsLabel(application)}
-                      </p>
-                    </div>
-                    <div className="rounded-2xl border border-white bg-white/80 px-4 py-3">
-                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                        Contact
-                      </p>
-                      <p className="mt-2 text-sm leading-6 text-slate-700">
-                        {application.family.contactEmail ? (
-                          <a
-                            href={`mailto:${application.family.contactEmail}`}
-                            className="break-all text-primary hover:text-primaryDark"
-                          >
-                            {application.family.contactEmail}
-                          </a>
-                        ) : (
-                          "Non renseigné"
-                        )}
-                      </p>
-                    </div>
-                    <div className="rounded-2xl border border-white bg-white/80 px-4 py-3">
-                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                        Date
-                      </p>
-                      <p className="mt-2 text-sm leading-6 text-slate-700">
-                        {priorityDateFormatter.format(new Date(application.createdAt))}
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="mt-4 flex flex-wrap gap-2">
-                    {application.students.length === 0 ? (
-                      <span className="rounded-full bg-white px-3 py-1.5 text-xs font-medium text-slate-500 ring-1 ring-slate-200">
-                        Aucun élève rattaché
-                      </span>
-                    ) : (
-                      application.students.map((student) => (
-                        <span
-                          key={`${application.id}-${student.firstName}-${student.lastName}-${student.level.code}`}
-                          className="ui-surface-hover__chip rounded-full bg-white px-3 py-1.5 text-xs font-medium text-slate-700 ring-1 ring-slate-200"
+                      <div className="flex flex-wrap items-center gap-2">
+                        <StatusBadge status={application.status} />
+                        <Link
+                          to={`/applications/${application.id}`}
+                          className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary/30 hover:text-primary"
                         >
-                          {student.firstName} {student.lastName} · {student.level.code}
+                          Voir la demande
+                        </Link>
+                      </div>
+                    </div>
+
+                    <div className="mt-5 grid gap-3 md:grid-cols-2">
+                      <div className="rounded-2xl border border-white bg-white/80 px-4 py-3">
+                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                          Enfants
+                        </p>
+                        <p className="mt-2 text-sm leading-6 text-slate-700">
+                          {getPriorityChildrenLabel(application)}
+                        </p>
+                      </div>
+                      <div className="rounded-2xl border border-white bg-white/80 px-4 py-3">
+                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                          Niveau
+                        </p>
+                        <div className="mt-2 flex flex-wrap gap-2">
+                          {priorityLevels.length === 0 ? (
+                            <span className="text-sm leading-6 text-slate-500">
+                              Niveau non renseigné
+                            </span>
+                          ) : (
+                            priorityLevels.map((level) => (
+                              <LevelBadge
+                                key={`${application.id}-${level.code}-${level.label}`}
+                                code={level.code}
+                                label={level.label}
+                                size="sm"
+                              />
+                            ))
+                          )}
+                        </div>
+                      </div>
+                      <div className="rounded-2xl border border-white bg-white/80 px-4 py-3">
+                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                          Contact
+                        </p>
+                        <p className="mt-2 text-sm leading-6 text-slate-700">
+                          {application.family.contactEmail ? (
+                            <a
+                              href={`mailto:${application.family.contactEmail}`}
+                              className="break-all text-primary hover:text-primaryDark"
+                            >
+                              {application.family.contactEmail}
+                            </a>
+                          ) : (
+                            "Non renseigné"
+                          )}
+                        </p>
+                      </div>
+                      <div className="rounded-2xl border border-white bg-white/80 px-4 py-3">
+                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                          Date
+                        </p>
+                        <p className="mt-2 text-sm leading-6 text-slate-700">
+                          {priorityDateFormatter.format(new Date(application.createdAt))}
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      {application.students.length === 0 ? (
+                        <span className="rounded-full bg-white px-3 py-1.5 text-xs font-medium text-slate-500 ring-1 ring-slate-200">
+                          Aucun élève rattaché
                         </span>
-                      ))
-                    )}
-                  </div>
-                </article>
-              ))
+                      ) : (
+                        application.students.map((student) => (
+                          <span
+                            key={`${application.id}-${student.firstName}-${student.lastName}-${student.level.code}`}
+                            className="ui-surface-hover__chip inline-flex items-center gap-2 rounded-full bg-white px-2.5 py-1.5 text-xs font-medium text-slate-700 ring-1 ring-slate-200"
+                          >
+                            <span>
+                              {student.firstName} {student.lastName}
+                            </span>
+                            <LevelBadge
+                              code={student.level.code}
+                              label={student.level.label}
+                              size="xs"
+                            />
+                          </span>
+                        ))
+                      )}
+                    </div>
+                  </article>
+                );
+              })
             )}
           </div>
 

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type CSSProperties, type JSX } from "react";
 import { Link } from "react-router-dom";
 
 import PageSectionHeader from "../components/layout/PageSectionHeader";
@@ -8,18 +8,145 @@ import ErrorState from "../components/ui/ErrorState";
 import LoadingState from "../components/ui/LoadingState";
 import PriorityBadge from "../components/ui/PriorityBadge";
 import StatusBadge from "../components/ui/StatusBadge";
-import { fetchDashboardStats } from "../lib/api";
+import { fetchDashboardStats, getActiveSchoolYear } from "../lib/api";
+import type { SchoolYearSummary } from "../types/application";
 import type {
   DashboardApplicationStatus,
   DashboardPriorityApplication,
   DashboardStats
 } from "../types/dashboard";
 
+type IconProps = {
+  className?: string;
+};
+
+type DashboardMetricIcon = (props: IconProps) => JSX.Element;
+
 type StatusCardConfig = {
   status: DashboardApplicationStatus;
   label: string;
   description: string;
   valueClassName: string;
+  surfaceClassName: string;
+  iconClassName: string;
+  Icon: DashboardMetricIcon;
+};
+
+type MetricCardProps = {
+  description: string;
+  Icon: DashboardMetricIcon;
+  iconClassName: string;
+  label: string;
+  motionDelay?: number;
+  surfaceClassName: string;
+  value: number;
+  valueClassName?: string;
+};
+
+type LevelVisualStyle = {
+  barColor: string;
+  cardBackground: string;
+  borderColor: string;
+  codeBackground: string;
+  codeTextColor: string;
+  trackColor: string;
+};
+
+const PRIORITY_DISPLAY_LIMIT = 3;
+
+const dashboardHeaderEyebrow = "Administration ECE";
+const dashboardHeaderTitle = "Bienvenue dans l'espace d'administration ECE";
+const dashboardHeaderDescription =
+  "Centralisez le suivi des inscriptions, priorisez les demandes sensibles et gardez les indicateurs principaux visibles pour accélérer les décisions quotidiennes.";
+
+const priorityDateFormatter = new Intl.DateTimeFormat("fr-FR", {
+  dateStyle: "long"
+});
+
+const formatSchoolYearLabel = (label: string): string => {
+  return label.replace(/^(\d{4})-(\d{4})$/u, "$1 - $2");
+};
+
+const getEnterStyle = (delay: number): CSSProperties => {
+  return {
+    "--ui-enter-delay": `${delay}ms`
+  } as CSSProperties;
+};
+
+const OverviewMetricIcon = ({ className = "h-5 w-5" }: IconProps) => {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      className={className}
+    >
+      <path d="M3.5 15.5h13" strokeLinecap="round" />
+      <path d="M5.5 13V8.5" strokeLinecap="round" />
+      <path d="M10 13V5.5" strokeLinecap="round" />
+      <path d="M14.5 13v-3" strokeLinecap="round" />
+    </svg>
+  );
+};
+
+const MailMetricIcon = ({ className = "h-5 w-5" }: IconProps) => {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      className={className}
+    >
+      <rect x="3.5" y="4.5" width="13" height="11" rx="2.2" />
+      <path d="M4.5 6 10 10l5.5-4" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+};
+
+const ReviewMetricIcon = ({ className = "h-5 w-5" }: IconProps) => {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      className={className}
+    >
+      <circle cx="10" cy="10" r="6.2" />
+      <path d="M10 6.8V10l2.5 1.7" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+};
+
+const AcceptedMetricIcon = ({ className = "h-5 w-5" }: IconProps) => {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.9"
+      className={className}
+    >
+      <path d="m4.8 10.2 3.1 3.1 7.3-7.3" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+};
+
+const RefusedMetricIcon = ({ className = "h-5 w-5" }: IconProps) => {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.9"
+      className={className}
+    >
+      <path d="m6 6 8 8" strokeLinecap="round" />
+      <path d="m14 6-8 8" strokeLinecap="round" />
+    </svg>
+  );
 };
 
 const statusCards: StatusCardConfig[] = [
@@ -27,32 +154,39 @@ const statusCards: StatusCardConfig[] = [
     status: "RECEIVED",
     label: "Reçues",
     description: "Demandes nouvellement importées ou enregistrées.",
-    valueClassName: "text-slate-900"
+    valueClassName: "text-slate-900",
+    surfaceClassName: "bg-slate-50/90",
+    iconClassName: "bg-slate-900 text-white",
+    Icon: MailMetricIcon
   },
   {
     status: "IN_REVIEW",
     label: "En revue",
     description: "Demandes en cours d'analyse par l'administration.",
-    valueClassName: "text-info"
+    valueClassName: "text-info",
+    surfaceClassName: "bg-info/10",
+    iconClassName: "bg-info text-white",
+    Icon: ReviewMetricIcon
   },
   {
     status: "ACCEPTED",
     label: "Acceptées",
     description: "Décisions favorables déjà prises.",
-    valueClassName: "text-success"
+    valueClassName: "text-success",
+    surfaceClassName: "bg-success/10",
+    iconClassName: "bg-success text-white",
+    Icon: AcceptedMetricIcon
   },
   {
     status: "REFUSED",
     label: "Refusées",
     description: "Demandes clôturées avec décision négative.",
-    valueClassName: "text-danger"
+    valueClassName: "text-danger",
+    surfaceClassName: "bg-danger/10",
+    iconClassName: "bg-danger text-white",
+    Icon: RefusedMetricIcon
   }
 ];
-
-const createdAtFormatter = new Intl.DateTimeFormat("fr-FR", {
-  dateStyle: "medium",
-  timeStyle: "short"
-});
 
 const isAbortError = (error: unknown): boolean => {
   return error instanceof DOMException && error.name === "AbortError";
@@ -81,7 +215,7 @@ const getFamilyDisplayName = (
   return "Famille non renseignée";
 };
 
-const getPriorityDescription = (
+const getPriorityChildrenLabel = (
   application: DashboardPriorityApplication
 ): string => {
   if (application.students.length === 0) {
@@ -89,40 +223,182 @@ const getPriorityDescription = (
   }
 
   return application.students
-    .map(
-      (student) => `${student.firstName} ${student.lastName} · ${student.level.label}`
-    )
-    .join(" | ");
+    .map((student) => `${student.firstName} ${student.lastName}`)
+    .join(" · ");
 };
 
-type MetricCardProps = {
-  label: string;
-  value: number;
-  description: string;
-  valueClassName?: string;
+const getPriorityLevelsLabel = (
+  application: DashboardPriorityApplication
+): string => {
+  const levelLabels = application.students
+    .map((student) => student.level.label.trim())
+    .filter((value) => value.length > 0);
+
+  if (levelLabels.length === 0) {
+    return "Niveau non renseigné";
+  }
+
+  return Array.from(new Set(levelLabels)).join(" · ");
 };
 
 const MetricCard = ({
   label,
   value,
   description,
+  Icon,
+  iconClassName,
+  motionDelay = 0,
+  surfaceClassName,
   valueClassName = "text-primary"
 }: MetricCardProps) => {
   return (
-    <article className="rounded-3xl border border-white/80 bg-white/90 p-5 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] backdrop-blur">
-      <p className="text-sm font-medium uppercase tracking-[0.2em] text-slate-500">
-        {label}
+    <article
+      className={`ui-animate-in ui-surface-hover rounded-[28px] border border-white/80 p-5 shadow-[0_18px_40px_-30px_rgba(15,23,42,0.32)] ${surfaceClassName}`}
+      style={getEnterStyle(motionDelay)}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+          {label}
+        </p>
+        <span
+          className={`ui-surface-hover__icon inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl ${iconClassName}`}
+        >
+          <Icon className="h-5 w-5" />
+        </span>
+      </div>
+      <p className={`mt-6 text-4xl font-semibold tracking-tight ${valueClassName}`}>
+        {value}
       </p>
-      <p className={`mt-4 text-4xl font-semibold ${valueClassName}`}>{value}</p>
-      <p className="mt-3 text-sm leading-6 text-slate-600">{description}</p>
+      <p className="mt-2 text-sm font-medium text-slate-700">{label}</p>
+      <p className="mt-3 text-sm leading-6 text-slate-500">{description}</p>
     </article>
   );
+};
+
+const fallbackLevelVisualStyles: LevelVisualStyle[] = [
+  {
+    barColor: "#2F6B52",
+    cardBackground: "#F7FBF9",
+    borderColor: "rgba(47,107,82,0.10)",
+    codeBackground: "rgba(47,107,82,0.10)",
+    codeTextColor: "#2F6B52",
+    trackColor: "#E8EFF0"
+  },
+  {
+    barColor: "#4E8769",
+    cardBackground: "#F7FBF9",
+    borderColor: "rgba(78,135,105,0.10)",
+    codeBackground: "rgba(78,135,105,0.10)",
+    codeTextColor: "#4E8769",
+    trackColor: "#E8EFF0"
+  },
+  {
+    barColor: "#76AD7A",
+    cardBackground: "#F7FBF8",
+    borderColor: "rgba(118,173,122,0.12)",
+    codeBackground: "rgba(118,173,122,0.12)",
+    codeTextColor: "#4E8769",
+    trackColor: "#E8EFF0"
+  },
+  {
+    barColor: "#A8CF8C",
+    cardBackground: "#FAFCF8",
+    borderColor: "rgba(168,207,140,0.16)",
+    codeBackground: "rgba(168,207,140,0.18)",
+    codeTextColor: "#5D8E4F",
+    trackColor: "#EDF2EA"
+  },
+  {
+    barColor: "#D4A24C",
+    cardBackground: "#FCF8F0",
+    borderColor: "rgba(212,162,76,0.16)",
+    codeBackground: "rgba(212,162,76,0.16)",
+    codeTextColor: "#B8842F",
+    trackColor: "#F3E9D7"
+  },
+  {
+    barColor: "#E2C15A",
+    cardBackground: "#FDF9EF",
+    borderColor: "rgba(226,193,90,0.18)",
+    codeBackground: "rgba(226,193,90,0.18)",
+    codeTextColor: "#B8842F",
+    trackColor: "#F4EBD5"
+  },
+  {
+    barColor: "#CF7560",
+    cardBackground: "#FCF4F2",
+    borderColor: "rgba(207,117,96,0.16)",
+    codeBackground: "rgba(207,117,96,0.14)",
+    codeTextColor: "#B85B4B",
+    trackColor: "#F3E8E6"
+  },
+  {
+    barColor: "#C8574B",
+    cardBackground: "#FCF1EF",
+    borderColor: "rgba(200,87,75,0.16)",
+    codeBackground: "rgba(200,87,75,0.14)",
+    codeTextColor: "#B14B40",
+    trackColor: "#F4E5E1"
+  }
+];
+
+const getLevelVisualStyle = (
+  levelCode: string,
+  levelLabel: string,
+  index: number
+): LevelVisualStyle => {
+  const normalized = `${levelCode} ${levelLabel}`.trim().toUpperCase();
+
+  if (normalized.includes("PS") || normalized.includes("MAT")) {
+    return fallbackLevelVisualStyles[0];
+  }
+
+  if (normalized.includes("MS")) {
+    return fallbackLevelVisualStyles[1];
+  }
+
+  if (normalized.includes("GS")) {
+    return fallbackLevelVisualStyles[2];
+  }
+
+  if (normalized.includes("CP")) {
+    return fallbackLevelVisualStyles[3];
+  }
+
+  if (normalized.includes("CE1")) {
+    return fallbackLevelVisualStyles[4];
+  }
+
+  if (normalized.includes("CE2")) {
+    return fallbackLevelVisualStyles[5];
+  }
+
+  if (normalized.includes("CM1")) {
+    return fallbackLevelVisualStyles[6];
+  }
+
+  if (normalized.includes("CM2")) {
+    return fallbackLevelVisualStyles[7];
+  }
+
+  return fallbackLevelVisualStyles[index % fallbackLevelVisualStyles.length];
+};
+
+const isWideLevelCard = (levelCode: string): boolean => {
+  const normalizedCode = levelCode.trim().toUpperCase();
+
+  return normalizedCode === "CM1" || normalizedCode === "CM2";
 };
 
 const DashboardPage = () => {
   const [data, setData] = useState<DashboardStats | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [currentPriorityPage, setCurrentPriorityPage] = useState(1);
+  const [activeSchoolYear, setActiveSchoolYear] = useState<SchoolYearSummary | null>(
+    null
+  );
+  const [isLoadingActiveSchoolYear, setIsLoadingActiveSchoolYear] = useState(true);
 
   const loadDashboard = async (signal?: AbortSignal): Promise<void> => {
     setIsLoading(true);
@@ -158,54 +434,92 @@ const DashboardPage = () => {
     const controller = new AbortController();
 
     void loadDashboard(controller.signal);
+    void (async () => {
+      setIsLoadingActiveSchoolYear(true);
+
+      try {
+        const schoolYear = await getActiveSchoolYear({ signal: controller.signal });
+
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        setActiveSchoolYear(schoolYear);
+      } catch (loadError) {
+        if (isAbortError(loadError) || controller.signal.aborted) {
+          return;
+        }
+
+        setActiveSchoolYear(null);
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoadingActiveSchoolYear(false);
+        }
+      }
+    })();
 
     return () => {
       controller.abort();
     };
   }, []);
 
+  useEffect(() => {
+    const totalPages = Math.max(
+      1,
+      Math.ceil((data?.priorityApplications.length ?? 0) / PRIORITY_DISPLAY_LIMIT)
+    );
+
+    setCurrentPriorityPage((currentPage) => Math.min(currentPage, totalPages));
+  }, [data?.priorityApplications.length]);
+
   const pageTopBar = (
-    <Breadcrumb
-      items={[
-        { label: "Accueil", href: "/" },
-        { label: "Tableau de bord" }
-      ]}
-    />
+    <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+      <div
+        className="ui-animate-in ui-animate-in--subtle w-fit rounded-2xl border border-primary/10 bg-white/80 px-4 py-3 text-sm text-primaryDark shadow-[0_10px_22px_-22px_rgba(15,23,42,0.18)]"
+        style={getEnterStyle(20)}
+      >
+        <Breadcrumb
+          items={[
+            { label: "Tableau de bord" }
+          ]}
+        />
+      </div>
+
+      <div className="flex lg:justify-end">
+        <div
+          className="ui-animate-in ui-animate-in--subtle rounded-2xl border border-primary/10 bg-white/80 px-4 py-3 text-center text-sm text-primaryDark shadow-[0_10px_22px_-22px_rgba(15,23,42,0.18)]"
+          style={getEnterStyle(90)}
+        >
+          <p className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-primaryLight">
+            Année active
+          </p>
+          <p className="mt-1 text-center font-semibold">
+            {isLoadingActiveSchoolYear
+              ? "Chargement..."
+              : activeSchoolYear
+                ? formatSchoolYearLabel(activeSchoolYear.label)
+                : "Non configurée"}
+          </p>
+        </div>
+      </div>
+    </div>
   );
 
-  const pageHeaderAside = (
-    <div className="flex flex-col items-start gap-3 lg:items-end">
-      <div className="flex flex-wrap items-center gap-3 lg:justify-end">
-        <Link
-          to="/applications"
-          className="inline-flex items-center rounded-full bg-primary px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-primaryDark"
-        >
-          Ouvrir les demandes
-        </Link>
-        <Link
-          to="/imports/new"
-          className="inline-flex items-center rounded-full bg-secondary px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-secondaryDark"
-        >
-          Importer un CSV
-        </Link>
-      </div>
-
-      <div className="rounded-2xl border border-primary/10 bg-primary/5 px-4 py-3 text-sm text-primaryDark">
-        Source : <span className="font-semibold">GET /api/dashboard/stats</span>
-      </div>
+  const pageHeader = (
+    <div className="ui-animate-in ui-animate-in--subtle" style={getEnterStyle(130)}>
+      <PageSectionHeader
+        topBar={pageTopBar}
+        eyebrow={dashboardHeaderEyebrow}
+        title={dashboardHeaderTitle}
+        description={dashboardHeaderDescription}
+      />
     </div>
   );
 
   if (isLoading && !data) {
     return (
       <>
-        <PageSectionHeader
-          topBar={pageTopBar}
-          eyebrow="Dashboard Admin"
-          title="Vue d'ensemble des demandes d'inscription"
-          description="Première version branchée sur l'API réelle pour suivre le volume global, les statuts, la répartition des élèves et les dossiers prioritaires."
-          aside={pageHeaderAside}
-        />
+        {pageHeader}
         <LoadingState variant="page" />
       </>
     );
@@ -214,13 +528,7 @@ const DashboardPage = () => {
   if (error && !data) {
     return (
       <>
-        <PageSectionHeader
-          topBar={pageTopBar}
-          eyebrow="Dashboard Admin"
-          title="Vue d'ensemble des demandes d'inscription"
-          description="Première version branchée sur l'API réelle pour suivre le volume global, les statuts, la répartition des élèves et les dossiers prioritaires."
-          aside={pageHeaderAside}
-        />
+        {pageHeader}
         <ErrorState
           message={error}
           actionLabel="Réessayer"
@@ -233,13 +541,7 @@ const DashboardPage = () => {
   if (!data || data.totalApplications === 0) {
     return (
       <>
-        <PageSectionHeader
-          topBar={pageTopBar}
-          eyebrow="Dashboard Admin"
-          title="Vue d'ensemble des demandes d'inscription"
-          description="Première version branchée sur l'API réelle pour suivre le volume global, les statuts, la répartition des élèves et les dossiers prioritaires."
-          aside={pageHeaderAside}
-        />
+        {pageHeader}
         <EmptyState
           title="Aucune donnée disponible"
           description="Le dashboard s'alimentera automatiquement dès qu'une demande et des élèves seront présents en base."
@@ -249,74 +551,180 @@ const DashboardPage = () => {
   }
 
   const maxLevelCount = Math.max(...data.byLevel.map((level) => level.count), 0);
+  const totalStudents = data.byLevel.reduce((sum, level) => sum + level.count, 0);
+  const totalPriorityPages = Math.max(
+    1,
+    Math.ceil(data.priorityApplications.length / PRIORITY_DISPLAY_LIMIT)
+  );
+  const priorityStartIndex = (currentPriorityPage - 1) * PRIORITY_DISPLAY_LIMIT;
+  const visiblePriorityApplications = data.priorityApplications.slice(
+    priorityStartIndex,
+    priorityStartIndex + PRIORITY_DISPLAY_LIMIT
+  );
+  const visiblePriorityStart =
+    data.priorityApplications.length === 0 ? 0 : priorityStartIndex + 1;
+  const visiblePriorityEnd = Math.min(
+    currentPriorityPage * PRIORITY_DISPLAY_LIMIT,
+    data.priorityApplications.length
+  );
 
   return (
     <>
-      <PageSectionHeader
-        topBar={pageTopBar}
-        eyebrow="Dashboard Admin"
-        title="Vue d'ensemble des demandes d'inscription"
-        description="Première version branchée sur l'API réelle pour suivre le volume global, les statuts, la répartition des élèves et les dossiers prioritaires."
-        aside={pageHeaderAside}
-      />
-      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
-        <MetricCard
-          label="Demandes totales"
-          value={data.totalApplications}
-          description="Volume global des demandes présentes dans la base seedée."
-        />
-        {statusCards.map((card) => (
-          <MetricCard
-            key={card.status}
-            label={card.label}
-            value={data.byStatus[card.status]}
-            description={card.description}
-            valueClassName={card.valueClassName}
-          />
-        ))}
+      {pageHeader}
+
+      <section
+        className="ui-animate-in ui-surface-hover ui-surface-hover--soft overflow-hidden rounded-[32px] border border-white/80 bg-white/92 shadow-[0_24px_50px_-34px_rgba(15,23,42,0.3)]"
+        style={getEnterStyle(190)}
+      >
+        <div className="p-6 sm:p-8">
+          <div className="mt-6 flex flex-wrap gap-3">
+            <span
+              className="ui-animate-in inline-flex items-center rounded-full border border-primary/15 bg-primary/5 px-4 py-2 text-sm font-medium text-primaryDark"
+              style={getEnterStyle(240)}
+            >
+              {data.totalApplications} demandes en base
+            </span>
+            <span
+              className="ui-animate-in inline-flex items-center rounded-full border border-secondary/20 bg-secondary/10 px-4 py-2 text-sm font-medium text-secondaryDark"
+              style={getEnterStyle(300)}
+            >
+              {data.priorityApplications.length} prioritaires
+            </span>
+            <span
+              className="ui-animate-in inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-700"
+              style={getEnterStyle(360)}
+            >
+              {data.byLevel.length} niveaux suivis
+            </span>
+          </div>
+
+          <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+            <MetricCard
+              label="Demandes totales"
+              value={data.totalApplications}
+              description="Vue globale des dossiers disponibles dans l'application."
+              Icon={OverviewMetricIcon}
+              iconClassName="bg-primary text-white"
+              motionDelay={300}
+              surfaceClassName="bg-primary/5"
+            />
+            {statusCards.map((card, index) => (
+              <MetricCard
+                key={card.status}
+                label={card.label}
+                value={data.byStatus[card.status]}
+                description={card.description}
+                Icon={card.Icon}
+                iconClassName={card.iconClassName}
+                motionDelay={360 + index * 70}
+                surfaceClassName={card.surfaceClassName}
+                valueClassName={card.valueClassName}
+              />
+            ))}
+          </div>
+        </div>
       </section>
 
-      <section className="mt-6 grid gap-6 xl:grid-cols-[1.05fr_1.45fr]">
-        <article className="rounded-3xl border border-white/80 bg-white/90 p-6 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)]">
-          <div className="flex items-center justify-between gap-4">
-            <div>
+      <section className="mt-6 space-y-6">
+        <article
+          className="ui-animate-in ui-surface-hover ui-surface-hover--soft rounded-[30px] border border-white/80 bg-white/92 p-6 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] sm:p-8"
+          style={getEnterStyle(430)}
+        >
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+            <div className="min-w-0">
               <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primaryLight">
                 Répartition par niveau
               </p>
-              <h2 className="mt-2 text-2xl font-semibold text-slate-900">
+              <h2 className="mt-2 text-3xl font-semibold tracking-tight text-slate-900">
                 Élèves par classe demandée
               </h2>
+              <p className="mt-3 max-w-4xl text-[1.02rem] leading-8 text-slate-600">
+                Repérez d&apos;un coup d&apos;œil les niveaux les plus demandés
+                pour faciliter la préparation des places et l&apos;ordre de
+                traitement.
+              </p>
             </div>
-            <div className="rounded-full bg-secondary/15 px-4 py-2 text-sm font-medium text-secondaryDark">
-              {data.byLevel.reduce((sum, level) => sum + level.count, 0)} élèves
+
+            <div
+              className="ui-animate-in inline-flex w-fit shrink-0 flex-col rounded-[28px] border border-secondary/20 bg-secondary/10 px-7 py-5 text-center shadow-[0_14px_26px_-22px_rgba(212,162,76,0.28)] lg:ml-6"
+              style={getEnterStyle(500)}
+            >
+              <p className="text-[0.74rem] font-semibold uppercase tracking-[0.22em] text-secondaryDark">
+                Total
+              </p>
+              <p className="mt-3 text-4xl font-semibold tracking-tight text-slate-900">
+                {totalStudents}
+              </p>
+              <p className="mt-1 text-sm text-slate-500">élèves répartis</p>
             </div>
           </div>
 
-          <div className="mt-6 space-y-4">
+          <div className="mt-8 grid gap-5 md:grid-cols-2 xl:grid-cols-12">
             {data.byLevel.length === 0 ? (
               <p className="rounded-2xl border border-dashed border-border bg-background/70 px-4 py-6 text-sm text-slate-500">
                 Aucun niveau disponible.
               </p>
             ) : (
-              data.byLevel.map((level) => {
+              data.byLevel.map((level, index) => {
+                const share =
+                  totalStudents === 0
+                    ? 0
+                    : Math.round((level.count / totalStudents) * 100);
                 const width =
-                  maxLevelCount === 0 ? 0 : (level.count / maxLevelCount) * 100;
+                  maxLevelCount === 0 || level.count === 0
+                    ? 0
+                    : Math.max((level.count / maxLevelCount) * 100, 6);
+                const visual = getLevelVisualStyle(level.code, level.label, index);
+                const levelCardClassName = isWideLevelCard(level.code)
+                  ? "xl:col-span-6"
+                  : "xl:col-span-4";
 
                 return (
-                  <div key={level.code} className="space-y-2">
-                    <div className="flex items-center justify-between gap-4">
+                  <div
+                    key={level.code}
+                    className={`ui-animate-in ui-surface-hover ui-surface-hover--soft rounded-[28px] border p-5 shadow-[0_16px_28px_-26px_rgba(15,23,42,0.16)] ${levelCardClassName}`}
+                    style={{
+                      ...getEnterStyle(560 + index * 70),
+                      backgroundColor: visual.cardBackground,
+                      borderColor: visual.borderColor
+                    }}
+                  >
+                    <div className="flex items-start justify-between gap-4">
                       <div>
-                        <p className="font-semibold text-slate-900">{level.label}</p>
-                        <p className="text-sm text-slate-500">{level.code}</p>
+                        <p className="text-2xl font-semibold tracking-tight text-slate-900">
+                          {level.label}
+                        </p>
+                        <span
+                          className="ui-surface-hover__chip mt-3 inline-flex w-fit items-center rounded-full px-3.5 py-1.5 text-[0.68rem] font-semibold uppercase tracking-[0.22em]"
+                          style={{
+                            backgroundColor: visual.codeBackground,
+                            color: visual.codeTextColor
+                          }}
+                        >
+                          {level.code}
+                        </span>
                       </div>
-                      <p className="text-sm font-semibold text-slate-700">
-                        {level.count}
-                      </p>
+
+                      <div className="shrink-0 text-right">
+                        <p className="text-3xl font-semibold tracking-tight text-slate-900">
+                          {level.count}
+                        </p>
+                        <p className="mt-2 text-sm text-slate-500">
+                          {share}% des élèves
+                        </p>
+                      </div>
                     </div>
-                    <div className="h-3 overflow-hidden rounded-full bg-slate-100">
+
+                    <div
+                      className="mt-6 overflow-hidden rounded-full p-1"
+                      style={{ backgroundColor: visual.trackColor }}
+                    >
                       <div
-                        className="h-full rounded-full bg-primary"
-                        style={{ width: `${width}%` }}
+                        className="ui-surface-hover__bar h-3.5 rounded-full shadow-[0_10px_18px_-14px_rgba(15,23,42,0.55)]"
+                        style={{
+                          width: `${width}%`,
+                          backgroundColor: visual.barColor
+                        }}
                       />
                     </div>
                   </div>
@@ -326,7 +734,10 @@ const DashboardPage = () => {
           </div>
         </article>
 
-        <article className="rounded-3xl border border-white/80 bg-white/90 p-6 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)]">
+        <article
+          className="ui-animate-in ui-surface-hover ui-surface-hover--soft rounded-[30px] border border-white/80 bg-white/90 p-6 shadow-[0_18px_38px_-30px_rgba(15,23,42,0.24)]"
+          style={getEnterStyle(690)}
+        >
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div>
               <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primaryLight">
@@ -335,6 +746,11 @@ const DashboardPage = () => {
               <h2 className="mt-2 text-2xl font-semibold text-slate-900">
                 Dossiers à traiter en priorité
               </h2>
+              <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+                Conservez les dossiers sensibles en haut de pile avec une lecture
+                rapide de la famille, des enfants concernés, du niveau demandé et
+                du statut actuel.
+              </p>
             </div>
             <div className="rounded-full bg-primary/10 px-4 py-2 text-sm font-medium text-primaryDark">
               {data.priorityApplications.length} priorité
@@ -348,14 +764,15 @@ const DashboardPage = () => {
                 Aucune demande prioritaire pour le moment.
               </p>
             ) : (
-              data.priorityApplications.map((application) => (
+              visiblePriorityApplications.map((application, index) => (
                 <article
                   key={application.id}
-                  className="rounded-3xl border border-slate-200 bg-slate-50/80 p-5"
+                  className="ui-animate-in ui-surface-hover ui-surface-hover--soft rounded-[28px] border border-slate-200/90 bg-slate-50/80 p-5 shadow-[0_14px_28px_-24px_rgba(15,23,42,0.18)]"
+                  style={getEnterStyle(760 + index * 80)}
                 >
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div>
-                      <div className="flex flex-wrap items-center gap-2">
+                  <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2.5">
                         <h3 className="text-lg font-semibold text-slate-900">
                           Famille {getFamilyDisplayName(application)}
                         </h3>
@@ -366,36 +783,129 @@ const DashboardPage = () => {
                         {application.schoolYear.isActive ? " · année active" : ""}
                       </p>
                     </div>
-                    <StatusBadge status={application.status} />
+                    <div className="flex flex-wrap items-center gap-2">
+                      <StatusBadge status={application.status} />
+                      <Link
+                        to={`/applications/${application.id}`}
+                        className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary/30 hover:text-primary"
+                      >
+                        Voir la demande
+                      </Link>
+                    </div>
                   </div>
 
-                  <p className="mt-4 text-sm leading-6 text-slate-600">
-                    {getPriorityDescription(application)}
-                  </p>
+                  <div className="mt-5 grid gap-3 md:grid-cols-2">
+                    <div className="rounded-2xl border border-white bg-white/80 px-4 py-3">
+                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                        Enfants
+                      </p>
+                      <p className="mt-2 text-sm leading-6 text-slate-700">
+                        {getPriorityChildrenLabel(application)}
+                      </p>
+                    </div>
+                    <div className="rounded-2xl border border-white bg-white/80 px-4 py-3">
+                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                        Niveau
+                      </p>
+                      <p className="mt-2 text-sm leading-6 text-slate-700">
+                        {getPriorityLevelsLabel(application)}
+                      </p>
+                    </div>
+                    <div className="rounded-2xl border border-white bg-white/80 px-4 py-3">
+                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                        Contact
+                      </p>
+                      <p className="mt-2 text-sm leading-6 text-slate-700">
+                        {application.family.contactEmail ? (
+                          <a
+                            href={`mailto:${application.family.contactEmail}`}
+                            className="break-all text-primary hover:text-primaryDark"
+                          >
+                            {application.family.contactEmail}
+                          </a>
+                        ) : (
+                          "Non renseigné"
+                        )}
+                      </p>
+                    </div>
+                    <div className="rounded-2xl border border-white bg-white/80 px-4 py-3">
+                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                        Date
+                      </p>
+                      <p className="mt-2 text-sm leading-6 text-slate-700">
+                        {priorityDateFormatter.format(new Date(application.createdAt))}
+                      </p>
+                    </div>
+                  </div>
 
                   <div className="mt-4 flex flex-wrap gap-2">
-                    {application.students.map((student) => (
-                      <span
-                        key={`${application.id}-${student.firstName}-${student.lastName}-${student.level.code}`}
-                        className="rounded-full bg-white px-3 py-1.5 text-xs font-medium text-slate-700 ring-1 ring-slate-200"
-                      >
-                        {student.firstName} {student.lastName} · {student.level.code}
+                    {application.students.length === 0 ? (
+                      <span className="rounded-full bg-white px-3 py-1.5 text-xs font-medium text-slate-500 ring-1 ring-slate-200">
+                        Aucun élève rattaché
                       </span>
-                    ))}
-                  </div>
-
-                  <div className="mt-5 flex flex-wrap items-center justify-between gap-3 border-t border-slate-200 pt-4 text-sm text-slate-500">
-                    <span>
-                      Contact : {application.family.contactEmail ?? "non renseigné"}
-                    </span>
-                    <span>
-                      Créée le {createdAtFormatter.format(new Date(application.createdAt))}
-                    </span>
+                    ) : (
+                      application.students.map((student) => (
+                        <span
+                          key={`${application.id}-${student.firstName}-${student.lastName}-${student.level.code}`}
+                          className="ui-surface-hover__chip rounded-full bg-white px-3 py-1.5 text-xs font-medium text-slate-700 ring-1 ring-slate-200"
+                        >
+                          {student.firstName} {student.lastName} · {student.level.code}
+                        </span>
+                      ))
+                    )}
                   </div>
                 </article>
               ))
             )}
           </div>
+
+          {data.priorityApplications.length > 0 ? (
+            <div className="mt-6 flex flex-col gap-4 border-t border-slate-200 pt-5 sm:flex-row sm:items-center sm:justify-between">
+              <div className="text-sm text-slate-500">
+                Affichage de {visiblePriorityStart} à {visiblePriorityEnd} sur{" "}
+                {data.priorityApplications.length} demande
+                {data.priorityApplications.length > 1 ? "s" : ""}.
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() =>
+                    setCurrentPriorityPage((page) => Math.max(1, page - 1))
+                  }
+                  disabled={currentPriorityPage === 1}
+                  className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Précédent
+                </button>
+                <span className="min-w-[96px] text-center text-sm font-medium text-slate-600">
+                  Page {currentPriorityPage} / {totalPriorityPages}
+                </span>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setCurrentPriorityPage((page) =>
+                      Math.min(totalPriorityPages, page + 1)
+                    )
+                  }
+                  disabled={currentPriorityPage === totalPriorityPages}
+                  className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Suivant
+                </button>
+              </div>
+            </div>
+          ) : null}
+
+          {data.priorityApplications.length > 0 ? (
+            <div className="mt-4">
+              <Link
+                to="/applications"
+                className="inline-flex items-center rounded-full text-sm font-semibold text-primary transition hover:text-primaryDark"
+              >
+                Ouvrir toutes les demandes
+              </Link>
+            </div>
+          ) : null}
         </article>
       </section>
     </>


### PR DESCRIPTION
## Objectif

Améliorer le dashboard pour le rapprocher visuellement de la maquette cible, tout en harmonisant les badges de niveaux sur l’ensemble de l’application admin.

## Contenu

### Sidebar
- suppression des entrées :
  - `Validation`
  - `Administration`
- augmentation de l’espace entre `Import CSV` et `Déconnexion`

### Dashboard
- amélioration ciblée du `main` sans toucher au layout global ni au header
- simplification du haut de page :
  - suppression des actions inutiles
  - remplacement par une présentation métier :
    - `Administration ECE`
    - `Bienvenue dans l'espace d'administration ECE`
    - texte de présentation orienté usage admin
- remplacement du bloc `Source API` par l’affichage de l’année scolaire active
- cartouches visuels pour `Tableau de bord` et `Année active`
- alignements ajustés selon la maquette

### Cards statistiques
- hiérarchie visuelle améliorée
- alignement homogène
- correction de la taille du fond d’icône pour `Demandes totales`
- conservation des couleurs déjà validées

### Répartition par niveau
- refonte du bloc pour occuper toute la largeur du main
- palette par niveau cohérente avec la charte
- affichage horizontal en grille responsive
- repositionnement du total élèves en haut à droite
- `CM1` et `CM2` élargis pour occuper toute la dernière ligne sur grand écran

### Demandes prioritaires
- cartes restructurées sans perdre les tags / couleurs existants
- affichage limité à 3 demandes par page
- pagination frontend avec `Précédent / Suivant`

### Animations / micro-interactions
- ajout de classes réutilisables dans `index.css`
- apparition progressive des blocs au chargement
- hover moderne sur les surfaces pertinentes
- micro-interactions sur icônes, barres et tags
- prise en charge de `prefers-reduced-motion`

### Ajustements hover / ombres
- allègement des ombres globales
- retrait du contour doré sur les trois grands panneaux du dashboard
- conservation des accents dorés sur les cartes et surfaces où le hover est pertinent

### Harmonisation des badges de niveaux
- centralisation de la palette des niveaux dans `levelVisuals.ts`
- création d’un composant partagé `LevelBadge.tsx`
- utilisation des mêmes couleurs de niveaux sur :
  - dashboard
  - liste des demandes
  - détail d’une demande
- adaptation de la taille des badges selon le contexte (`xs`, `sm`, `md`)

## Fichiers concernés

- `apps/web/src/pages/DashboardPage.tsx`
- `apps/web/src/index.css`
- `apps/web/src/components/layout/AppLayout.tsx`
- `apps/web/src/components/ui/LevelBadge.tsx`
- `apps/web/src/lib/levelVisuals.ts`
- `apps/web/src/pages/ApplicationsPage.tsx`
- `apps/web/src/pages/ApplicationDetailPage.tsx`

## Vérifications

- [x] `npm exec -w apps/web -- tsc -b`
- [x] `npm run build -w apps/web`
- [x] `npm run dev:web`

## Notes

- aucune modification backend
- aucun changement du layout global hors simplification ciblée de la sidebar
- travail focalisé sur le contenu du dashboard et l’harmonisation visuelle des niveaux
- les effets hover restent présents uniquement sur les surfaces pertinentes