### PR TITLE
feat(ui): refine applications list layout and pagination

### DIFF
--- a/apps/web/src/pages/ApplicationsPage.tsx
+++ b/apps/web/src/pages/ApplicationsPage.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useDeferredValue, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type ReactNode
+} from "react";
 import { Link } from "react-router-dom";
 
 import PageSectionHeader from "../components/layout/PageSectionHeader";
@@ -26,6 +34,8 @@ type FilterState = {
 
 type SortOption = "createdAtDesc" | "createdAtAsc" | "priorityDesc";
 
+type PageSize = 6 | 8 | 10 | 12;
+
 type StatusOption = {
   value: "" | ApplicationStatus;
   label: string;
@@ -35,6 +45,26 @@ type ApplicationsSortOption = {
   value: SortOption;
   label: string;
 };
+
+type IconProps = {
+  className?: string;
+};
+
+type FilterFieldProps = {
+  label: string;
+  className?: string;
+  children: ReactNode;
+};
+
+type PaginationItem = number | "ellipsis-left" | "ellipsis-right";
+
+type PaginationControlsProps = {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+};
+
+const pageSizeOptions: PageSize[] = [6, 8, 10, 12];
 
 const statusOptions: StatusOption[] = [
   { value: "", label: "Tous les statuts" },
@@ -50,10 +80,30 @@ const sortOptions: ApplicationsSortOption[] = [
   { value: "priorityDesc", label: "Prioritaires d'abord" }
 ];
 
-const createdAtFormatter = new Intl.DateTimeFormat("fr-FR", {
-  dateStyle: "medium",
-  timeStyle: "short"
+const createdAtDateFormatter = new Intl.DateTimeFormat("fr-FR", {
+  day: "2-digit",
+  month: "short",
+  year: "numeric"
 });
+
+const createdAtTimeFormatter = new Intl.DateTimeFormat("fr-FR", {
+  hour: "2-digit",
+  minute: "2-digit"
+});
+
+const formatSchoolYearLabel = (label: string): string => {
+  return label.replace(/^(\d{4})-(\d{4})$/u, "$1 - $2");
+};
+
+const getEnterStyle = (delay: number): CSSProperties => {
+  return {
+    "--ui-enter-delay": `${delay}ms`
+  } as CSSProperties;
+};
+
+const getApplicationsCountLabel = (count: number): string => {
+  return `${count} demande${count > 1 ? "s" : ""}`;
+};
 
 const isAbortError = (error: unknown): boolean => {
   return error instanceof DOMException && error.name === "AbortError";
@@ -121,6 +171,177 @@ const getFamilyDisplayName = (application: ApplicationListItem): string => {
   return "Famille non renseignée";
 };
 
+const getPaginationItems = (
+  currentPage: number,
+  totalPages: number
+): PaginationItem[] => {
+  if (totalPages <= 5) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+
+  const items: PaginationItem[] = [1];
+  let startPage = Math.max(2, currentPage - 1);
+  let endPage = Math.min(totalPages - 1, currentPage + 1);
+
+  if (currentPage <= 2) {
+    endPage = 4;
+  }
+
+  if (currentPage >= totalPages - 1) {
+    startPage = totalPages - 3;
+  }
+
+  if (startPage > 2) {
+    items.push("ellipsis-left");
+  }
+
+  for (let page = startPage; page <= endPage; page += 1) {
+    items.push(page);
+  }
+
+  if (endPage < totalPages - 1) {
+    items.push("ellipsis-right");
+  }
+
+  items.push(totalPages);
+
+  return items;
+};
+
+const SearchIcon = ({ className = "h-4 w-4" }: IconProps) => {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <circle cx="7" cy="7" r="4.6" />
+      <path d="m10.3 10.3 3.2 3.2" />
+    </svg>
+  );
+};
+
+const ChevronLeftIcon = ({ className = "h-4 w-4" }: IconProps) => {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="m9.75 3.25-4.5 4.75 4.5 4.75" />
+    </svg>
+  );
+};
+
+const ChevronRightIcon = ({ className = "h-4 w-4" }: IconProps) => {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="m6.25 3.25 4.5 4.75-4.5 4.75" />
+    </svg>
+  );
+};
+
+const FilterField = ({ label, className, children }: FilterFieldProps) => {
+  return (
+    <label className={className}>
+      <span className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+        {label}
+      </span>
+      <div className="mt-2">{children}</div>
+    </label>
+  );
+};
+
+const PaginationControls = ({
+  currentPage,
+  totalPages,
+  onPageChange
+}: PaginationControlsProps) => {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  const paginationItems = getPaginationItems(currentPage, totalPages);
+  const baseButtonClassName =
+    "inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary/25 hover:text-primary disabled:cursor-not-allowed disabled:opacity-50";
+
+  return (
+    <div className="mt-6 flex justify-center border-t border-slate-200/80 pt-5">
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <button
+          type="button"
+          onClick={() => onPageChange(currentPage - 1)}
+          disabled={currentPage === 1}
+          className={baseButtonClassName}
+        >
+          <ChevronLeftIcon />
+          <span>Précédent</span>
+        </button>
+
+        <div className="hidden items-center gap-2 sm:flex">
+          {paginationItems.map((item) =>
+            typeof item === "number" ? (
+              <button
+                key={item}
+                type="button"
+                onClick={() => onPageChange(item)}
+                aria-current={item === currentPage ? "page" : undefined}
+                className={`inline-flex h-10 min-w-[2.5rem] items-center justify-center rounded-full border px-3 text-sm font-semibold transition ${
+                  item === currentPage
+                    ? "border-primary bg-primary text-white shadow-[0_14px_26px_-20px_rgba(31,77,58,0.55)]"
+                    : "border-slate-300 bg-white text-slate-700 hover:border-primary/25 hover:text-primary"
+                }`}
+              >
+                {item}
+              </button>
+            ) : (
+              <span
+                key={item}
+                className="inline-flex h-10 min-w-[2.5rem] items-center justify-center text-sm font-semibold text-slate-400"
+              >
+                …
+              </span>
+            )
+          )}
+        </div>
+
+        <span className="min-w-[96px] text-center text-sm font-medium text-slate-600 sm:hidden">
+          Page {currentPage} / {totalPages}
+        </span>
+
+        <button
+          type="button"
+          onClick={() => onPageChange(currentPage + 1)}
+          disabled={currentPage === totalPages}
+          className={baseButtonClassName}
+        >
+          <span>Suivant</span>
+          <ChevronRightIcon />
+        </button>
+      </div>
+    </div>
+  );
+};
+
 const ApplicationsPage = () => {
   const [filters, setFilters] = useState<FilterState>({
     status: "",
@@ -136,6 +357,8 @@ const ApplicationsPage = () => {
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [isSchoolYearsLoading, setIsSchoolYearsLoading] = useState(true);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState<PageSize>(8);
   const deferredSearch = useDeferredValue(filters.search);
   const applicationQueryParams = useMemo<ApplicationFilterParams>(() => {
     const params: ApplicationFilterParams = {};
@@ -162,12 +385,51 @@ const ApplicationsPage = () => {
   const displayedApplications = useMemo(() => {
     return sortApplications(applications, sort);
   }, [applications, sort]);
+  const selectedSchoolYear = useMemo(() => {
+    return schoolYears.find((schoolYear) => schoolYear.id === filters.schoolYearId) ?? null;
+  }, [filters.schoolYearId, schoolYears]);
+  const activeSchoolYear = useMemo(() => {
+    return schoolYears.find((schoolYear) => schoolYear.isActive) ?? null;
+  }, [schoolYears]);
+  const totalPages = useMemo(() => {
+    return Math.max(1, Math.ceil(displayedApplications.length / pageSize));
+  }, [displayedApplications.length, pageSize]);
+  const resolvedCurrentPage = Math.min(currentPage, totalPages);
+  const currentPageApplications = useMemo(() => {
+    const startIndex = (resolvedCurrentPage - 1) * pageSize;
+
+    return displayedApplications.slice(startIndex, startIndex + pageSize);
+  }, [displayedApplications, pageSize, resolvedCurrentPage]);
 
   const hasActiveFilters =
     filters.status !== "" ||
     filters.schoolYearId !== "" ||
     filters.isPriority !== "" ||
     filters.search.trim().length > 0;
+  const activeFilterCount = [
+    filters.status,
+    filters.schoolYearId,
+    filters.isPriority,
+    filters.search.trim()
+  ].filter((value) => value !== "").length;
+  const visibleStart = displayedApplications.length === 0
+    ? 0
+    : (resolvedCurrentPage - 1) * pageSize + 1;
+  const visibleEnd = Math.min(
+    resolvedCurrentPage * pageSize,
+    displayedApplications.length
+  );
+  const schoolYearSummaryLabel = isSchoolYearsLoading
+    ? "Chargement..."
+    : filters.schoolYearId
+      ? selectedSchoolYear
+        ? formatSchoolYearLabel(selectedSchoolYear.label)
+        : "Année sélectionnée"
+      : activeSchoolYear
+        ? formatSchoolYearLabel(activeSchoolYear.label)
+        : "Toutes les années";
+  const inputClassName =
+    "w-full rounded-2xl border border-slate-200 bg-white/95 px-4 py-2.5 text-sm text-slate-900 shadow-[0_12px_26px_-24px_rgba(15,23,42,0.28)] outline-none transition placeholder:text-slate-400 focus:border-primary focus:ring-2 focus:ring-primary/15";
 
   const resetFilters = (): void => {
     setFilters({
@@ -259,39 +521,57 @@ const ApplicationsPage = () => {
     };
   }, []);
 
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [filters.status, filters.schoolYearId, filters.isPriority, filters.search, pageSize, sort]);
+
+  useEffect(() => {
+    setCurrentPage((page) => Math.min(page, totalPages));
+  }, [totalPages]);
+
   const pageTopBar = (
-    <Breadcrumb
-      items={[
-        { label: "Accueil", href: "/" },
-        { label: "Liste des demandes" }
-      ]}
-    />
+    <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+      <div
+        className="ui-animate-in ui-animate-in--subtle w-fit rounded-2xl border border-primary/10 bg-white/80 px-4 py-3 text-sm text-primaryDark shadow-[0_10px_22px_-22px_rgba(15,23,42,0.18)]"
+        style={getEnterStyle(20)}
+      >
+        <Breadcrumb
+          items={[
+            { label: "Tableau de bord", href: "/" },
+            { label: "Liste des demandes" }
+          ]}
+        />
+      </div>
+
+      <div className="flex lg:justify-end">
+        <div
+          className="ui-animate-in ui-animate-in--subtle rounded-2xl border border-primary/10 bg-white/80 px-4 py-3 text-center text-sm text-primaryDark shadow-[0_10px_22px_-22px_rgba(15,23,42,0.18)]"
+          style={getEnterStyle(90)}
+        >
+          <p className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-primaryLight">
+            {filters.schoolYearId ? "Année filtrée" : "Année active"}
+          </p>
+          <p className="mt-1 font-semibold">{schoolYearSummaryLabel}</p>
+        </div>
+      </div>
+    </div>
   );
 
-  const pageHeaderAside = (
-    <div className="flex flex-col items-start gap-3 lg:items-end">
-      <Link
-        to="/imports/new"
-        className="inline-flex items-center rounded-full bg-secondary px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-secondaryDark"
-      >
-        Importer un CSV
-      </Link>
-      <div className="rounded-2xl border border-primary/10 bg-primary/5 px-4 py-3 text-sm text-primaryDark">
-        Source : <span className="font-semibold">GET /api/applications</span>
-      </div>
+  const pageHeader = (
+    <div className="ui-animate-in ui-animate-in--subtle" style={getEnterStyle(130)}>
+      <PageSectionHeader
+        topBar={pageTopBar}
+        eyebrow="Applications"
+        title="Liste des demandes d'inscription"
+        description="Passez d'une famille à l'autre plus vite grâce à une vue compacte, des filtres stables et un accès direct au détail de chaque dossier."
+      />
     </div>
   );
 
   if (isLoading && !hasLoadedOnce) {
     return (
       <>
-        <PageSectionHeader
-          topBar={pageTopBar}
-          eyebrow="Applications"
-          title="Liste des demandes d'inscription"
-          description="Première version branchée sur l'API réelle pour filtrer, parcourir et préqualifier les dossiers avant l'écran de détail."
-          aside={pageHeaderAside}
-        />
+        {pageHeader}
         <LoadingState variant="page" />
       </>
     );
@@ -300,13 +580,7 @@ const ApplicationsPage = () => {
   if (error && applications.length === 0) {
     return (
       <>
-        <PageSectionHeader
-          topBar={pageTopBar}
-          eyebrow="Applications"
-          title="Liste des demandes d'inscription"
-          description="Première version branchée sur l'API réelle pour filtrer, parcourir et préqualifier les dossiers avant l'écran de détail."
-          aside={pageHeaderAside}
-        />
+        {pageHeader}
         <ErrorState
           message={error}
           actionLabel="Réessayer"
@@ -318,43 +592,49 @@ const ApplicationsPage = () => {
 
   return (
     <>
-      <PageSectionHeader
-        topBar={pageTopBar}
-        eyebrow="Applications"
-        title="Liste des demandes d'inscription"
-        description="Première version branchée sur l'API réelle pour filtrer, parcourir et préqualifier les dossiers avant l'écran de détail."
-        aside={pageHeaderAside}
-      />
-      <section className="rounded-3xl border border-white/80 bg-white/90 p-6 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] backdrop-blur">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+      {pageHeader}
+
+      <section
+        className="ui-animate-in ui-surface-hover ui-surface-hover--soft ui-surface-hover--no-accent rounded-[32px] border border-white/80 bg-white/92 p-6 shadow-[0_24px_50px_-34px_rgba(15,23,42,0.3)] sm:p-7"
+        style={getEnterStyle(190)}
+      >
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
           <div>
             <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primaryLight">
               Filtres
             </p>
             <h2 className="mt-2 text-2xl font-semibold text-slate-900">
-              Rechercher et segmenter les demandes
+              Rechercher, segmenter, trier
             </h2>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+              Gardez la même logique métier, mais avec une barre de commande plus
+              dense pour scanner rapidement les dossiers utiles.
+            </p>
           </div>
-          <div className="flex flex-wrap items-center gap-3">
-            <div className="rounded-2xl border border-primary/10 bg-primary/5 px-4 py-3 text-sm text-primaryDark">
-              {isLoading
-                ? "Actualisation en cours..."
-                : `${displayedApplications.length} demande${displayedApplications.length > 1 ? "s" : ""}`}
-            </div>
+
+          <div className="flex flex-wrap items-center gap-2.5">
+            <span className="inline-flex items-center rounded-full border border-primary/15 bg-primary/5 px-4 py-2 text-sm font-medium text-primaryDark">
+              {isLoading ? "Actualisation..." : getApplicationsCountLabel(displayedApplications.length)}
+            </span>
+            {activeFilterCount > 0 ? (
+              <span className="inline-flex items-center rounded-full border border-secondary/20 bg-secondary/10 px-4 py-2 text-sm font-medium text-secondaryDark">
+                {activeFilterCount} filtre{activeFilterCount > 1 ? "s" : ""} actif
+                {activeFilterCount > 1 ? "s" : ""}
+              </span>
+            ) : null}
             <button
               type="button"
               onClick={resetFilters}
               disabled={!hasActiveFilters && sort === "createdAtDesc"}
-              className="inline-flex items-center rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary/25 hover:text-primary disabled:cursor-not-allowed disabled:opacity-50"
             >
               Réinitialiser
             </button>
           </div>
         </div>
 
-        <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-[220px_260px_220px_220px_minmax(0,1fr)]">
-          <label className="block">
-            <span className="text-sm font-medium text-slate-700">Statut</span>
+        <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-[190px_220px_190px_220px_minmax(0,1fr)]">
+          <FilterField label="Statut" className="block">
             <select
               value={filters.status}
               onChange={(event) =>
@@ -363,7 +643,7 @@ const ApplicationsPage = () => {
                   status: event.target.value as FilterState["status"]
                 }))
               }
-              className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
+              className={inputClassName}
             >
               {statusOptions.map((option) => (
                 <option key={option.value || "all"} value={option.value}>
@@ -371,10 +651,9 @@ const ApplicationsPage = () => {
                 </option>
               ))}
             </select>
-          </label>
+          </FilterField>
 
-          <label className="block">
-            <span className="text-sm font-medium text-slate-700">Année scolaire</span>
+          <FilterField label="Année scolaire" className="block">
             <select
               value={filters.schoolYearId}
               onChange={(event) =>
@@ -384,7 +663,7 @@ const ApplicationsPage = () => {
                 }))
               }
               disabled={isSchoolYearsLoading}
-              className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15 disabled:cursor-wait disabled:bg-slate-50"
+              className={`${inputClassName} disabled:cursor-wait disabled:bg-slate-50`}
             >
               <option value="">
                 {isSchoolYearsLoading
@@ -393,15 +672,14 @@ const ApplicationsPage = () => {
               </option>
               {schoolYears.map((schoolYear) => (
                 <option key={schoolYear.id} value={schoolYear.id}>
-                  {schoolYear.label}
+                  {formatSchoolYearLabel(schoolYear.label)}
                   {schoolYear.isActive ? " · active" : ""}
                 </option>
               ))}
             </select>
-          </label>
+          </FilterField>
 
-          <label className="block">
-            <span className="text-sm font-medium text-slate-700">Priorité</span>
+          <FilterField label="Priorité" className="block">
             <select
               value={filters.isPriority}
               onChange={(event) =>
@@ -410,19 +688,18 @@ const ApplicationsPage = () => {
                   isPriority: event.target.value as FilterState["isPriority"]
                 }))
               }
-              className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
+              className={inputClassName}
             >
               <option value="">Toutes les demandes</option>
               <option value="true">Prioritaires uniquement</option>
             </select>
-          </label>
+          </FilterField>
 
-          <label className="block">
-            <span className="text-sm font-medium text-slate-700">Tri</span>
+          <FilterField label="Tri" className="block">
             <select
               value={sort}
               onChange={(event) => setSort(event.target.value as SortOption)}
-              className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
+              className={inputClassName}
             >
               {sortOptions.map((option) => (
                 <option key={option.value} value={option.value}>
@@ -430,27 +707,31 @@ const ApplicationsPage = () => {
                 </option>
               ))}
             </select>
-          </label>
+          </FilterField>
 
-          <label className="block">
-            <span className="text-sm font-medium text-slate-700">Recherche</span>
-            <input
-              type="search"
-              value={filters.search}
-              onChange={(event) =>
-                setFilters((currentFilters) => ({
-                  ...currentFilters,
-                  search: event.target.value
-                }))
-              }
-              placeholder="Nom de famille, élève ou email..."
-              className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm outline-none transition placeholder:text-slate-400 focus:border-primary focus:ring-2 focus:ring-primary/15"
-            />
-          </label>
+          <FilterField label="Recherche" className="block">
+            <div className="relative">
+              <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4 text-slate-400">
+                <SearchIcon />
+              </span>
+              <input
+                type="search"
+                value={filters.search}
+                onChange={(event) =>
+                  setFilters((currentFilters) => ({
+                    ...currentFilters,
+                    search: event.target.value
+                  }))
+                }
+                placeholder="Famille, élève ou email..."
+                className={`${inputClassName} pl-11`}
+              />
+            </div>
+          </FilterField>
         </div>
 
         {schoolYearsError ? (
-          <p className="mt-4 rounded-2xl border border-warning/20 bg-warning/10 px-4 py-3 text-sm text-slate-700">
+          <p className="mt-4 rounded-[24px] border border-warning/20 bg-warning/10 px-4 py-3 text-sm text-slate-700">
             Impossible de charger la liste des années scolaires. Le filtre par année
             reste indisponible tant que l&apos;API ne répond pas.
           </p>
@@ -481,105 +762,186 @@ const ApplicationsPage = () => {
           />
         ) : null}
 
-        {displayedApplications.map((application) => (
-          <article
-            key={application.id}
-            className="rounded-3xl border border-white/80 bg-white/90 p-6 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] backdrop-blur"
+        {displayedApplications.length > 0 ? (
+          <section
+            className="ui-animate-in ui-surface-hover ui-surface-hover--soft ui-surface-hover--no-accent overflow-hidden rounded-[32px] border border-white/80 bg-white/92 shadow-[0_24px_48px_-34px_rgba(15,23,42,0.3)]"
+            style={getEnterStyle(250)}
           >
-            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-              <div>
-                <div className="flex flex-wrap items-center gap-2">
-                  <h2 className="text-2xl font-semibold text-slate-900">
-                    Famille {getFamilyDisplayName(application)}
+            <div className="border-b border-slate-200/80 px-6 py-5 sm:px-7">
+              <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+                <div>
+                  <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primaryLight">
+                    Demandes
+                  </p>
+                  <h2 className="mt-2 text-2xl font-semibold text-slate-900">
+                    Vue synthétique par famille
                   </h2>
-                  <PriorityBadge isPriority={application.isPriority} />
-                  <StatusBadge status={application.status} />
+                  <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+                    Chaque ligne garde les repères utiles du dossier: famille,
+                    année, élèves, niveaux, statut, priorité et accès immédiat au
+                    détail.
+                  </p>
                 </div>
 
-                <p className="mt-2 text-sm text-slate-500">
-                  Contact : {application.family.contactEmail ?? "non renseigné"}
-                </p>
-              </div>
-
-              <Link
-                to={`/applications/${application.id}`}
-                className="inline-flex items-center justify-center rounded-full border border-primary/20 bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-primaryDark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-              >
-                Voir le détail
-              </Link>
-            </div>
-
-            <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-              <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4">
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                  Année scolaire
-                </p>
-                <p className="mt-2 text-sm font-semibold text-slate-900">
-                  {application.schoolYear.label}
-                </p>
-                <p className="mt-1 text-sm text-slate-500">
-                  {application.schoolYear.isActive ? "Année active" : "Historique"}
-                </p>
-              </div>
-
-              <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4">
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                  Création
-                </p>
-                <p className="mt-2 text-sm font-semibold text-slate-900">
-                  {createdAtFormatter.format(new Date(application.createdAt))}
-                </p>
-                <p className="mt-1 text-sm text-slate-500">
-                  {application.students.length} élève
-                  {application.students.length > 1 ? "s" : ""} rattaché
-                  {application.students.length > 1 ? "s" : ""}
-                </p>
-              </div>
-
-              <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4">
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                  Recherche rapide
-                </p>
-                <p className="mt-2 text-sm font-semibold text-slate-900">
-                  {application.students.length > 0
-                    ? application.students
-                        .map((student) => `${student.firstName} ${student.lastName}`)
-                        .join(" · ")
-                    : "Aucun élève"}
-                </p>
-              </div>
-            </div>
-
-            <div className="mt-5">
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                Élèves
-              </p>
-              <div className="mt-3 flex flex-wrap gap-2">
-                {application.students.length === 0 ? (
-                  <span className="rounded-full bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-600">
-                    Aucun élève rattaché
+                <div className="flex flex-nowrap items-center gap-2">
+                  <span className="inline-flex shrink-0 items-center rounded-full border border-primary/15 bg-primary/5 px-3.5 py-2 text-sm font-medium text-primaryDark">
+                    {visibleStart}-{visibleEnd} sur {displayedApplications.length}
                   </span>
-                ) : (
-                  application.students.map((student) => (
-                    <span
-                      key={student.id}
-                      className="inline-flex items-center gap-2 rounded-full bg-white px-2.5 py-1.5 text-xs font-medium text-slate-700 ring-1 ring-slate-200"
+                  <label className="inline-flex min-w-0 shrink-0 items-center gap-2 rounded-full border border-slate-200 bg-slate-50 py-1.5 pl-3.5 pr-1.5 text-sm font-medium text-slate-700">
+                    <span className="whitespace-nowrap">Demandes par page</span>
+                    <select
+                      value={pageSize}
+                      onChange={(event) =>
+                        setPageSize(Number(event.target.value) as PageSize)
+                      }
+                      className="w-[4.25rem] rounded-full border border-slate-200 bg-white px-2.5 py-1 text-sm font-semibold text-slate-900 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
                     >
-                      <span>
-                        {student.firstName} {student.lastName}
-                      </span>
-                      <LevelBadge
-                        code={student.level.code}
-                        label={student.level.label}
-                        size="xs"
-                      />
-                    </span>
-                  ))
+                      {pageSizeOptions.map((option) => (
+                        <option key={option} value={option}>
+                          {option}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+              </div>
+            </div>
+
+            <div className="px-4 py-4 sm:px-6">
+              <div className="hidden xl:grid xl:grid-cols-[minmax(0,1.5fr)_170px_minmax(0,1.7fr)_180px_130px_108px] xl:items-center xl:gap-4 xl:px-4 xl:pb-3">
+                {["Famille", "Année", "Élèves / niveaux", "Statut", "Date", "Accès"].map(
+                  (label) => (
+                    <p
+                      key={label}
+                      className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500"
+                    >
+                      {label}
+                    </p>
+                  )
                 )}
               </div>
+
+              <div className="space-y-3">
+                {currentPageApplications.map((application, index) => {
+                  const createdAtDate = new Date(application.createdAt);
+                  const rowSurfaceClassName = application.isPriority
+                    ? "border-secondary/20 bg-secondary/5"
+                    : "border-slate-200/90 bg-slate-50/80";
+
+                  return (
+                    <article
+                      key={application.id}
+                      className={`group ui-animate-in ui-surface-hover ui-surface-hover--soft rounded-[28px] border p-4 shadow-[0_14px_30px_-24px_rgba(15,23,42,0.16)] sm:p-5 ${rowSurfaceClassName}`}
+                      style={getEnterStyle(310 + index * 55)}
+                    >
+                      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.5fr)_170px_minmax(0,1.7fr)_180px_130px_108px] xl:items-center">
+                        <div className="min-w-0">
+                          <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500 xl:hidden">
+                            Famille
+                          </p>
+                          <h3 className="mt-1 text-lg font-semibold text-slate-900 xl:mt-0">
+                            Famille {getFamilyDisplayName(application)}
+                          </h3>
+                          <p className="mt-1 break-all text-sm text-slate-500">
+                            {application.family.contactEmail ?? "Contact non renseigné"}
+                          </p>
+                        </div>
+
+                        <div>
+                          <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500 xl:hidden">
+                            Année scolaire
+                          </p>
+                          <p className="mt-1 text-sm font-semibold text-slate-900 xl:mt-0">
+                            {formatSchoolYearLabel(application.schoolYear.label)}
+                          </p>
+                          <p className="mt-1 text-sm text-slate-500">
+                            {application.schoolYear.isActive ? "Année active" : "Historique"}
+                          </p>
+                        </div>
+
+                        <div className="min-w-0">
+                          <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500 xl:hidden">
+                            Élèves / niveaux
+                          </p>
+                          {application.students.length === 0 ? (
+                            <span className="mt-1 inline-flex rounded-full bg-white px-3 py-1.5 text-xs font-medium text-slate-500 ring-1 ring-slate-200">
+                              Aucun élève rattaché
+                            </span>
+                          ) : (
+                            <div className="mt-1 flex flex-wrap gap-2 xl:mt-0">
+                              {application.students.map((student) => (
+                                <span
+                                  key={student.id}
+                                  className="ui-surface-hover__chip inline-flex items-center gap-2 rounded-full bg-white px-2.5 py-1.5 text-xs font-medium text-slate-700 ring-1 ring-slate-200"
+                                >
+                                  <span>
+                                    {student.firstName} {student.lastName}
+                                  </span>
+                                  <LevelBadge
+                                    code={student.level.code}
+                                    label={student.level.label}
+                                    size="xs"
+                                  />
+                                </span>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+
+                        <div>
+                          <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500 xl:hidden">
+                            Statut
+                          </p>
+                          <div className="mt-1 flex flex-wrap items-center gap-2 xl:mt-0 xl:flex-col xl:items-start">
+                            <StatusBadge status={application.status} />
+                            {application.isPriority ? (
+                              <PriorityBadge isPriority={application.isPriority} />
+                            ) : (
+                              <p className="text-xs font-medium text-slate-500">
+                                Traitement standard
+                              </p>
+                            )}
+                          </div>
+                        </div>
+
+                        <div>
+                          <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500 xl:hidden">
+                            Date
+                          </p>
+                          <p className="mt-1 text-sm font-semibold text-slate-900 xl:mt-0">
+                            {createdAtDateFormatter.format(createdAtDate)}
+                          </p>
+                          <p className="mt-1 text-sm text-slate-500">
+                            {createdAtTimeFormatter.format(createdAtDate)}
+                          </p>
+                        </div>
+
+                        <div className="xl:justify-self-end">
+                          <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500 xl:hidden">
+                            Accès
+                          </p>
+                          <Link
+                            to={`/applications/${application.id}`}
+                            className="mt-1 inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition group-hover:border-primary/25 group-hover:text-primary hover:border-primary/25 hover:text-primary xl:mt-0"
+                          >
+                            <span>Voir</span>
+                            <ChevronRightIcon />
+                          </Link>
+                        </div>
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+
+              <PaginationControls
+                currentPage={resolvedCurrentPage}
+                totalPages={totalPages}
+                onPageChange={(page) => setCurrentPage(Math.min(totalPages, Math.max(1, page)))}
+              />
             </div>
-          </article>
-        ))}
+          </section>
+        ) : null}
       </section>
     </>
   );


### PR DESCRIPTION
## Objectif

Améliorer la page de liste des demandes pour la rendre plus compacte, plus lisible et plus proche d’une vraie interface métier, tout en conservant le style visuel déjà posé sur le dashboard.

## Contenu

### Refonte visuelle de la page
- refonte de `ApplicationsPage` sans toucher au backend ni au layout global
- header retravaillé dans la continuité du dashboard
- barre de filtres conservée mais rendue plus dense et plus lisible
- liste transformée en vue hybride carte/tableau plus compacte
- meilleure hiérarchie de lecture :
  - famille
  - année
  - niveaux
  - statut
  - priorité
  - date
  - accès au détail

### Filtres
- conservation des filtres existants :
  - statut
  - année scolaire
  - priorité
  - recherche
  - tri
- meilleur alignement et meilleure densité visuelle

### Fil d’Ariane
- remplacement de `Accueil / Liste des demandes` par :
  - `Tableau de bord / Liste des demandes`

### Header
- suppression du bouton `Importer un CSV` pour éviter le doublon avec la sidebar

### Pagination
- ajout / amélioration de la pagination frontend appliquée après filtrage et tri
- remise automatique à la page 1 quand un filtre change
- sélection du nombre d’éléments par page :
  - 6
  - 8
  - 10
  - 12
- suppression de la phrase :
  - `Affichage de 1 à 8 sur ...`
- recentrage des boutons de pagination sous la liste
- compactage du bloc compteur + sélecteur en haut à droite pour éviter les chevauchements à 10 ou 12 éléments par page

### UX / lisibilité
- hover subtil sur les lignes / cartes
- alignement amélioré
- cohérence avec les badges de statut, priorité et niveaux déjà harmonisés

## Fichiers concernés

- `apps/web/src/pages/ApplicationsPage.tsx`

## Vérifications

- [x] `npm exec -w apps/web -- tsc -b`
- [x] `npm run build -w apps/web`
- [x] `npm run dev:web`

## Contrôles manuels à effectuer

- [ ] filtres + tri combinés
- [ ] changement du nombre d’éléments par page
- [ ] pagination (précédent / suivant / pages)
- [ ] retour en page 1 après modification d’un filtre
- [ ] ouverture du détail d’une demande

## Notes

- aucune modification backend
- aucune modification du layout global
- objectif atteint : page plus compacte, plus lisible et cohérente avec le dashboard