### PR TITLE
feat(ui): refine application detail page and add dedicated email view

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,7 @@ import AppLayout from "./components/layout/AppLayout";
 import ToastViewport from "./components/ui/ToastViewport";
 import { ToastProvider } from "./context/ToastContext";
 import ApplicationDetailPage from "./pages/ApplicationDetailPage";
+import ApplicationEmailPage from "./pages/ApplicationEmailPage";
 import ApplicationsPage from "./pages/ApplicationsPage";
 import DashboardPage from "./pages/DashboardPage";
 import ImportCsvPage from "./pages/ImportCsvPage";
@@ -53,6 +54,7 @@ function App() {
           <Route element={<AppLayout />}>
             <Route index element={<DashboardPage />} />
             <Route path="applications" element={<ApplicationsPage />} />
+            <Route path="applications/:id/email" element={<ApplicationEmailPage />} />
             <Route path="applications/:id" element={<ApplicationDetailPage />} />
             <Route path="imports">
               <Route index element={<Navigate to="new" replace />} />

--- a/apps/web/src/components/ui/PersonAvatar.tsx
+++ b/apps/web/src/components/ui/PersonAvatar.tsx
@@ -1,0 +1,187 @@
+import type { JSX } from "react";
+
+export type PersonAvatarVariant = "boy" | "girl" | "neutral" | "man" | "woman";
+
+type PersonAvatarSize = "sm" | "md" | "lg";
+type FamilyAvatarSize = "md" | "lg";
+
+type PersonAvatarProps = {
+  label: string;
+  size?: PersonAvatarSize;
+  variant?: PersonAvatarVariant;
+};
+
+type FamilyAvatarProps = {
+  label: string;
+  size?: FamilyAvatarSize;
+};
+
+type AvatarPalette = {
+  backgroundClassName: string;
+  hair: string;
+  shirt: string;
+  skin: string;
+};
+
+const sizeClassNames: Record<PersonAvatarSize, string> = {
+  sm: "h-11 w-11",
+  md: "h-14 w-14",
+  lg: "h-16 w-16"
+};
+
+const familyAvatarSizeClassNames: Record<FamilyAvatarSize, string> = {
+  md: "h-16 w-16",
+  lg: "h-20 w-20"
+};
+
+const avatarPalettes: Record<PersonAvatarVariant, AvatarPalette> = {
+  boy: {
+    backgroundClassName: "bg-info/10 ring-info/20",
+    hair: "#334155",
+    shirt: "#1F4D3A",
+    skin: "#F1C9A5"
+  },
+  girl: {
+    backgroundClassName: "bg-secondary/15 ring-secondary/25",
+    hair: "#4A332E",
+    shirt: "#B8842F",
+    skin: "#F1C9A5"
+  },
+  neutral: {
+    backgroundClassName: "bg-slate-100 ring-slate-200",
+    hair: "#64748B",
+    shirt: "#475569",
+    skin: "#E9C8A6"
+  },
+  man: {
+    backgroundClassName: "bg-primary/10 ring-primary/15",
+    hair: "#334155",
+    shirt: "#1F4D3A",
+    skin: "#E8BE98"
+  },
+  woman: {
+    backgroundClassName: "bg-secondary/15 ring-secondary/25",
+    hair: "#4A332E",
+    shirt: "#D4A24C",
+    skin: "#E8BE98"
+  }
+};
+
+const isLongHairVariant = (variant: PersonAvatarVariant): boolean => {
+  return variant === "girl" || variant === "woman";
+};
+
+const PersonAvatar = ({
+  label,
+  size = "md",
+  variant = "neutral"
+}: PersonAvatarProps): JSX.Element => {
+  const palette = avatarPalettes[variant];
+  const hasLongHair = isLongHairVariant(variant);
+
+  return (
+    <span
+      role="img"
+      aria-label={label}
+      className={`inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full ring-1 ${sizeClassNames[size]} ${palette.backgroundClassName}`}
+    >
+      <svg viewBox="0 0 64 64" className="h-full w-full" aria-hidden="true">
+        <circle cx="32" cy="32" r="31" fill="currentColor" className="text-white/55" />
+        {hasLongHair ? (
+          <path
+            d="M17.5 33.2c0-13.5 5.7-22.2 14.6-22.2s14.4 8.7 14.4 22.2v13.9h-29V33.2Z"
+            fill={palette.hair}
+          />
+        ) : (
+          <path
+            d="M18.5 28.8c.9-11 7.3-17.7 17.8-16.2 6.9 1 10.9 6.4 10.2 15.5-4.6-3.1-8.4-4.3-14.4-4.3-5.6 0-9.7 1.4-13.6 5Z"
+            fill={palette.hair}
+          />
+        )}
+        <path
+          d="M13.4 57.5c2.6-11.3 9.6-17.1 18.6-17.1s16 5.8 18.6 17.1H13.4Z"
+          fill={palette.shirt}
+        />
+        <circle cx="32" cy="29.5" r="12.6" fill={palette.skin} />
+        {hasLongHair ? (
+          <>
+            <path
+              d="M20.5 30.3c2.1-8 7.4-12.5 14.4-12.5 4.4 0 8 1.9 10.6 5.3-.8-7.1-5.7-12.1-13.4-12.1-8.9 0-14.6 8.7-14.6 22.2v2.6c.8-1.8 1.8-3.6 3-5.5Z"
+              fill={palette.hair}
+            />
+            <path d="M43.8 27.1c-5.7-.4-10.3-2.5-13.9-6.3-2.3 3.8-5.3 6-9 6.8 1.5-6.2 5.9-10.6 12-10.6 5.2 0 9.1 3.1 10.9 10.1Z" fill={palette.hair} />
+          </>
+        ) : (
+          <path
+            d="M20.4 26.8c3.9-5.4 8.5-7.7 14-7.3 4.4.3 8 2.4 10.7 6.5-4.2-2-8.2-3-12.2-3-5.4 0-9.6 1.2-12.5 3.8Z"
+            fill={palette.hair}
+          />
+        )}
+        <circle cx="27.5" cy="31.3" r="1.45" fill="#172033" />
+        <circle cx="36.5" cy="31.3" r="1.45" fill="#172033" />
+        <path
+          d="M27.8 36.9c2.5 2 5.9 2 8.4 0"
+          fill="none"
+          stroke="#172033"
+          strokeLinecap="round"
+          strokeWidth="1.7"
+        />
+      </svg>
+    </span>
+  );
+};
+
+export const FamilyAvatar = ({
+  label,
+  size = "lg"
+}: FamilyAvatarProps): JSX.Element => {
+  return (
+    <span
+      role="img"
+      aria-label={label}
+      className={`inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary/10 ring-1 ring-primary/15 ${familyAvatarSizeClassNames[size]}`}
+    >
+      <svg viewBox="0 0 80 80" className="h-full w-full" aria-hidden="true">
+        <circle cx="40" cy="40" r="39" fill="currentColor" className="text-white/60" />
+        <circle cx="25.5" cy="37.5" r="10.5" fill="#F1C9A5" />
+        <path
+          d="M15.4 39.2c1.3-9.4 6.6-14.3 14.1-12.9 5 .9 7.5 4.7 7.1 11.3-3.8-2.3-7-3.1-11.1-3.1-4.1 0-7.4 1.2-10.1 4.7Z"
+          fill="#334155"
+        />
+        <path
+          d="M8.9 73.4c2.2-12.7 8.5-19.1 16.6-19.1s14.4 6.4 16.6 19.1H8.9Z"
+          fill="#2F6B52"
+        />
+        <circle cx="54.5" cy="37.5" r="10.5" fill="#E8BE98" />
+        <path
+          d="M43.8 39.2c1.5-9 6.9-14.2 14.4-12.8 4.9 1 7.5 5.1 7 11.2-3.7-2.3-6.7-3.2-10.7-3.2-4.2 0-7.8 1.2-10.7 4.8Z"
+          fill="#4A332E"
+        />
+        <path
+          d="M37.9 73.4c2.2-12.7 8.5-19.1 16.6-19.1s14.4 6.4 16.6 19.1H37.9Z"
+          fill="#D4A24C"
+        />
+        <circle cx="40" cy="32.5" r="13.5" fill="#F1C9A5" />
+        <path
+          d="M25.5 31.9c2.3-10.2 8.5-16.1 17.7-14.6 6.3 1 9.9 5.8 9.4 14.2-4.5-2.8-8.6-4-13-4-5.6 0-10 1.4-14.1 4.4Z"
+          fill="#334155"
+        />
+        <path
+          d="M18.2 73.4c2.7-15.2 10.9-22.9 21.8-22.9s19.1 7.7 21.8 22.9H18.2Z"
+          fill="#1F4D3A"
+        />
+        <circle cx="35.2" cy="34.6" r="1.5" fill="#172033" />
+        <circle cx="44.8" cy="34.6" r="1.5" fill="#172033" />
+        <path
+          d="M35.9 40.6c2.5 1.9 5.7 1.9 8.2 0"
+          fill="none"
+          stroke="#172033"
+          strokeLinecap="round"
+          strokeWidth="1.7"
+        />
+      </svg>
+    </span>
+  );
+};
+
+export default PersonAvatar;

--- a/apps/web/src/lib/applicationEmail.ts
+++ b/apps/web/src/lib/applicationEmail.ts
@@ -1,0 +1,94 @@
+import type {
+  ApplicationEmailSendStatus,
+  ApplicationEmailType
+} from "../types/application";
+
+export const applicationEmailTypeLabels: Record<ApplicationEmailType, string> = {
+  ACCEPTANCE: "Acceptation",
+  REFUSAL: "Refus",
+  CUSTOM: "Personnalisé"
+};
+
+export const applicationEmailTypeStyles: Record<ApplicationEmailType, string> = {
+  ACCEPTANCE: "bg-success/10 text-success ring-success/20",
+  REFUSAL: "bg-danger/10 text-danger ring-danger/20",
+  CUSTOM: "bg-slate-100 text-slate-700 ring-slate-200"
+};
+
+export const applicationEmailSendStatusLabels: Record<
+  ApplicationEmailSendStatus,
+  string
+> = {
+  PENDING: "En attente",
+  SENT: "Envoyé",
+  FAILED: "Échec"
+};
+
+export const applicationEmailSendStatusStyles: Record<
+  ApplicationEmailSendStatus,
+  string
+> = {
+  PENDING: "bg-warning/10 text-warning ring-warning/20",
+  SENT: "bg-success/10 text-success ring-success/20",
+  FAILED: "bg-danger/10 text-danger ring-danger/20"
+};
+
+export const applicationEmailTypeOptions: Array<{
+  value: ApplicationEmailType;
+  label: string;
+}> = [
+  { value: "ACCEPTANCE", label: "Acceptation" },
+  { value: "REFUSAL", label: "Refus" },
+  { value: "CUSTOM", label: "Personnalisé" }
+];
+
+export const applicationEmailTemplates: Record<
+  Exclude<ApplicationEmailType, "CUSTOM">,
+  {
+    subject: string;
+    body: string;
+  }
+> = {
+  ACCEPTANCE: {
+    subject: "ECE - décision d'admission",
+    body: "Votre demande d'inscription a été acceptée."
+  },
+  REFUSAL: {
+    subject: "ECE - décision d'inscription",
+    body: "Nous regrettons de vous informer que votre demande n'a pas été retenue."
+  }
+};
+
+export const getApplicationEmailTemplate = (
+  emailType: ApplicationEmailType
+): {
+  subject: string;
+  body: string;
+} | null => {
+  if (emailType === "CUSTOM") {
+    return null;
+  }
+
+  return applicationEmailTemplates[emailType];
+};
+
+export const getApplicationEmailActionErrorMessage = (error: unknown): string => {
+  if (!(error instanceof Error)) {
+    return "Impossible d'envoyer l'email.";
+  }
+
+  switch (error.message) {
+    case "Invalid email type":
+      return "Le type d'email sélectionné est invalide.";
+    case "Invalid email payload":
+      return "Le sujet et le message sont obligatoires.";
+    case "Missing recipient email":
+      return "Aucune adresse email de contact n'est renseignée pour cette demande.";
+    case "Application not found":
+      return "Cette demande n'existe pas ou n'est plus accessible.";
+    case "Internal server error":
+      return "Une erreur serveur est survenue pendant l'envoi de l'email.";
+    default:
+      return error.message;
+  }
+};

--- a/apps/web/src/pages/ApplicationDetailPage.tsx
+++ b/apps/web/src/pages/ApplicationDetailPage.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type CSSProperties,
+  type ReactNode
+} from "react";
 import { Link, useParams } from "react-router-dom";
 
 import PageSectionHeader from "../components/layout/PageSectionHeader";
@@ -6,50 +12,63 @@ import Breadcrumb from "../components/ui/Breadcrumb";
 import ErrorState from "../components/ui/ErrorState";
 import LevelBadge from "../components/ui/LevelBadge";
 import LoadingState from "../components/ui/LoadingState";
+import PersonAvatar, {
+  FamilyAvatar,
+  type PersonAvatarVariant
+} from "../components/ui/PersonAvatar";
 import PriorityBadge from "../components/ui/PriorityBadge";
 import StatusBadge from "../components/ui/StatusBadge";
 import { useToast } from "../context/ToastContext";
 import {
   getApplicationById,
   getApplicationEmailLogs,
-  sendApplicationEmail,
   updateApplicationDecision,
   updateApplicationPriority,
   updateApplicationStatus
 } from "../lib/api";
+import {
+  applicationEmailSendStatusLabels,
+  applicationEmailSendStatusStyles,
+  applicationEmailTypeLabels,
+  applicationEmailTypeStyles
+} from "../lib/applicationEmail";
 import type {
   ApplicationDecisionStatus,
   ApplicationDetail,
+  ApplicationDetailStudent,
   ApplicationEmailLog,
-  ApplicationEmailSendStatus,
-  ApplicationEmailSendPayload,
-  ApplicationEmailType,
   ApplicationGender,
   ApplicationStatus
 } from "../types/application";
 
-const emailTypeLabels: Record<ApplicationEmailType, string> = {
-  ACCEPTANCE: "Acceptation",
-  REFUSAL: "Refus",
-  CUSTOM: "Personnalisé"
+type IconProps = {
+  className?: string;
 };
 
-const emailTypeStyles: Record<ApplicationEmailType, string> = {
-  ACCEPTANCE: "bg-success/10 text-success ring-success/20",
-  REFUSAL: "bg-danger/10 text-danger ring-danger/20",
-  CUSTOM: "bg-slate-100 text-slate-700 ring-slate-200"
+type DetailFieldProps = {
+  children: ReactNode;
+  className?: string;
+  label: string;
 };
 
-const emailSendStatusLabels: Record<ApplicationEmailSendStatus, string> = {
-  PENDING: "En attente",
-  SENT: "Envoyé",
-  FAILED: "Échec"
+type SectionCardProps = {
+  action?: ReactNode;
+  bodyClassName?: string;
+  children: ReactNode;
+  className?: string;
+  motionDelay?: number;
+  subtitle?: string;
+  title: string;
 };
 
-const emailSendStatusStyles: Record<ApplicationEmailSendStatus, string> = {
-  PENDING: "bg-warning/10 text-warning ring-warning/20",
-  SENT: "bg-success/10 text-success ring-success/20",
-  FAILED: "bg-danger/10 text-danger ring-danger/20"
+type TimelineEntry = {
+  badges?: ReactNode;
+  content?: string;
+  date: string;
+  id: string;
+  sortDate: number;
+  summary: string;
+  type: string;
 };
 
 const genderLabels: Record<ApplicationGender, string> = {
@@ -57,15 +76,6 @@ const genderLabels: Record<ApplicationGender, string> = {
   GIRL: "Fille",
   UNKNOWN: "Non renseigné"
 };
-
-const dateTimeFormatter = new Intl.DateTimeFormat("fr-FR", {
-  dateStyle: "medium",
-  timeStyle: "short"
-});
-
-const dateFormatter = new Intl.DateTimeFormat("fr-FR", {
-  dateStyle: "medium"
-});
 
 const statusOptions: Array<{
   value: ApplicationStatus;
@@ -85,47 +95,23 @@ const decisionOptions: Array<{
   { value: "REFUSED", label: "Refusée" }
 ];
 
-const emailTypeOptions: Array<{
-  value: ApplicationEmailType;
-  label: string;
-}> = [
-  { value: "ACCEPTANCE", label: "Acceptation" },
-  { value: "REFUSAL", label: "Refus" },
-  { value: "CUSTOM", label: "Personnalisé" }
-];
+const dateTimeFormatter = new Intl.DateTimeFormat("fr-FR", {
+  dateStyle: "medium",
+  timeStyle: "short"
+});
 
-const emailTemplates: Record<
-  Exclude<ApplicationEmailType, "CUSTOM">,
-  {
-    subject: string;
-    body: string;
-  }
-> = {
-  ACCEPTANCE: {
-    subject: "ECE - décision d'admission",
-    body: "Votre demande d'inscription a été acceptée."
-  },
-  REFUSAL: {
-    subject: "ECE - décision d'inscription",
-    body: "Nous regrettons de vous informer que votre demande n'a pas été retenue."
-  }
+const dateFormatter = new Intl.DateTimeFormat("fr-FR", {
+  dateStyle: "medium"
+});
+
+const getEnterStyle = (delay: number): CSSProperties => {
+  return {
+    "--ui-enter-delay": `${delay}ms`
+  } as CSSProperties;
 };
 
 const isAbortError = (error: unknown): boolean => {
   return error instanceof DOMException && error.name === "AbortError";
-};
-
-const getEmailTemplate = (
-  emailType: ApplicationEmailType
-): {
-  subject: string;
-  body: string;
-} | null => {
-  if (emailType === "CUSTOM") {
-    return null;
-  }
-
-  return emailTemplates[emailType];
 };
 
 const isDecisionStatus = (
@@ -138,6 +124,10 @@ const getDecisionSelection = (
   status: ApplicationStatus
 ): ApplicationDecisionStatus => {
   return isDecisionStatus(status) ? status : "ACCEPTED";
+};
+
+const formatSchoolYearLabel = (label: string): string => {
+  return label.replace(/^(\d{4})-(\d{4})$/u, "$1 - $2");
 };
 
 const formatOptionalText = (value: string | null | undefined): string => {
@@ -169,31 +159,11 @@ const formatParentName = (
   lastName: string | null | undefined
 ): string => {
   const parts = [firstName, lastName].filter(
-    (value): value is string => typeof value === "string" && value.trim().length > 0
+    (value): value is string =>
+      typeof value === "string" && value.trim().length > 0
   );
 
   return parts.length > 0 ? parts.join(" ") : "Non renseigné";
-};
-
-const getEmailActionErrorMessage = (error: unknown): string => {
-  if (!(error instanceof Error)) {
-    return "Impossible d'envoyer l'email.";
-  }
-
-  switch (error.message) {
-    case "Invalid email type":
-      return "Le type d'email sélectionné est invalide.";
-    case "Invalid email payload":
-      return "Le sujet et le message sont obligatoires.";
-    case "Missing recipient email":
-      return "Aucune adresse email de contact n'est renseignée pour cette demande.";
-    case "Application not found":
-      return "Cette demande n'existe pas ou n'est plus accessible.";
-    case "Internal server error":
-      return "Une erreur serveur est survenue pendant l'envoi de l'email.";
-    default:
-      return error.message;
-  }
 };
 
 const getActionErrorMessage = (fallbackMessage: string, error: unknown): string => {
@@ -232,22 +202,168 @@ const getApplicationFamilyTitle = (
     return `Famille ${familyNames.join(" / ")}`;
   }
 
+  const studentLastNames = application.students
+    .map((student) => student.lastName.trim())
+    .filter((value) => value.length > 0);
+
+  if (studentLastNames.length > 0) {
+    return `Famille ${Array.from(new Set(studentLastNames)).join(" / ")}`;
+  }
+
   return "Famille non renseignée";
 };
 
-const DetailField = ({
-  label,
-  value
-}: {
-  label: string;
-  value: string;
-}) => {
+const getFamilyLastNameTitle = (application: ApplicationDetail): string => {
+  const parentLastNames = [
+    application.family.fatherLastName,
+    application.family.motherLastName
+  ].filter(
+    (value): value is string =>
+      typeof value === "string" && value.trim().length > 0
+  );
+  const studentLastNames = application.students
+    .map((student) => student.lastName.trim())
+    .filter((value) => value.length > 0);
+  const lastNames =
+    parentLastNames.length > 0 ? parentLastNames : studentLastNames;
+  const uniqueLastNames = Array.from(new Set(lastNames.map((value) => value.trim())));
+
+  return uniqueLastNames.length > 0
+    ? uniqueLastNames.join(" / ")
+    : "Famille non renseignée";
+};
+
+const getApplicationLevels = (
+  application: ApplicationDetail
+): Array<{ code: string; label: string }> => {
+  const uniqueLevels = new Map<string, { code: string; label: string }>();
+
+  application.students.forEach((student) => {
+    const code = student.level.code.trim();
+    const label = student.level.label.trim();
+    const key = `${code}::${label}`;
+
+    if ((code.length > 0 || label.length > 0) && !uniqueLevels.has(key)) {
+      uniqueLevels.set(key, { code, label });
+    }
+  });
+
+  return Array.from(uniqueLevels.values());
+};
+
+const getStudentAvatarVariant = (
+  gender: ApplicationGender
+): PersonAvatarVariant => {
+  if (gender === "BOY") {
+    return "boy";
+  }
+
+  if (gender === "GIRL") {
+    return "girl";
+  }
+
+  return "neutral";
+};
+
+const getStudentsSummary = (students: ApplicationDetailStudent[]): string => {
+  if (students.length === 0) {
+    return "Aucun élève rattaché";
+  }
+
+  return students
+    .map((student) => `${student.firstName} ${student.lastName}`)
+    .join(" · ");
+};
+
+const getHeaderDescription = (application: ApplicationDetail | null): string => {
+  if (!application) {
+    return "Consultation et traitement administratif d'une demande d'inscription.";
+  }
+
+  const studentsSummary = getStudentsSummary(application.students);
+
+  return `${studentsSummary} · ${formatSchoolYearLabel(
+    application.schoolYear.label
+  )} · consultation et traitement du dossier.`;
+};
+
+const getDecisionSummary = (status: ApplicationDecisionStatus): string => {
+  return status === "ACCEPTED" ? "Acceptation enregistrée" : "Refus enregistré";
+};
+
+const BackIcon = ({ className = "h-4 w-4" }: IconProps) => {
   return (
-    <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4">
-      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.8"
+      className={className}
+    >
+      <path d="m9.75 3.25-4.5 4.75 4.5 4.75" />
+    </svg>
+  );
+};
+
+const MailIcon = ({ className = "h-4 w-4" }: IconProps) => {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.5"
+      className={className}
+    >
+      <rect x="2" y="3.25" width="12" height="9.5" rx="2" />
+      <path d="M3.25 5 8 8.5 12.75 5" />
+    </svg>
+  );
+};
+
+const SaveIcon = ({ className = "h-4 w-4" }: IconProps) => {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.6"
+      className={className}
+    >
+      <path d="M3.25 2.75h7.6l1.9 1.9v8.6h-9.5V2.75Z" />
+      <path d="M5.25 2.75v3h5.5" />
+      <path d="M5.5 11.25h5" />
+    </svg>
+  );
+};
+
+const StarIcon = ({ className = "h-4 w-4" }: IconProps) => {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor" className={className}>
+      <path d="m8 2.15 1.62 3.28 3.62.52-2.62 2.55.62 3.6L8 10.4l-3.24 1.7.62-3.6L2.76 5.95l3.62-.52L8 2.15Z" />
+    </svg>
+  );
+};
+
+const DetailField = ({ label, children, className }: DetailFieldProps) => {
+  return (
+    <div
+      className={`rounded-2xl border border-slate-200/90 bg-white/80 p-4 shadow-[0_10px_24px_-24px_rgba(15,23,42,0.18)] ${className ?? ""}`}
+    >
+      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
         {label}
       </p>
-      <p className="mt-2 text-sm font-semibold text-slate-900">{value}</p>
+      <div className="mt-2 break-words text-sm font-semibold leading-6 text-slate-900">
+        {children}
+      </div>
     </div>
   );
 };
@@ -255,25 +371,117 @@ const DetailField = ({
 const SectionCard = ({
   title,
   subtitle,
-  children
-}: {
-  title: string;
-  subtitle?: string;
-  children: React.ReactNode;
-}) => {
+  action,
+  children,
+  bodyClassName,
+  className,
+  motionDelay = 0
+}: SectionCardProps) => {
   return (
-    <section className="rounded-3xl border border-white/80 bg-white/90 p-6 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.35)] backdrop-blur">
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div>
-          <h2 className="text-2xl font-semibold text-slate-900">{title}</h2>
+    <section
+      className={`ui-animate-in ui-surface-hover ui-surface-hover--soft ui-surface-hover--no-accent rounded-[32px] border border-white/80 bg-white/90 p-6 shadow-[0_24px_50px_-34px_rgba(15,23,42,0.3)] backdrop-blur sm:p-7 ${className ?? ""}`}
+      style={getEnterStyle(motionDelay)}
+    >
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primaryLight">
+            {title}
+          </p>
           {subtitle ? (
-            <p className="mt-2 text-sm leading-6 text-slate-600">{subtitle}</p>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+              {subtitle}
+            </p>
           ) : null}
         </div>
+        {action ? <div className="shrink-0">{action}</div> : null}
       </div>
-      <div className="mt-6">{children}</div>
+      <div className={`mt-6 ${bodyClassName ?? ""}`}>{children}</div>
     </section>
   );
+};
+
+const ParentCard = ({
+  name,
+  role,
+  variant
+}: {
+  name: string;
+  role: string;
+  variant: PersonAvatarVariant;
+}) => {
+  return (
+    <article className="rounded-[26px] border border-slate-200/90 bg-slate-50/80 p-4">
+      <div className="flex items-center gap-4">
+        <PersonAvatar label={`${role} - ${name}`} size="md" variant={variant} />
+        <div className="min-w-0">
+          <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            {role}
+          </p>
+          <h3 className="mt-1 break-words text-base font-semibold text-slate-900">
+            {name}
+          </h3>
+        </div>
+      </div>
+    </article>
+  );
+};
+
+const buildTimelineEntries = (
+  application: ApplicationDetail,
+  emailLogs: ApplicationEmailLog[]
+): TimelineEntry[] => {
+  const createdAt = new Date(application.createdAt);
+  const entries: TimelineEntry[] = [
+    {
+      id: `${application.id}-created`,
+      type: "Demande reçue",
+      date: formatOptionalDateTime(application.createdAt),
+      sortDate: createdAt.getTime(),
+      summary: `Dossier créé pour ${getStudentsSummary(application.students)}.`,
+      content: `Année scolaire ${formatSchoolYearLabel(application.schoolYear.label)}.`
+    }
+  ];
+
+  if (application.decisionAt && isDecisionStatus(application.status)) {
+    entries.push({
+      id: `${application.id}-decision`,
+      type: "Décision finale",
+      date: formatOptionalDateTime(application.decisionAt),
+      sortDate: new Date(application.decisionAt).getTime(),
+      summary: getDecisionSummary(application.status),
+      content: application.decisionNote ?? undefined,
+      badges: <StatusBadge status={application.status} />
+    });
+  }
+
+  emailLogs.forEach((emailLog) => {
+    const timelineDate = emailLog.sentAt ?? emailLog.createdAt;
+
+    entries.push({
+      id: emailLog.id,
+      type: `Email ${applicationEmailTypeLabels[emailLog.emailType].toLowerCase()}`,
+      date: formatOptionalDateTime(timelineDate),
+      sortDate: new Date(timelineDate).getTime(),
+      summary: emailLog.subject,
+      content: emailLog.bodySnapshot,
+      badges: (
+        <div className="flex flex-wrap gap-2">
+          <span
+            className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ring-1 ${applicationEmailTypeStyles[emailLog.emailType]}`}
+          >
+            {applicationEmailTypeLabels[emailLog.emailType]}
+          </span>
+          <span
+            className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ring-1 ${applicationEmailSendStatusStyles[emailLog.sendStatus]}`}
+          >
+            {applicationEmailSendStatusLabels[emailLog.sendStatus]}
+          </span>
+        </div>
+      )
+    });
+  });
+
+  return entries.sort((leftEntry, rightEntry) => rightEntry.sortDate - leftEntry.sortDate);
 };
 
 const ApplicationDetailPage = () => {
@@ -290,32 +498,6 @@ const ApplicationDetailPage = () => {
     useState<ApplicationDecisionStatus>("ACCEPTED");
   const [decisionNote, setDecisionNote] = useState("");
   const [isDecisionSubmitting, setIsDecisionSubmitting] = useState(false);
-  const [selectedEmailType, setSelectedEmailType] =
-    useState<ApplicationEmailType>("ACCEPTANCE");
-  const [emailSubject, setEmailSubject] = useState(emailTemplates.ACCEPTANCE.subject);
-  const [emailBody, setEmailBody] = useState(emailTemplates.ACCEPTANCE.body);
-  const [isEmailSubjectDirty, setIsEmailSubjectDirty] = useState(false);
-  const [isEmailBodyDirty, setIsEmailBodyDirty] = useState(false);
-  const [isEmailSubmitting, setIsEmailSubmitting] = useState(false);
-
-  const resetEmailForm = useCallback((): void => {
-    setSelectedEmailType("ACCEPTANCE");
-    setEmailSubject(emailTemplates.ACCEPTANCE.subject);
-    setEmailBody(emailTemplates.ACCEPTANCE.body);
-    setIsEmailSubjectDirty(false);
-    setIsEmailBodyDirty(false);
-  }, []);
-
-  const handleEmailTypeChange = useCallback((emailType: ApplicationEmailType): void => {
-    setSelectedEmailType(emailType);
-
-    if (emailType === "CUSTOM") {
-      setEmailSubject("");
-      setEmailBody("");
-      setIsEmailSubjectDirty(false);
-      setIsEmailBodyDirty(false);
-    }
-  }, []);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -346,7 +528,6 @@ const ApplicationDetailPage = () => {
         setEmailLogs(emailLogsData);
         setSelectedDecisionStatus(getDecisionSelection(applicationData.status));
         setDecisionNote(applicationData.decisionNote ?? "");
-        resetEmailForm();
       } catch (loadError) {
         if (isAbortError(loadError) || controller.signal.aborted) {
           return;
@@ -371,7 +552,7 @@ const ApplicationDetailPage = () => {
     return () => {
       controller.abort();
     };
-  }, [applicationId, resetEmailForm]);
+  }, [applicationId]);
 
   useEffect(() => {
     if (application) {
@@ -379,61 +560,46 @@ const ApplicationDetailPage = () => {
     }
   }, [application]);
 
-  useEffect(() => {
-    const template = getEmailTemplate(selectedEmailType);
+  const handleStatusSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
+      event.preventDefault();
 
-    if (!template) {
-      return;
-    }
-
-    if (!isEmailSubjectDirty) {
-      setEmailSubject(template.subject);
-    }
-
-    if (!isEmailBodyDirty) {
-      setEmailBody(template.body);
-    }
-  }, [selectedEmailType, isEmailSubjectDirty, isEmailBodyDirty]);
-
-  const handleStatusSubmit = useCallback(async (
-    event: React.FormEvent<HTMLFormElement>
-  ): Promise<void> => {
-    event.preventDefault();
-
-    if (!application || selectedStatus === application.status) {
-      return;
-    }
-
-    setIsStatusSubmitting(true);
-
-    try {
-      const updatedApplication = await updateApplicationStatus(
-        application.id,
-        selectedStatus
-      );
-
-      setApplication((currentApplication) => {
-        if (!currentApplication || currentApplication.id !== updatedApplication.id) {
-          return currentApplication;
-        }
-
-        return {
-          ...currentApplication,
-          status: updatedApplication.status
-        };
-      });
-      if (isDecisionStatus(updatedApplication.status)) {
-        setSelectedDecisionStatus(updatedApplication.status);
+      if (!application || selectedStatus === application.status) {
+        return;
       }
-      showSuccess("Le statut a bien été mis à jour.");
-    } catch (updateError) {
-      showError(
-        getActionErrorMessage("Impossible de mettre à jour le statut.", updateError)
-      );
-    } finally {
-      setIsStatusSubmitting(false);
-    }
-  }, [application, selectedStatus, showError, showSuccess]);
+
+      setIsStatusSubmitting(true);
+
+      try {
+        const updatedApplication = await updateApplicationStatus(
+          application.id,
+          selectedStatus
+        );
+
+        setApplication((currentApplication) => {
+          if (!currentApplication || currentApplication.id !== updatedApplication.id) {
+            return currentApplication;
+          }
+
+          return {
+            ...currentApplication,
+            status: updatedApplication.status
+          };
+        });
+        if (isDecisionStatus(updatedApplication.status)) {
+          setSelectedDecisionStatus(updatedApplication.status);
+        }
+        showSuccess("Le statut a bien été mis à jour.");
+      } catch (updateError) {
+        showError(
+          getActionErrorMessage("Impossible de mettre à jour le statut.", updateError)
+        );
+      } finally {
+        setIsStatusSubmitting(false);
+      }
+    },
+    [application, selectedStatus, showError, showSuccess]
+  );
 
   const handlePriorityToggle = useCallback(async (): Promise<void> => {
     if (!application) {
@@ -477,118 +643,78 @@ const ApplicationDetailPage = () => {
     }
   }, [application, showError, showSuccess]);
 
-  const handleDecisionSubmit = useCallback(async (
-    event: React.FormEvent<HTMLFormElement>
-  ): Promise<void> => {
-    event.preventDefault();
+  const handleDecisionSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
+      event.preventDefault();
 
-    if (!application) {
-      return;
-    }
+      if (!application) {
+        return;
+      }
 
-    setIsDecisionSubmitting(true);
+      setIsDecisionSubmitting(true);
 
-    const normalizedDecisionNote = decisionNote.trim();
+      const normalizedDecisionNote = decisionNote.trim();
 
-    try {
-      const updatedApplication = await updateApplicationDecision(application.id, {
-        status: selectedDecisionStatus,
-        decisionNote: normalizedDecisionNote.length > 0 ? normalizedDecisionNote : null
-      });
+      try {
+        const updatedApplication = await updateApplicationDecision(application.id, {
+          status: selectedDecisionStatus,
+          decisionNote:
+            normalizedDecisionNote.length > 0 ? normalizedDecisionNote : null
+        });
 
-      setApplication((currentApplication) => {
-        if (!currentApplication || currentApplication.id !== updatedApplication.id) {
-          return currentApplication;
-        }
+        setApplication((currentApplication) => {
+          if (!currentApplication || currentApplication.id !== updatedApplication.id) {
+            return currentApplication;
+          }
 
-        return {
-          ...currentApplication,
-          status: updatedApplication.status,
-          decisionAt: updatedApplication.decisionAt,
-          decisionNote: updatedApplication.decisionNote
-        };
-      });
-      setSelectedDecisionStatus(updatedApplication.status);
-      setDecisionNote(updatedApplication.decisionNote ?? "");
-      showSuccess("La décision finale a bien été enregistrée.");
-    } catch (updateError) {
-      showError(
-        getActionErrorMessage(
-          "Impossible d'enregistrer la décision finale.",
-          updateError
-        )
-      );
-    } finally {
-      setIsDecisionSubmitting(false);
-    }
-  }, [application, decisionNote, selectedDecisionStatus, showError, showSuccess]);
-
-  const handleEmailSubmit = useCallback(async (
-    event: React.FormEvent<HTMLFormElement>
-  ): Promise<void> => {
-    event.preventDefault();
-
-    if (!application) {
-      return;
-    }
-
-    const normalizedSubject = emailSubject.trim();
-    const normalizedBody = emailBody.trim();
-
-    if (normalizedSubject.length === 0) {
-      showError("Le sujet est obligatoire.");
-      return;
-    }
-
-    if (normalizedBody.length === 0) {
-      showError("Le message est obligatoire.");
-      return;
-    }
-
-    setIsEmailSubmitting(true);
-
-    const payload: ApplicationEmailSendPayload = {
-      emailType: selectedEmailType,
-      subject: normalizedSubject,
-      body: normalizedBody
-    };
-
-    try {
-      const createdEmailLog = await sendApplicationEmail(application.id, payload);
-
-      setEmailLogs((currentEmailLogs) => [createdEmailLog, ...currentEmailLogs]);
-      resetEmailForm();
-      showSuccess("L'email a été envoyé et enregistré dans l'historique.");
-    } catch (sendError) {
-      showError(getEmailActionErrorMessage(sendError));
-    } finally {
-      setIsEmailSubmitting(false);
-    }
-  }, [
-    application,
-    emailBody,
-    emailSubject,
-    resetEmailForm,
-    selectedEmailType,
-    showError,
-    showSuccess
-  ]);
+          return {
+            ...currentApplication,
+            status: updatedApplication.status,
+            decisionAt: updatedApplication.decisionAt,
+            decisionNote: updatedApplication.decisionNote
+          };
+        });
+        setSelectedDecisionStatus(updatedApplication.status);
+        setDecisionNote(updatedApplication.decisionNote ?? "");
+        showSuccess("La décision finale a bien été enregistrée.");
+      } catch (updateError) {
+        showError(
+          getActionErrorMessage(
+            "Impossible d'enregistrer la décision finale.",
+            updateError
+          )
+        );
+      } finally {
+        setIsDecisionSubmitting(false);
+      }
+    },
+    [application, decisionNote, selectedDecisionStatus, showError, showSuccess]
+  );
 
   const pageTopBar = (
-    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-      <Breadcrumb
-        items={[
-          { label: "Accueil", href: "/" },
-          { label: "Demandes", href: "/applications" },
-          { label: "Détail" }
-        ]}
-      />
-      <Link
-        to="/applications"
-        className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+    <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+      <div
+        className="ui-animate-in ui-animate-in--subtle w-fit rounded-2xl border border-primary/10 bg-white/80 px-4 py-3 text-sm text-primaryDark shadow-[0_10px_22px_-22px_rgba(15,23,42,0.18)]"
+        style={getEnterStyle(20)}
       >
-        Retour aux demandes
-      </Link>
+        <Breadcrumb
+          items={[
+            { label: "Tableau de bord", href: "/" },
+            { label: "Liste des demandes", href: "/applications" },
+            { label: "Détail" }
+          ]}
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3 lg:justify-end">
+        <Link
+          to="/applications"
+          className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-primary/25 hover:text-primary"
+        >
+          <BackIcon />
+          <span>Retour aux demandes</span>
+        </Link>
+      </div>
     </div>
   );
 
@@ -610,7 +736,7 @@ const ApplicationDetailPage = () => {
           topBar={pageTopBar}
           eyebrow="Demande d'inscription"
           title={getApplicationFamilyTitle(null)}
-          description="Consultation détaillée d'une demande, de sa composition familiale, des élèves rattachés et de l'historique email."
+          description={getHeaderDescription(null)}
           aside={pageHeaderAside}
         />
         <LoadingState />
@@ -628,7 +754,7 @@ const ApplicationDetailPage = () => {
           topBar={pageTopBar}
           eyebrow="Demande d'inscription"
           title={getApplicationFamilyTitle(null)}
-          description="Consultation détaillée d'une demande, de sa composition familiale, des élèves rattachés et de l'historique email."
+          description={getHeaderDescription(null)}
           aside={pageHeaderAside}
         />
         <ErrorState
@@ -648,72 +774,229 @@ const ApplicationDetailPage = () => {
     );
   }
 
+  const timelineEntries = buildTimelineEntries(application, emailLogs);
+  const familyLastNameTitle = getFamilyLastNameTitle(application);
+  const familyAvatarLabel =
+    familyLastNameTitle === "Famille non renseignée"
+      ? familyLastNameTitle
+      : `Famille ${familyLastNameTitle}`;
+  const applicationLevels = getApplicationLevels(application);
+  const fatherName = formatParentName(
+    application.family.fatherFirstName,
+    application.family.fatherLastName
+  );
+  const motherName = formatParentName(
+    application.family.motherFirstName,
+    application.family.motherLastName
+  );
+
   return (
     <>
-      <PageSectionHeader
-        topBar={pageTopBar}
-        eyebrow="Demande d'inscription"
-        title={getApplicationFamilyTitle(application)}
-        description="Consultation détaillée d'une demande, de sa composition familiale, des élèves rattachés et de l'historique email."
-        aside={pageHeaderAside}
-      />
-      <div className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+      <div className="ui-animate-in ui-animate-in--subtle" style={getEnterStyle(120)}>
+        <PageSectionHeader
+          topBar={pageTopBar}
+          eyebrow="Demande d'inscription"
+          title={getApplicationFamilyTitle(application)}
+          description={getHeaderDescription(application)}
+          aside={pageHeaderAside}
+        />
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.08fr)_minmax(360px,0.72fr)] xl:items-start">
         <SectionCard
-          title="Demande"
-          subtitle="Informations générales du dossier et état actuel de la décision."
+          title="Informations principales"
+          subtitle="Repères essentiels du dossier avant traitement administratif."
+          className="xl:col-start-1 xl:row-start-1"
+          motionDelay={180}
         >
-          <div className="grid gap-4 md:grid-cols-2">
-            <DetailField label="Identifiant" value={application.id} />
-            <DetailField
-              label="Créée le"
-              value={formatOptionalDateTime(application.createdAt)}
-            />
-            <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4">
-              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                Statut
-              </p>
-              <div className="mt-2">
-                <StatusBadge status={application.status} />
+            <div className="rounded-[28px] border border-primary/10 bg-primary/5 p-5">
+              <div className="flex flex-col gap-5 sm:flex-row sm:items-center">
+                <FamilyAvatar label={familyAvatarLabel} size="lg" />
+                <div className="min-w-0 flex-1">
+                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-primaryLight">
+                    Famille
+                  </p>
+                  <h2 className="mt-1 text-2xl font-semibold text-slate-900">
+                    {familyLastNameTitle}
+                  </h2>
+                  <div className="mt-3 flex flex-wrap items-center gap-2">
+                    <StatusBadge status={application.status} />
+                    <PriorityBadge isPriority={application.isPriority} />
+                    {applicationLevels.length > 0 ? (
+                      applicationLevels.map((level) => (
+                        <LevelBadge
+                          key={`${level.code}-${level.label}`}
+                          code={level.code}
+                          label={level.label}
+                          size="sm"
+                        />
+                      ))
+                    ) : null}
+                  </div>
+                </div>
               </div>
             </div>
-            <DetailField
-              label="Priorité"
-              value={application.isPriority ? "Oui" : "Non"}
-            />
-            <DetailField
-              label="Décision prise le"
-              value={formatOptionalDateTime(application.decisionAt)}
-            />
-            <DetailField
-              label="Note de décision"
-              value={formatOptionalText(application.decisionNote)}
-            />
-          </div>
+
+            <div className="mt-5 grid gap-4 md:grid-cols-2">
+              <DetailField label="Identifiant">{application.id}</DetailField>
+              <DetailField label="Réception">
+                {formatOptionalDateTime(application.createdAt)}
+              </DetailField>
+              <DetailField label="Année scolaire">
+                {formatSchoolYearLabel(application.schoolYear.label)}
+              </DetailField>
+              <DetailField label="Élèves rattachés">
+                {application.students.length}
+              </DetailField>
+              <DetailField label="Décision prise le">
+                {formatOptionalDateTime(application.decisionAt)}
+              </DetailField>
+              <DetailField label="Note de décision">
+                {formatOptionalText(application.decisionNote)}
+              </DetailField>
+            </div>
         </SectionCard>
 
-        <div className="space-y-6">
+        <SectionCard
+          title="Famille"
+          subtitle="Parents et coordonnées à utiliser pour le suivi administratif."
+          className="xl:col-start-1 xl:row-start-2"
+          motionDelay={240}
+        >
+            <div className="grid gap-4 md:grid-cols-2">
+              <ParentCard name={fatherName} role="Père" variant="man" />
+              <ParentCard name={motherName} role="Mère" variant="woman" />
+            </div>
+
+            <div className="mt-5 grid gap-4 md:grid-cols-2">
+              <DetailField label="Email de contact">
+                {formatOptionalText(application.family.contactEmail)}
+              </DetailField>
+              <DetailField label="Téléphone">
+                {formatOptionalText(application.family.contactPhone)}
+              </DetailField>
+              <DetailField label="Situation familiale">
+                {formatOptionalText(application.family.familyStatus)}
+              </DetailField>
+              <DetailField label="Adresse postale">
+                {formatOptionalText(application.family.postalAddress)}
+              </DetailField>
+            </div>
+        </SectionCard>
+
+        <div className="space-y-6 xl:col-start-2 xl:row-start-1 xl:row-span-2 xl:min-h-0 xl:self-stretch xl:[contain:size]">
           <SectionCard
-            title="Actions"
-            subtitle="Mettre à jour le statut administratif, la priorité, la décision finale et les emails sans recharger toute l'application."
+            title="Traitement"
+            subtitle="Statut, priorité, décision finale et email."
+            bodyClassName="!mt-4 flex flex-1 flex-col gap-3 xl:min-h-0"
+            className="!p-5 sm:!p-6 xl:flex xl:h-full xl:min-h-0 xl:flex-col"
+            motionDelay={220}
           >
-            <form className="space-y-4" onSubmit={handleStatusSubmit}>
-              <div className="space-y-2">
+            <form className="shrink-0" onSubmit={handleStatusSubmit}>
+              <div className="rounded-[22px] border border-slate-200/90 bg-slate-50/80 p-3.5">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                      Statut actuel
+                    </p>
+                    <div className="mt-1.5">
+                      <StatusBadge status={application.status} />
+                    </div>
+                  </div>
+                  <select
+                    id="application-status"
+                    aria-label="Nouveau statut"
+                    value={selectedStatus}
+                    onChange={(event) =>
+                      setSelectedStatus(event.target.value as ApplicationStatus)
+                    }
+                    disabled={isStatusSubmitting}
+                    className="min-w-[170px] rounded-2xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm font-medium text-slate-900 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
+                  >
+                    {statusOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <button
+                  type="submit"
+                  disabled={isStatusSubmitting || selectedStatus === application.status}
+                  className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white transition hover:bg-primaryDark disabled:cursor-not-allowed disabled:bg-slate-300"
+                >
+                  <SaveIcon />
+                  <span>
+                    {isStatusSubmitting ? "Mise à jour..." : "Mettre à jour"}
+                  </span>
+                </button>
+              </div>
+            </form>
+
+            <div className="shrink-0 rounded-[22px] border border-slate-200/90 bg-slate-50/80 p-3.5">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                    Priorité
+                  </p>
+                  <div className="mt-1.5">
+                    {application.isPriority ? (
+                      <PriorityBadge isPriority={application.isPriority} />
+                    ) : (
+                      <span className="text-sm font-medium text-slate-600">
+                        Non prioritaire
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={handlePriorityToggle}
+                  disabled={isPrioritySubmitting}
+                  className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 transition hover:border-primary/25 hover:text-primary disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400"
+                >
+                  <StarIcon />
+                  <span>
+                    {isPrioritySubmitting
+                      ? "Mise à jour..."
+                      : application.isPriority
+                        ? "Retirer"
+                        : "Activer"}
+                  </span>
+                </button>
+              </div>
+            </div>
+
+            <form
+              className="shrink-0 rounded-[22px] border border-slate-200/90 bg-slate-50/80 p-3.5"
+              onSubmit={handleDecisionSubmit}
+            >
+              <div>
+                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  Décision finale
+                </p>
+              </div>
+
+              <div className="mt-3 space-y-1.5">
                 <label
-                  htmlFor="application-status"
+                  htmlFor="application-decision-status"
                   className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500"
                 >
-                  Nouveau statut
+                  Décision
                 </label>
                 <select
-                  id="application-status"
-                  value={selectedStatus}
+                  id="application-decision-status"
+                  value={selectedDecisionStatus}
                   onChange={(event) =>
-                    setSelectedStatus(event.target.value as ApplicationStatus)
+                    setSelectedDecisionStatus(
+                      event.target.value as ApplicationDecisionStatus
+                    )
                   }
-                  disabled={isStatusSubmitting}
-                  className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-900 outline-none transition focus:border-primary/40 focus:bg-white"
+                  disabled={isDecisionSubmitting}
+                  className="w-full rounded-2xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm font-medium text-slate-900 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
                 >
-                  {statusOptions.map((option) => (
+                  {decisionOptions.map((option) => (
                     <option key={option.value} value={option.value}>
                       {option.label}
                     </option>
@@ -721,402 +1004,158 @@ const ApplicationDetailPage = () => {
                 </select>
               </div>
 
-              <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4">
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                  Statut actuel
-                </p>
-                <div className="mt-2">
-                  <StatusBadge status={application.status} />
-                </div>
+              <div className="mt-3 space-y-1.5">
+                <label
+                  htmlFor="application-decision-note"
+                  className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500"
+                >
+                  Note
+                </label>
+                <textarea
+                  id="application-decision-note"
+                  value={decisionNote}
+                  onChange={(event) => setDecisionNote(event.target.value)}
+                  disabled={isDecisionSubmitting}
+                  rows={2}
+                  className="w-full rounded-2xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm text-slate-900 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
+                  placeholder="Note interne de décision."
+                />
               </div>
 
               <button
                 type="submit"
-                disabled={isStatusSubmitting || selectedStatus === application.status}
-                className="inline-flex items-center rounded-full bg-primary px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-primaryDark disabled:cursor-not-allowed disabled:bg-slate-300"
+                disabled={isDecisionSubmitting}
+                className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white transition hover:bg-primaryDark disabled:cursor-not-allowed disabled:bg-slate-300"
               >
-                {isStatusSubmitting ? "Mise à jour..." : "Mettre à jour le statut"}
+                <SaveIcon />
+                <span>
+                  {isDecisionSubmitting
+                    ? "Enregistrement..."
+                    : "Enregistrer la décision"}
+                </span>
               </button>
             </form>
 
-            <div className="mt-6 border-t border-slate-200 pt-6">
-              <div className="space-y-4">
-                <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4">
-                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                    Priorité actuelle
-                  </p>
-                  <div className="mt-2 flex flex-wrap items-center gap-2">
-                    <PriorityBadge isPriority={application.isPriority} />
-                    {!application.isPriority ? (
-                      <span className="text-sm text-slate-600">Aucune priorité</span>
-                    ) : null}
-                  </div>
-                </div>
-
-                <button
-                  type="button"
-                  onClick={handlePriorityToggle}
-                  disabled={isPrioritySubmitting}
-                  className="inline-flex items-center rounded-full border border-slate-300 px-5 py-2.5 text-sm font-semibold text-slate-800 transition hover:border-slate-400 hover:bg-slate-50 disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400"
-                >
-                  {isPrioritySubmitting
-                    ? "Mise à jour..."
-                    : application.isPriority
-                      ? "Désactiver la priorité"
-                      : "Activer la priorité"}
-                </button>
+            <div className="flex min-h-[150px] flex-1 flex-col justify-between rounded-[22px] border border-secondary/20 bg-secondary/10 p-4">
+              <div>
+                <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-secondaryDark">
+                  Email
+                </p>
+                <p className="mt-2 text-sm leading-6 text-slate-700">
+                  Ouvrez la page dédiée pour rédiger le message de décision, choisir
+                  le type d'email et enregistrer l'envoi dans l'historique du dossier.
+                </p>
               </div>
-            </div>
-
-            <div className="mt-6 border-t border-slate-200 pt-6">
-              <form className="space-y-4" onSubmit={handleDecisionSubmit}>
-                <div>
-                  <h3 className="text-sm font-semibold text-slate-900">
-                    Décision finale
-                  </h3>
-                  <p className="mt-1 text-sm text-slate-600">
-                    Enregistrer une acceptation ou un refus définitif avec une note
-                    optionnelle.
-                  </p>
-                </div>
-
-                <div className="space-y-2">
-                  <label
-                    htmlFor="application-decision-status"
-                    className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500"
-                  >
-                    Décision
-                  </label>
-                  <select
-                    id="application-decision-status"
-                    value={selectedDecisionStatus}
-                    onChange={(event) =>
-                      setSelectedDecisionStatus(
-                        event.target.value as ApplicationDecisionStatus
-                      )
-                    }
-                    disabled={isDecisionSubmitting}
-                    className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-900 outline-none transition focus:border-primary/40 focus:bg-white"
-                  >
-                    {decisionOptions.map((option) => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                <div className="space-y-2">
-                  <label
-                    htmlFor="application-decision-note"
-                    className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500"
-                  >
-                    Note de décision
-                  </label>
-                  <textarea
-                    id="application-decision-note"
-                    value={decisionNote}
-                    onChange={(event) => setDecisionNote(event.target.value)}
-                    disabled={isDecisionSubmitting}
-                    rows={4}
-                    className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-primary/40 focus:bg-white"
-                    placeholder="Ajouter une note visible dans le détail de la demande."
-                  />
-                </div>
-
-                <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4">
-                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
-                    Décision actuellement visible
-                  </p>
-                  <div className="mt-2 flex flex-wrap items-center gap-3">
-                    <StatusBadge status={application.status} />
-                    <span className="text-sm text-slate-600">
-                      {formatOptionalDateTime(application.decisionAt)}
-                    </span>
-                  </div>
-                  <p className="mt-3 text-sm text-slate-600">
-                    {formatOptionalText(application.decisionNote)}
-                  </p>
-                </div>
-
-                <button
-                  type="submit"
-                  disabled={isDecisionSubmitting}
-                  className="inline-flex items-center rounded-full bg-primary px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-primaryDark disabled:cursor-not-allowed disabled:bg-slate-300"
-                >
-                  {isDecisionSubmitting
-                    ? "Enregistrement..."
-                    : "Enregistrer la décision finale"}
-                </button>
-              </form>
-            </div>
-
-            <div className="mt-6 border-t border-slate-200 pt-6">
-              <form className="space-y-4" onSubmit={handleEmailSubmit}>
-                <div>
-                  <h3 className="text-sm font-semibold text-slate-900">
-                    Envoyer un email
-                  </h3>
-                  <p className="mt-1 text-sm text-slate-600">
-                    Enregistrer un email envoyé et rafraîchir immédiatement
-                    l'historique visible.
-                  </p>
-                </div>
-
-                <div className="space-y-2">
-                  <label
-                    htmlFor="application-email-type"
-                    className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500"
-                  >
-                    Type d'email
-                  </label>
-                  <select
-                    id="application-email-type"
-                    value={selectedEmailType}
-                    onChange={(event) => {
-                      handleEmailTypeChange(
-                        event.target.value as ApplicationEmailType
-                      );
-                    }}
-                    disabled={isEmailSubmitting}
-                    className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-900 outline-none transition focus:border-primary/40 focus:bg-white"
-                  >
-                    {emailTypeOptions.map((option) => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                <div className="space-y-2">
-                  <label
-                    htmlFor="application-email-subject"
-                    className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500"
-                  >
-                    Sujet
-                  </label>
-                  <input
-                    id="application-email-subject"
-                    type="text"
-                    value={emailSubject}
-                    onChange={(event) => {
-                      setEmailSubject(event.target.value);
-                      setIsEmailSubjectDirty(true);
-                    }}
-                    disabled={isEmailSubmitting}
-                    className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-primary/40 focus:bg-white"
-                    placeholder={
-                      selectedEmailType === "CUSTOM"
-                          ? "Saisir un sujet personnalisé"
-                          : "ECE - décision d'admission"
-                      }
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <label
-                      htmlFor="application-email-body"
-                      className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500"
-                    >
-                      Message
-                    </label>
-                    <textarea
-                      id="application-email-body"
-                      value={emailBody}
-                      onChange={(event) => {
-                        setEmailBody(event.target.value);
-                        setIsEmailBodyDirty(true);
-                      }}
-                      disabled={isEmailSubmitting}
-                      rows={5}
-                      className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-primary/40 focus:bg-white"
-                      placeholder={
-                        selectedEmailType === "CUSTOM"
-                          ? "Saisir votre message personnalisé."
-                          : "Votre demande a été acceptée."
-                      }
-                    />
-                  </div>
-
-                  <button
-                    type="submit"
-                    disabled={isEmailSubmitting}
-                    className="inline-flex items-center rounded-full bg-primary px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-primaryDark disabled:cursor-not-allowed disabled:bg-slate-300"
-                  >
-                    {isEmailSubmitting ? "Envoi en cours..." : "Envoyer l'email"}
-                  </button>
-                </form>
-              </div>
-            </SectionCard>
-
-            <SectionCard
-              title="Année scolaire"
-              subtitle="Campagne d'inscription associée à cette demande."
-            >
-              <div className="grid gap-4">
-                <DetailField label="Libellé" value={application.schoolYear.label} />
-                <DetailField
-                  label="Statut"
-                  value={application.schoolYear.isActive ? "Année active" : "Historique"}
-                />
-              </div>
-            </SectionCard>
-          </div>
-        </div>
-
-        <div className="mt-6 grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
-          <SectionCard
-            title="Famille"
-            subtitle="Coordonnées et informations de contact utilisées par l'administration."
-          >
-            <div className="grid gap-4 md:grid-cols-2">
-              <DetailField
-                label="Email de contact"
-                value={formatOptionalText(application.family.contactEmail)}
-              />
-              <DetailField
-                label="Téléphone"
-                value={formatOptionalText(application.family.contactPhone)}
-              />
-              <DetailField
-                label="Père"
-                value={formatParentName(
-                  application.family.fatherFirstName,
-                  application.family.fatherLastName
-                )}
-              />
-              <DetailField
-                label="Mère"
-                value={formatParentName(
-                  application.family.motherFirstName,
-                  application.family.motherLastName
-                )}
-              />
-              <DetailField
-                label="Situation familiale"
-                value={formatOptionalText(application.family.familyStatus)}
-              />
-              <DetailField
-                label="Adresse postale"
-                value={formatOptionalText(application.family.postalAddress)}
-              />
+              <Link
+                to={`/applications/${application.id}/email`}
+                className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-full bg-secondary px-5 py-2 text-sm font-semibold text-white transition hover:bg-secondaryDark"
+              >
+                <MailIcon />
+                <span>Accéder à l'envoi d'email</span>
+              </Link>
             </div>
           </SectionCard>
+        </div>
+      </div>
 
-          <SectionCard
-            title="Élèves"
-            subtitle="Enfants rattachés à la demande et niveaux demandés."
-          >
-            {application.students.length === 0 ? (
-              <p className="rounded-2xl border border-dashed border-border bg-background/70 px-4 py-6 text-sm text-slate-500">
-                Aucun élève n'est rattaché à cette demande.
-              </p>
-            ) : (
-              <div className="space-y-4">
-                {application.students.map((student) => (
-                  <article
-                    key={student.id}
-                    className="rounded-3xl border border-slate-200 bg-slate-50/80 p-5"
-                  >
-                    <div className="flex flex-wrap items-start justify-between gap-3">
-                      <div>
-                        <h3 className="text-lg font-semibold text-slate-900">
+      <div className="mt-6">
+        <SectionCard
+          title="Élèves"
+          subtitle="Enfants rattachés à la demande et niveaux demandés."
+          motionDelay={300}
+        >
+          {application.students.length === 0 ? (
+            <p className="rounded-2xl border border-dashed border-border bg-background/70 px-4 py-6 text-sm text-slate-500">
+              Aucun élève n'est rattaché à cette demande.
+            </p>
+          ) : (
+            <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
+              {application.students.map((student) => (
+                <article
+                  key={student.id}
+                  className="rounded-[28px] border border-slate-200/90 bg-slate-50/80 p-5 shadow-[0_14px_30px_-26px_rgba(15,23,42,0.2)]"
+                >
+                  <div className="flex items-start gap-4">
+                    <PersonAvatar
+                      label={`${student.firstName} ${student.lastName}`}
+                      size="md"
+                      variant={getStudentAvatarVariant(student.gender)}
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h3 className="break-words text-lg font-semibold text-slate-900">
                           {student.firstName} {student.lastName}
                         </h3>
-                        <div className="mt-2 flex flex-wrap items-center gap-2">
-                          <p className="text-sm text-slate-500">{student.level.label}</p>
-                          <LevelBadge
-                            code={student.level.code}
-                            label={student.level.label}
-                            size="sm"
-                          />
-                        </div>
+                        {student.rankInForm ? (
+                          <span className="rounded-full bg-white px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-slate-700 ring-1 ring-slate-200">
+                            Rang {student.rankInForm}
+                          </span>
+                        ) : null}
                       </div>
-                      {student.rankInForm ? (
-                        <span className="rounded-full bg-white px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] text-slate-700 ring-1 ring-slate-200">
-                          Rang {student.rankInForm}
+                      <div className="mt-2 flex flex-wrap items-center gap-2">
+                        <LevelBadge
+                          code={student.level.code}
+                          label={student.level.label}
+                          size="sm"
+                        />
+                        <span className="text-sm font-medium text-slate-600">
+                          {student.level.label}
                         </span>
-                      ) : null}
-                    </div>
-
-                    <div className="mt-4 grid gap-3 md:grid-cols-2">
-                      <DetailField label="Genre" value={genderLabels[student.gender]} />
-                      <DetailField
-                        label="Date de naissance"
-                        value={formatOptionalDate(student.birthDate)}
-                      />
-                    </div>
-                  </article>
-                ))}
-              </div>
-            )}
-          </SectionCard>
-        </div>
-
-        <div className="mt-6">
-          <SectionCard
-            title="Historique email"
-            subtitle="Logs métiers des emails envoyés ou simulés pour cette demande."
-          >
-            {emailLogs.length === 0 ? (
-              <p className="rounded-2xl border border-dashed border-border bg-background/70 px-4 py-6 text-sm text-slate-500">
-                Aucun email n'a encore été enregistré pour cette demande.
-              </p>
-            ) : (
-              <div className="space-y-4">
-                {emailLogs.map((emailLog) => (
-                  <article
-                    key={emailLog.id}
-                    className="rounded-3xl border border-slate-200 bg-slate-50/80 p-5"
-                  >
-                    <div className="flex flex-wrap items-start justify-between gap-3">
-                      <div>
-                        <div className="flex flex-wrap items-center gap-2">
-                          <h3 className="text-lg font-semibold text-slate-900">
-                            {emailLog.subject}
-                          </h3>
-                          <span
-                            className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ring-1 ${emailTypeStyles[emailLog.emailType]}`}
-                          >
-                            {emailTypeLabels[emailLog.emailType]}
-                          </span>
-                          <span
-                            className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ring-1 ${emailSendStatusStyles[emailLog.sendStatus]}`}
-                          >
-                            {emailSendStatusLabels[emailLog.sendStatus]}
-                          </span>
-                        </div>
-                        <p className="mt-2 text-sm text-slate-500">
-                          Destinataire : {emailLog.recipientEmail}
-                        </p>
                       </div>
                     </div>
+                  </div>
 
-                    <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-                      <DetailField
-                        label="Type d'email"
-                        value={emailTypeLabels[emailLog.emailType]}
-                      />
-                      <DetailField
-                        label="Statut d'envoi"
-                        value={emailSendStatusLabels[emailLog.sendStatus]}
-                      />
-                      <DetailField
-                        label="Envoyé le"
-                        value={formatOptionalDateTime(emailLog.sentAt)}
-                      />
-                      <DetailField
-                        label="Log créé le"
-                        value={formatOptionalDateTime(emailLog.createdAt)}
-                      />
+                  <div className="mt-5 grid gap-3 sm:grid-cols-2">
+                    <DetailField label="Genre">{genderLabels[student.gender]}</DetailField>
+                    <DetailField label="Naissance">
+                      {formatOptionalDate(student.birthDate)}
+                    </DetailField>
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+        </SectionCard>
+      </div>
+
+      <div className="mt-6">
+        <SectionCard
+          title="Historique du dossier"
+          subtitle="Lecture chronologique des événements métier, décisions et emails."
+          motionDelay={360}
+        >
+          <ol className="relative space-y-4 before:absolute before:bottom-3 before:left-[0.95rem] before:top-3 before:w-px before:bg-slate-200">
+            {timelineEntries.map((entry) => (
+              <li key={entry.id} className="relative pl-10">
+                <span className="absolute left-0 top-1.5 flex h-8 w-8 items-center justify-center rounded-full border border-white bg-primary text-white shadow-[0_10px_20px_-14px_rgba(31,77,58,0.7)]">
+                  <span className="h-2.5 w-2.5 rounded-full bg-white" />
+                </span>
+                <article className="rounded-[26px] border border-slate-200/90 bg-slate-50/80 p-5">
+                  <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                        {entry.date}
+                      </p>
+                      <h3 className="mt-1 text-lg font-semibold text-slate-900">
+                        {entry.type}
+                      </h3>
                     </div>
-                  </article>
-                ))}
-              </div>
-            )}
-          </SectionCard>
-        </div>
+                    {entry.badges ? <div className="shrink-0">{entry.badges}</div> : null}
+                  </div>
+                  <p className="mt-4 text-sm font-semibold leading-6 text-slate-800">
+                    {entry.summary}
+                  </p>
+                  {entry.content ? (
+                    <p className="mt-2 whitespace-pre-line text-sm leading-6 text-slate-600">
+                      {entry.content}
+                    </p>
+                  ) : null}
+                </article>
+              </li>
+            ))}
+          </ol>
+        </SectionCard>
+      </div>
     </>
   );
 };

--- a/apps/web/src/pages/ApplicationEmailPage.tsx
+++ b/apps/web/src/pages/ApplicationEmailPage.tsx
@@ -1,0 +1,687 @@
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type CSSProperties,
+  type ReactNode
+} from "react";
+import { Link, useParams } from "react-router-dom";
+
+import PageSectionHeader from "../components/layout/PageSectionHeader";
+import Breadcrumb from "../components/ui/Breadcrumb";
+import ErrorState from "../components/ui/ErrorState";
+import LevelBadge from "../components/ui/LevelBadge";
+import LoadingState from "../components/ui/LoadingState";
+import PersonAvatar, {
+  type PersonAvatarVariant
+} from "../components/ui/PersonAvatar";
+import PriorityBadge from "../components/ui/PriorityBadge";
+import StatusBadge from "../components/ui/StatusBadge";
+import { useToast } from "../context/ToastContext";
+import {
+  getApplicationById,
+  getApplicationEmailLogs,
+  sendApplicationEmail
+} from "../lib/api";
+import {
+  applicationEmailSendStatusLabels,
+  applicationEmailSendStatusStyles,
+  applicationEmailTemplates,
+  applicationEmailTypeLabels,
+  applicationEmailTypeOptions,
+  applicationEmailTypeStyles,
+  getApplicationEmailActionErrorMessage,
+  getApplicationEmailTemplate
+} from "../lib/applicationEmail";
+import type {
+  ApplicationDetail,
+  ApplicationEmailLog,
+  ApplicationEmailSendPayload,
+  ApplicationEmailType,
+  ApplicationGender
+} from "../types/application";
+
+type IconProps = {
+  className?: string;
+};
+
+type DetailFieldProps = {
+  children: ReactNode;
+  label: string;
+};
+
+type SectionCardProps = {
+  children: ReactNode;
+  motionDelay?: number;
+  subtitle?: string;
+  title: string;
+};
+
+const dateTimeFormatter = new Intl.DateTimeFormat("fr-FR", {
+  dateStyle: "medium",
+  timeStyle: "short"
+});
+
+const getEnterStyle = (delay: number): CSSProperties => {
+  return {
+    "--ui-enter-delay": `${delay}ms`
+  } as CSSProperties;
+};
+
+const isAbortError = (error: unknown): boolean => {
+  return error instanceof DOMException && error.name === "AbortError";
+};
+
+const formatSchoolYearLabel = (label: string): string => {
+  return label.replace(/^(\d{4})-(\d{4})$/u, "$1 - $2");
+};
+
+const formatOptionalText = (value: string | null | undefined): string => {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value;
+  }
+
+  return "Non renseigné";
+};
+
+const formatOptionalDateTime = (value: string | null | undefined): string => {
+  if (!value) {
+    return "Non renseigné";
+  }
+
+  return dateTimeFormatter.format(new Date(value));
+};
+
+const formatParentName = (
+  firstName: string | null | undefined,
+  lastName: string | null | undefined
+): string => {
+  const parts = [firstName, lastName].filter(
+    (value): value is string =>
+      typeof value === "string" && value.trim().length > 0
+  );
+
+  return parts.length > 0 ? parts.join(" ") : "Non renseigné";
+};
+
+const getApplicationFamilyTitle = (
+  application: ApplicationDetail | null
+): string => {
+  if (!application) {
+    return "Chargement de l'envoi";
+  }
+
+  const familyNames = [
+    formatParentName(
+      application.family.fatherFirstName,
+      application.family.fatherLastName
+    ),
+    formatParentName(
+      application.family.motherFirstName,
+      application.family.motherLastName
+    )
+  ].filter((value, index, values) => {
+    return value !== "Non renseigné" && values.indexOf(value) === index;
+  });
+
+  if (familyNames.length > 0) {
+    return `Famille ${familyNames.join(" / ")}`;
+  }
+
+  return "Famille non renseignée";
+};
+
+const getStudentAvatarVariant = (
+  gender: ApplicationGender
+): PersonAvatarVariant => {
+  if (gender === "BOY") {
+    return "boy";
+  }
+
+  if (gender === "GIRL") {
+    return "girl";
+  }
+
+  return "neutral";
+};
+
+const BackIcon = ({ className = "h-4 w-4" }: IconProps) => {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.8"
+      className={className}
+    >
+      <path d="m9.75 3.25-4.5 4.75 4.5 4.75" />
+    </svg>
+  );
+};
+
+const SendIcon = ({ className = "h-4 w-4" }: IconProps) => {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.55"
+      className={className}
+    >
+      <path d="M13.5 2.8 6.9 9.4" />
+      <path d="m13.5 2.8-3.2 10.4-3.4-3.8-4.1-1.8 10.7-4.8Z" />
+    </svg>
+  );
+};
+
+const DetailField = ({ label, children }: DetailFieldProps) => {
+  return (
+    <div className="rounded-2xl border border-slate-200/90 bg-white/80 p-4 shadow-[0_10px_24px_-24px_rgba(15,23,42,0.18)]">
+      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+        {label}
+      </p>
+      <div className="mt-2 break-words text-sm font-semibold leading-6 text-slate-900">
+        {children}
+      </div>
+    </div>
+  );
+};
+
+const SectionCard = ({
+  title,
+  subtitle,
+  children,
+  motionDelay = 0
+}: SectionCardProps) => {
+  return (
+    <section
+      className="ui-animate-in ui-surface-hover ui-surface-hover--soft ui-surface-hover--no-accent rounded-[32px] border border-white/80 bg-white/90 p-6 shadow-[0_24px_50px_-34px_rgba(15,23,42,0.3)] backdrop-blur sm:p-7"
+      style={getEnterStyle(motionDelay)}
+    >
+      <div>
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primaryLight">
+          {title}
+        </p>
+        {subtitle ? (
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+            {subtitle}
+          </p>
+        ) : null}
+      </div>
+      <div className="mt-6">{children}</div>
+    </section>
+  );
+};
+
+const ApplicationEmailPage = () => {
+  const { id: applicationId } = useParams<{ id: string }>();
+  const { showError, showSuccess } = useToast();
+  const [application, setApplication] = useState<ApplicationDetail | null>(null);
+  const [emailLogs, setEmailLogs] = useState<ApplicationEmailLog[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [selectedEmailType, setSelectedEmailType] =
+    useState<ApplicationEmailType>("ACCEPTANCE");
+  const [emailSubject, setEmailSubject] = useState(
+    applicationEmailTemplates.ACCEPTANCE.subject
+  );
+  const [emailBody, setEmailBody] = useState(
+    applicationEmailTemplates.ACCEPTANCE.body
+  );
+  const [isEmailSubjectDirty, setIsEmailSubjectDirty] = useState(false);
+  const [isEmailBodyDirty, setIsEmailBodyDirty] = useState(false);
+  const [isEmailSubmitting, setIsEmailSubmitting] = useState(false);
+
+  const resetEmailForm = useCallback((): void => {
+    setSelectedEmailType("ACCEPTANCE");
+    setEmailSubject(applicationEmailTemplates.ACCEPTANCE.subject);
+    setEmailBody(applicationEmailTemplates.ACCEPTANCE.body);
+    setIsEmailSubjectDirty(false);
+    setIsEmailBodyDirty(false);
+  }, []);
+
+  const handleEmailTypeChange = useCallback((emailType: ApplicationEmailType): void => {
+    setSelectedEmailType(emailType);
+
+    if (emailType === "CUSTOM") {
+      setEmailSubject("");
+      setEmailBody("");
+      setIsEmailSubjectDirty(false);
+      setIsEmailBodyDirty(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const loadApplicationEmailContext = async (): Promise<void> => {
+      if (!applicationId) {
+        setApplication(null);
+        setEmailLogs([]);
+        setError("Application not found");
+        setIsLoading(false);
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const [applicationData, emailLogsData] = await Promise.all([
+          getApplicationById(applicationId, { signal: controller.signal }),
+          getApplicationEmailLogs(applicationId, { signal: controller.signal })
+        ]);
+
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        setApplication(applicationData);
+        setEmailLogs(emailLogsData);
+        resetEmailForm();
+      } catch (loadError) {
+        if (isAbortError(loadError) || controller.signal.aborted) {
+          return;
+        }
+
+        setApplication(null);
+        setEmailLogs([]);
+        setError(
+          loadError instanceof Error
+            ? loadError.message
+            : "Une erreur inattendue est survenue."
+        );
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadApplicationEmailContext();
+
+    return () => {
+      controller.abort();
+    };
+  }, [applicationId, resetEmailForm]);
+
+  useEffect(() => {
+    const template = getApplicationEmailTemplate(selectedEmailType);
+
+    if (!template) {
+      return;
+    }
+
+    if (!isEmailSubjectDirty) {
+      setEmailSubject(template.subject);
+    }
+
+    if (!isEmailBodyDirty) {
+      setEmailBody(template.body);
+    }
+  }, [selectedEmailType, isEmailSubjectDirty, isEmailBodyDirty]);
+
+  const handleEmailSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
+      event.preventDefault();
+
+      if (!application) {
+        return;
+      }
+
+      const normalizedSubject = emailSubject.trim();
+      const normalizedBody = emailBody.trim();
+
+      if (normalizedSubject.length === 0) {
+        showError("Le sujet est obligatoire.");
+        return;
+      }
+
+      if (normalizedBody.length === 0) {
+        showError("Le message est obligatoire.");
+        return;
+      }
+
+      setIsEmailSubmitting(true);
+
+      const payload: ApplicationEmailSendPayload = {
+        emailType: selectedEmailType,
+        subject: normalizedSubject,
+        body: normalizedBody
+      };
+
+      try {
+        const createdEmailLog = await sendApplicationEmail(application.id, payload);
+
+        setEmailLogs((currentEmailLogs) => [createdEmailLog, ...currentEmailLogs]);
+        resetEmailForm();
+        showSuccess("L'email a été envoyé et enregistré dans l'historique.");
+      } catch (sendError) {
+        showError(getApplicationEmailActionErrorMessage(sendError));
+      } finally {
+        setIsEmailSubmitting(false);
+      }
+    },
+    [
+      application,
+      emailBody,
+      emailSubject,
+      resetEmailForm,
+      selectedEmailType,
+      showError,
+      showSuccess
+    ]
+  );
+
+  const detailPath = applicationId ? `/applications/${applicationId}` : "/applications";
+  const pageTopBar = (
+    <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+      <div
+        className="ui-animate-in ui-animate-in--subtle w-fit rounded-2xl border border-primary/10 bg-white/80 px-4 py-3 text-sm text-primaryDark shadow-[0_10px_22px_-22px_rgba(15,23,42,0.18)]"
+        style={getEnterStyle(20)}
+      >
+        <Breadcrumb
+          items={[
+            { label: "Tableau de bord", href: "/" },
+            { label: "Liste des demandes", href: "/applications" },
+            { label: "Détail", href: detailPath },
+            { label: "Envoi email" }
+          ]}
+        />
+      </div>
+
+      <Link
+        to={detailPath}
+        className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-primary/25 hover:text-primary"
+      >
+        <BackIcon />
+        <span>Retour au détail</span>
+      </Link>
+    </div>
+  );
+
+  const pageHeaderAside = application ? (
+    <div className="flex flex-wrap items-center gap-2">
+      <PriorityBadge isPriority={application.isPriority} />
+      <StatusBadge status={application.status} />
+    </div>
+  ) : isLoading ? (
+    <span className="rounded-full border border-primary/10 bg-primary/5 px-4 py-2 text-sm text-primaryDark">
+      Chargement...
+    </span>
+  ) : null;
+
+  if (isLoading) {
+    return (
+      <>
+        <PageSectionHeader
+          topBar={pageTopBar}
+          eyebrow="Email de décision"
+          title="Préparer l'email"
+          description="Page dédiée à la rédaction et à l'envoi d'un email lié à une demande."
+          aside={pageHeaderAside}
+        />
+        <LoadingState />
+      </>
+    );
+  }
+
+  if (error || !application) {
+    const errorMessage = error ?? "Application not found";
+    const isApplicationNotFound = errorMessage === "Application not found";
+
+    return (
+      <>
+        <PageSectionHeader
+          topBar={pageTopBar}
+          eyebrow="Email de décision"
+          title="Préparer l'email"
+          description="Page dédiée à la rédaction et à l'envoi d'un email lié à une demande."
+          aside={pageHeaderAside}
+        />
+        <ErrorState
+          title={isApplicationNotFound ? "Demande introuvable" : undefined}
+          message={
+            isApplicationNotFound
+              ? "Revenez à la liste des demandes et vérifiez l'identifiant ciblé."
+              : errorMessage
+          }
+          actionLabel={isApplicationNotFound ? undefined : "Actualiser"}
+          onAction={
+            isApplicationNotFound ? undefined : () => window.location.reload()
+          }
+          backLink="/applications"
+        />
+      </>
+    );
+  }
+
+  const latestEmailLogs = emailLogs.slice(0, 4);
+
+  return (
+    <>
+      <div className="ui-animate-in ui-animate-in--subtle" style={getEnterStyle(120)}>
+        <PageSectionHeader
+          topBar={pageTopBar}
+          eyebrow="Email de décision"
+          title="Envoyer un email à la famille"
+          description={`${getApplicationFamilyTitle(
+            application
+          )} · destinataire ${formatOptionalText(application.family.contactEmail)}.`}
+          aside={pageHeaderAside}
+        />
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(340px,0.62fr)] xl:items-start">
+        <SectionCard
+          title="Rédaction"
+          subtitle="Composer le message avant envoi et historisation sur le dossier."
+          motionDelay={180}
+        >
+          <form className="space-y-5" onSubmit={handleEmailSubmit}>
+            <div className="rounded-[26px] border border-slate-200/90 bg-slate-50/80 p-4">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                Destinataire
+              </p>
+              <p className="mt-2 break-all text-sm font-semibold text-slate-900">
+                {formatOptionalText(application.family.contactEmail)}
+              </p>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-[220px_minmax(0,1fr)]">
+              <label className="block">
+                <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                  Type d'email
+                </span>
+                <select
+                  value={selectedEmailType}
+                  onChange={(event) => {
+                    handleEmailTypeChange(event.target.value as ApplicationEmailType);
+                  }}
+                  disabled={isEmailSubmitting}
+                  className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-900 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
+                >
+                  {applicationEmailTypeOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="block">
+                <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                  Sujet
+                </span>
+                <input
+                  type="text"
+                  value={emailSubject}
+                  onChange={(event) => {
+                    setEmailSubject(event.target.value);
+                    setIsEmailSubjectDirty(true);
+                  }}
+                  disabled={isEmailSubmitting}
+                  className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
+                  placeholder={
+                    selectedEmailType === "CUSTOM"
+                      ? "Saisir un sujet personnalisé"
+                      : "ECE - décision d'admission"
+                  }
+                />
+              </label>
+            </div>
+
+            <label className="block">
+              <span className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                Message
+              </span>
+              <textarea
+                value={emailBody}
+                onChange={(event) => {
+                  setEmailBody(event.target.value);
+                  setIsEmailBodyDirty(true);
+                }}
+                disabled={isEmailSubmitting}
+                rows={10}
+                className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm leading-6 text-slate-900 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
+                placeholder={
+                  selectedEmailType === "CUSTOM"
+                    ? "Saisir votre message personnalisé."
+                    : "Votre demande a été acceptée."
+                }
+              />
+            </label>
+
+            <div className="flex flex-col gap-3 border-t border-slate-200 pt-5 sm:flex-row sm:items-center sm:justify-between">
+              <Link
+                to={detailPath}
+                className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-300 bg-white px-5 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-primary/25 hover:text-primary"
+              >
+                <BackIcon />
+                <span>Revenir au dossier</span>
+              </Link>
+              <button
+                type="submit"
+                disabled={isEmailSubmitting}
+                className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-primaryDark disabled:cursor-not-allowed disabled:bg-slate-300"
+              >
+                <SendIcon />
+                <span>{isEmailSubmitting ? "Envoi en cours..." : "Envoyer l'email"}</span>
+              </button>
+            </div>
+          </form>
+        </SectionCard>
+
+        <div className="space-y-6 xl:sticky xl:top-6">
+          <SectionCard
+            title="Dossier"
+            subtitle="Contexte de la demande pendant la rédaction."
+            motionDelay={240}
+          >
+            <div className="space-y-4">
+              <DetailField label="Famille">
+                {getApplicationFamilyTitle(application)}
+              </DetailField>
+              <DetailField label="Année scolaire">
+                {formatSchoolYearLabel(application.schoolYear.label)}
+              </DetailField>
+              <DetailField label="Statut">
+                <StatusBadge status={application.status} />
+              </DetailField>
+              <DetailField label="Contact">
+                {formatOptionalText(application.family.contactEmail)}
+              </DetailField>
+            </div>
+
+            <div className="mt-5 space-y-3">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                Élèves
+              </p>
+              {application.students.length === 0 ? (
+                <p className="rounded-2xl border border-dashed border-border bg-background/70 px-4 py-5 text-sm text-slate-500">
+                  Aucun élève rattaché.
+                </p>
+              ) : (
+                application.students.map((student) => (
+                  <div
+                    key={student.id}
+                    className="flex items-center gap-3 rounded-[24px] border border-slate-200/90 bg-slate-50/80 p-3"
+                  >
+                    <PersonAvatar
+                      label={`${student.firstName} ${student.lastName}`}
+                      size="sm"
+                      variant={getStudentAvatarVariant(student.gender)}
+                    />
+                    <div className="min-w-0 flex-1">
+                      <p className="break-words text-sm font-semibold text-slate-900">
+                        {student.firstName} {student.lastName}
+                      </p>
+                      <div className="mt-1 flex flex-wrap items-center gap-2">
+                        <LevelBadge
+                          code={student.level.code}
+                          label={student.level.label}
+                          size="xs"
+                        />
+                        <span className="text-xs font-medium text-slate-500">
+                          {student.level.label}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </SectionCard>
+
+          <SectionCard
+            title="Historique récent"
+            subtitle="Derniers emails enregistrés pour cette demande."
+            motionDelay={300}
+          >
+            {latestEmailLogs.length === 0 ? (
+              <p className="rounded-2xl border border-dashed border-border bg-background/70 px-4 py-6 text-sm text-slate-500">
+                Aucun email n'a encore été enregistré pour cette demande.
+              </p>
+            ) : (
+              <div className="space-y-3">
+                {latestEmailLogs.map((emailLog) => (
+                  <article
+                    key={emailLog.id}
+                    className="rounded-[24px] border border-slate-200/90 bg-slate-50/80 p-4"
+                  >
+                    <div className="flex flex-wrap gap-2">
+                      <span
+                        className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ring-1 ${applicationEmailTypeStyles[emailLog.emailType]}`}
+                      >
+                        {applicationEmailTypeLabels[emailLog.emailType]}
+                      </span>
+                      <span
+                        className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ring-1 ${applicationEmailSendStatusStyles[emailLog.sendStatus]}`}
+                      >
+                        {applicationEmailSendStatusLabels[emailLog.sendStatus]}
+                      </span>
+                    </div>
+                    <h3 className="mt-3 text-sm font-semibold leading-6 text-slate-900">
+                      {emailLog.subject}
+                    </h3>
+                    <p className="mt-1 text-xs font-medium uppercase tracking-[0.16em] text-slate-500">
+                      {formatOptionalDateTime(emailLog.sentAt ?? emailLog.createdAt)}
+                    </p>
+                  </article>
+                ))}
+              </div>
+            )}
+          </SectionCard>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ApplicationEmailPage;


### PR DESCRIPTION
## Objectif

Améliorer la page détail d’une demande pour la rendre plus lisible, plus structurée et plus proche d’une vraie interface métier d’administration, tout en gardant la cohérence visuelle du dashboard et de la liste des demandes.

## Contenu

### Structure générale
- refonte de la page détail en colonnes plus lisibles
- meilleure hiérarchie entre :
  - informations principales
  - famille
  - traitement
  - élèves
  - historique

### Haut de page
- simplification du haut de page
- suppression du bloc année active redondant
- suppression du bloc repères redondant
- conservation du bouton `Retour aux demandes`

### Informations principales
- transformation du bloc en vue famille plutôt qu’élève
- ajout d’un avatar groupe/famille
- affichage du ou des noms de famille uniquement
- conservation du statut de la demande
- affichage des niveaux/classes concernés par la demande

### Bloc Famille / Traitement
- réorganisation de la grille pour coller à la référence visuelle
- bloc `Traitement` repositionné en haut à droite
- bloc `Traitement` étendu sur 2 lignes visuelles (aligné avec Informations principales + Famille)
- correction des gaps et des espacements pour équilibrer les blocs gauche/droite
- suppression du scroll interne du bloc `Traitement`
- compactage du contenu pour tenir proprement dans l’espace disponible

### Bloc Traitement
- conservation des actions métier existantes :
  - changement de statut
  - priorité
  - décision
- suppression de l’affichage redondant de la note de décision dans ce bloc
- répartition verticale propre des sous-blocs internes
- bloc email étiré pour occuper l’espace restant jusqu’en bas
- texte email plus explicite

### Email
- suppression de la rédaction d’email inline dans la page détail
- remplacement par une action vers une page dédiée
- ajout d’une page dédiée :
  - `/applications/:id/email`

### Historique
- historique métier conservé
- meilleure lisibilité globale de la page

### Avatars fictifs
- ajout d’avatars fictifs standards pour :
  - enfants
  - parents
  - famille/groupe
- rendu cohérent avec la capture et le style admin

## Fichiers concernés

- `apps/web/src/pages/ApplicationDetailPage.tsx`
- `apps/web/src/pages/ApplicationEmailPage.tsx`
- `apps/web/src/components/ui/PersonAvatar.tsx`
- `apps/web/src/lib/applicationEmail.ts`
- `apps/web/src/App.tsx`

## Vérifications

- [x] `npm exec -w apps/web -- tsc -b`
- [x] `npm run build -w apps/web`
- [x] `npm run dev:web`

## Contrôles manuels à effectuer

- [ ] ouverture d’un détail de demande
- [ ] cohérence visuelle des colonnes
- [ ] statut / priorité / décision toujours fonctionnels
- [ ] bouton email redirige bien vers la page dédiée
- [ ] page `/applications/:id/email` bien servie
- [ ] avatars affichés correctement selon le contexte
- [ ] aucune régression navigation

## Notes

- aucune modification backend
- aucune modification Prisma / migrations / seeds / .env
- la page email est désormais dédiée, la page détail reste focalisée sur la consultation / le traitement
- cohérence renforcée avec le style visuel déjà posé sur le dashboard et la liste des demandes