### PR TITLE
fix(import): persist CSV import history

### DIFF
--- a/apps/api/src/controllers/import.controller.ts
+++ b/apps/api/src/controllers/import.controller.ts
@@ -5,6 +5,30 @@ import { buildApplicationImportHash, normalizeLevelLookupKey, parseCsvImportFile
 import { badRequest, notFound } from "../lib/errors";
 import { prisma } from "../prisma/client";
 
+const csvImportLogSelect = {
+  id: true,
+  fileName: true,
+  importedFamilies: true,
+  importedApplications: true,
+  importedStudents: true,
+  skippedRows: true,
+  duplicateRows: true,
+  invalidRows: true,
+  totalRows: true,
+  status: true,
+  createdAt: true,
+  schoolYear: {
+    select: {
+      id: true,
+      label: true
+    }
+  }
+} satisfies Prisma.CsvImportLogSelect;
+
+type CsvImportLogResponse = Prisma.CsvImportLogGetPayload<{
+  select: typeof csvImportLogSelect;
+}>;
+
 const ACCEPTED_CSV_MIME_TYPES = new Set([
   "application/csv",
   "application/vnd.ms-excel",
@@ -126,6 +150,36 @@ const buildFamilyUpdateData = (
   }
 
   return updateData;
+};
+
+const mapCsvImportLog = (log: CsvImportLogResponse) => {
+  return {
+    id: log.id,
+    fileName: log.fileName,
+    importedFamilies: log.importedFamilies,
+    importedApplications: log.importedApplications,
+    importedStudents: log.importedStudents,
+    skippedRows: log.skippedRows,
+    duplicateRows: log.duplicateRows,
+    invalidRows: log.invalidRows,
+    totalRows: log.totalRows,
+    status: log.status,
+    createdAt: log.createdAt,
+    schoolYearId: log.schoolYear?.id ?? null,
+    schoolYearLabel: log.schoolYear?.label ?? null
+  };
+};
+
+export const getCsvImportHistory = async (_req: Request, res: Response): Promise<void> => {
+  const importLogs = await prisma.csvImportLog.findMany({
+    orderBy: {
+      createdAt: "desc"
+    },
+    take: 50,
+    select: csvImportLogSelect
+  });
+
+  res.status(200).json(importLogs.map(mapCsvImportLog));
 };
 
 export const importCsv = async (req: Request, res: Response): Promise<void> => {
@@ -300,6 +354,21 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
     }
   }
 
+  const createdImportLog = await prisma.csvImportLog.create({
+    data: {
+      schoolYearId: activeSchoolYear.id,
+      fileName: file.originalname.trim().length > 0 ? file.originalname.trim() : null,
+      importedFamilies,
+      importedApplications,
+      importedStudents,
+      skippedRows: invalidRows + duplicateRows,
+      duplicateRows,
+      invalidRows,
+      totalRows: parsedImport.totalRows
+    },
+    select: csvImportLogSelect
+  });
+
   res.status(200).json({
     importedFamilies,
     importedApplications,
@@ -309,6 +378,7 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
     invalidRows,
     totalRows: parsedImport.totalRows,
     activeSchoolYear: activeSchoolYear.label,
-    delimiter: parsedImport.detectedDelimiter
+    delimiter: parsedImport.detectedDelimiter,
+    historyEntry: mapCsvImportLog(createdImportLog)
   });
 };

--- a/apps/api/src/routes/import.routes.ts
+++ b/apps/api/src/routes/import.routes.ts
@@ -2,7 +2,7 @@ import type { RequestHandler } from "express";
 import { Router } from "express";
 import multer from "multer";
 
-import { importCsv } from "../controllers/import.controller";
+import { getCsvImportHistory, importCsv } from "../controllers/import.controller";
 import { badRequest } from "../lib/errors";
 
 const router = Router();
@@ -25,6 +25,7 @@ const uploadCsvFile: RequestHandler = (req, res, next) => {
   });
 };
 
+router.get("/import/csv/history", getCsvImportHistory);
 router.post("/import/csv", uploadCsvFile, importCsv);
 
 export default router;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -12,7 +12,7 @@ import type {
   SchoolYearSummary
 } from "../types/application";
 import type { DashboardStats } from "../types/dashboard";
-import type { CsvImportSummary } from "../types/import";
+import type { CsvImportHistoryItem, CsvImportSummary } from "../types/import";
 
 const API_BASE_URL = (import.meta.env.VITE_API_URL ?? "").replace(/\/$/, "");
 
@@ -248,4 +248,10 @@ export const uploadCsvImport = async (
   }
 
   return (await response.json()) as CsvImportSummary;
+};
+
+export const getCsvImportHistory = async (
+  init?: RequestInit
+): Promise<CsvImportHistoryItem[]> => {
+  return fetchJson<CsvImportHistoryItem[]>("/api/import/csv/history", init);
 };

--- a/apps/web/src/pages/ImportCsvPage.tsx
+++ b/apps/web/src/pages/ImportCsvPage.tsx
@@ -4,18 +4,9 @@ import { Link } from "react-router-dom";
 
 import PageSectionHeader from "../components/layout/PageSectionHeader";
 import { useToast } from "../context/ToastContext";
-import { getActiveSchoolYear, uploadCsvImport } from "../lib/api";
+import { getActiveSchoolYear, getCsvImportHistory, uploadCsvImport } from "../lib/api";
 import type { SchoolYearSummary } from "../types/application";
-import type { CsvImportSummary } from "../types/import";
-
-const IMPORT_HISTORY_STORAGE_KEY = "csv_import_history";
-const MAX_IMPORT_HISTORY_ITEMS = 6;
-
-type ImportHistoryItem = CsvImportSummary & {
-  id: string;
-  fileName: string;
-  importedAt: string;
-};
+import type { CsvImportHistoryItem, CsvImportSummary } from "../types/import";
 
 type IconProps = {
   className?: string;
@@ -55,7 +46,7 @@ const pluralize = (count: number, singular: string, plural: string): string => {
   return `${numberFormatter.format(count)} ${count > 1 ? plural : singular}`;
 };
 
-const getImportHistoryResult = (item: ImportHistoryItem): string => {
+const getImportHistoryResult = (item: CsvImportHistoryItem): string => {
   return [
     pluralize(item.importedFamilies, "famille", "familles"),
     pluralize(item.importedApplications, "demande", "demandes"),
@@ -78,6 +69,14 @@ const getActiveSchoolYearErrorMessage = (error: unknown): string => {
   }
 
   return `Impossible de charger l'année scolaire active. ${error.message}`;
+};
+
+const getImportHistoryErrorMessage = (error: unknown): string => {
+  if (!(error instanceof Error) || error.message.trim().length === 0) {
+    return "Impossible de charger l'historique des imports.";
+  }
+
+  return `Impossible de charger l'historique des imports. ${error.message}`;
 };
 
 const getImportErrorMessage = (error: unknown): string => {
@@ -111,55 +110,6 @@ const getImportErrorMessage = (error: unknown): string => {
 
 const isCsvFile = (file: File): boolean => {
   return file.name.trim().toLowerCase().endsWith(".csv");
-};
-
-const isImportHistoryItem = (value: unknown): value is ImportHistoryItem => {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-
-  const candidate = value as Record<string, unknown>;
-
-  return (
-    typeof candidate.id === "string" &&
-    typeof candidate.fileName === "string" &&
-    typeof candidate.importedAt === "string" &&
-    typeof candidate.importedFamilies === "number" &&
-    typeof candidate.importedApplications === "number" &&
-    typeof candidate.importedStudents === "number" &&
-    typeof candidate.skippedRows === "number"
-  );
-};
-
-const readStoredImportHistory = (): ImportHistoryItem[] => {
-  try {
-    const rawValue = window.localStorage.getItem(IMPORT_HISTORY_STORAGE_KEY);
-
-    if (!rawValue) {
-      return [];
-    }
-
-    const parsedValue = JSON.parse(rawValue) as unknown;
-
-    if (!Array.isArray(parsedValue)) {
-      return [];
-    }
-
-    return parsedValue.filter(isImportHistoryItem).slice(0, MAX_IMPORT_HISTORY_ITEMS);
-  } catch {
-    return [];
-  }
-};
-
-const persistImportHistory = (items: ImportHistoryItem[]): void => {
-  try {
-    window.localStorage.setItem(
-      IMPORT_HISTORY_STORAGE_KEY,
-      JSON.stringify(items.slice(0, MAX_IMPORT_HISTORY_ITEMS))
-    );
-  } catch {
-    // Ignore storage write failures and keep the in-memory history.
-  }
 };
 
 const ChevronDownIcon = ({ className = "h-4 w-4" }: IconProps) => {
@@ -263,14 +213,12 @@ const ImportCsvPage = () => {
   const [activeSchoolYearError, setActiveSchoolYearError] = useState<string | null>(null);
   const [isLoadingActiveSchoolYear, setIsLoadingActiveSchoolYear] = useState(true);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const [history, setHistory] = useState<ImportHistoryItem[]>(() => readStoredImportHistory());
+  const [history, setHistory] = useState<CsvImportHistoryItem[]>([]);
+  const [historyError, setHistoryError] = useState<string | null>(null);
+  const [isLoadingHistory, setIsLoadingHistory] = useState(true);
   const [inlineMessage, setInlineMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
-
-  useEffect(() => {
-    persistImportHistory(history);
-  }, [history]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -308,11 +256,47 @@ const ImportCsvPage = () => {
     };
   }, []);
 
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const loadImportHistory = async (): Promise<void> => {
+      setIsLoadingHistory(true);
+      setHistoryError(null);
+
+      try {
+        const importHistory = await getCsvImportHistory({ signal: controller.signal });
+
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        setHistory(importHistory);
+      } catch (loadError) {
+        if (isAbortError(loadError) || controller.signal.aborted) {
+          return;
+        }
+
+        setHistory([]);
+        setHistoryError(getImportHistoryErrorMessage(loadError));
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoadingHistory(false);
+        }
+      }
+    };
+
+    void loadImportHistory();
+
+    return () => {
+      controller.abort();
+    };
+  }, []);
+
   const latestImport = history[0] ?? null;
   const activeSchoolYearLabel = activeSchoolYear
     ? formatSchoolYearLabel(activeSchoolYear.label)
-    : latestImport?.activeSchoolYear
-      ? formatSchoolYearLabel(latestImport.activeSchoolYear)
+    : latestImport?.schoolYearLabel
+      ? formatSchoolYearLabel(latestImport.schoolYearLabel)
       : "Non configurée";
 
   const openFilePicker = (): void => {
@@ -419,16 +403,14 @@ const ImportCsvPage = () => {
 
     try {
       const summary = await uploadCsvImport(selectedFile);
-      const nextHistoryItem: ImportHistoryItem = {
-        id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
-        fileName: selectedFile.name,
-        importedAt: new Date().toISOString(),
-        ...summary
-      };
 
-      setHistory((currentHistory) =>
-        [nextHistoryItem, ...currentHistory].slice(0, MAX_IMPORT_HISTORY_ITEMS)
-      );
+      if (summary.historyEntry) {
+        setHistory((currentHistory) => [
+          summary.historyEntry as CsvImportHistoryItem,
+          ...currentHistory.filter((item) => item.id !== summary.historyEntry?.id)
+        ]);
+      }
+
       clearSelectedFile();
       showSuccess(getImportSuccessMessage(summary));
     } catch (submitError) {
@@ -585,13 +567,13 @@ const ImportCsvPage = () => {
                   Résumé du dernier import
                 </h2>
                 <p className="mt-2 text-sm leading-6 text-slate-600">
-                  {latestImport.fileName} ·{" "}
-                  {dateTimeFormatter.format(new Date(latestImport.importedAt))}
+                  {latestImport.fileName ?? "Fichier non renseigné"} ·{" "}
+                  {dateTimeFormatter.format(new Date(latestImport.createdAt))}
                 </p>
               </div>
               <div className="rounded-full border border-secondary/20 bg-secondary/10 px-4 py-2 text-sm font-medium text-secondaryDark">
-                {latestImport.activeSchoolYear
-                  ? formatSchoolYearLabel(latestImport.activeSchoolYear)
+                {latestImport.schoolYearLabel
+                  ? formatSchoolYearLabel(latestImport.schoolYearLabel)
                   : activeSchoolYearLabel}
               </div>
             </div>
@@ -628,6 +610,12 @@ const ImportCsvPage = () => {
           </h2>
         </div>
 
+        {historyError ? (
+          <p className="border-b border-danger/10 bg-danger/5 px-5 py-4 text-sm text-danger sm:px-6">
+            {historyError}
+          </p>
+        ) : null}
+
         <div className="overflow-x-auto">
           <table className="min-w-full border-collapse text-left">
             <thead className="bg-white/45">
@@ -641,7 +629,16 @@ const ImportCsvPage = () => {
               </tr>
             </thead>
             <tbody>
-              {history.length === 0 ? (
+              {isLoadingHistory ? (
+                <tr>
+                  <td
+                    colSpan={2}
+                    className="px-5 py-6 text-center text-base text-slate-500 sm:px-6"
+                  >
+                    Chargement de l&apos;historique des imports...
+                  </td>
+                </tr>
+              ) : history.length === 0 ? (
                 <tr>
                   <td
                     colSpan={2}
@@ -655,9 +652,11 @@ const ImportCsvPage = () => {
                   <tr key={item.id} className="align-top">
                     <td className="border-b border-[#f2e9de] px-5 py-4 text-sm text-slate-700 sm:px-6">
                       <div className="font-medium text-slate-900">
-                        {dateTimeFormatter.format(new Date(item.importedAt))}
+                        {dateTimeFormatter.format(new Date(item.createdAt))}
                       </div>
-                      <div className="mt-1 text-slate-500">{item.fileName}</div>
+                      <div className="mt-1 text-slate-500">
+                        {item.fileName ?? "Fichier non renseigné"}
+                      </div>
                     </td>
                     <td className="border-b border-[#f2e9de] px-5 py-4 text-sm text-slate-700 sm:px-6">
                       <div className="font-medium text-slate-900">

--- a/apps/web/src/types/import.ts
+++ b/apps/web/src/types/import.ts
@@ -1,3 +1,21 @@
+export type CsvImportStatus = "SUCCESS" | "FAILED";
+
+export type CsvImportHistoryItem = {
+  id: string;
+  fileName: string | null;
+  importedFamilies: number;
+  importedApplications: number;
+  importedStudents: number;
+  skippedRows: number;
+  duplicateRows: number;
+  invalidRows: number;
+  totalRows: number;
+  status: CsvImportStatus;
+  createdAt: string;
+  schoolYearId: string | null;
+  schoolYearLabel: string | null;
+};
+
 export type CsvImportSummary = {
   importedFamilies: number;
   importedApplications: number;
@@ -8,4 +26,5 @@ export type CsvImportSummary = {
   totalRows?: number;
   activeSchoolYear?: string;
   delimiter?: string;
+  historyEntry?: CsvImportHistoryItem;
 };

--- a/prisma/migrations/20260424044406_add_csv_import_log/migration.sql
+++ b/prisma/migrations/20260424044406_add_csv_import_log/migration.sql
@@ -1,0 +1,33 @@
+-- CreateEnum
+CREATE TYPE "CsvImportStatus" AS ENUM ('SUCCESS', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "CsvImportLog" (
+    "id" TEXT NOT NULL,
+    "schoolYearId" TEXT,
+    "fileName" TEXT,
+    "importedFamilies" INTEGER NOT NULL DEFAULT 0,
+    "importedApplications" INTEGER NOT NULL DEFAULT 0,
+    "importedStudents" INTEGER NOT NULL DEFAULT 0,
+    "skippedRows" INTEGER NOT NULL DEFAULT 0,
+    "duplicateRows" INTEGER NOT NULL DEFAULT 0,
+    "invalidRows" INTEGER NOT NULL DEFAULT 0,
+    "totalRows" INTEGER NOT NULL DEFAULT 0,
+    "status" "CsvImportStatus" NOT NULL DEFAULT 'SUCCESS',
+    "errorMessage" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CsvImportLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "CsvImportLog_schoolYearId_idx" ON "CsvImportLog"("schoolYearId");
+
+-- CreateIndex
+CREATE INDEX "CsvImportLog_createdAt_idx" ON "CsvImportLog"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "CsvImportLog_status_idx" ON "CsvImportLog"("status");
+
+-- AddForeignKey
+ALTER TABLE "CsvImportLog" ADD CONSTRAINT "CsvImportLog_schoolYearId_fkey" FOREIGN KEY ("schoolYearId") REFERENCES "SchoolYear"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,6 +31,11 @@ enum EmailSendStatus {
   FAILED
 }
 
+enum CsvImportStatus {
+  SUCCESS
+  FAILED
+}
+
 model SchoolYear {
   id           String        @id @default(cuid())
   label        String        @unique
@@ -38,6 +43,7 @@ model SchoolYear {
   endYear      Int
   isActive     Boolean       @default(false)
   applications Application[]
+  csvImportLogs CsvImportLog[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -143,4 +149,26 @@ model ApplicationEmailLog {
 
   @@index([applicationId])
   @@index([sendStatus])
+}
+
+model CsvImportLog {
+  id                   String          @id @default(cuid())
+  schoolYearId         String?
+  fileName             String?
+  importedFamilies     Int             @default(0)
+  importedApplications Int             @default(0)
+  importedStudents     Int             @default(0)
+  skippedRows          Int             @default(0)
+  duplicateRows        Int             @default(0)
+  invalidRows          Int             @default(0)
+  totalRows            Int             @default(0)
+  status               CsvImportStatus @default(SUCCESS)
+  errorMessage         String?
+  createdAt            DateTime        @default(now())
+
+  schoolYear SchoolYear? @relation(fields: [schoolYearId], references: [id], onDelete: SetNull)
+
+  @@index([schoolYearId])
+  @@index([createdAt])
+  @@index([status])
 }


### PR DESCRIPTION
## Objectif

Corriger la perte de l’historique d’import CSV après redémarrage de l’application.

## Diagnostic

L’historique n’était pas réellement persistant :
- aucun log d’import n’était stocké côté backend
- `POST /api/import/csv` ne créait pas de trace durable
- la page Import CSV dépendait d’un historique local côté frontend

Conséquence :
- les données importées restaient bien en BDD
- mais l’historique disparaissait après redémarrage

## Correctif

### Backend
- ajout d’un modèle Prisma `CsvImportLog`
- ajout d’un enum `CsvImportStatus`
- création d’une migration dédiée :
  - `20260424044406_add_csv_import_log`
- création d’un log à chaque import CSV réussi
- ajout de l’endpoint :
  - `GET /api/import/csv/history`
- tri de l’historique par `createdAt DESC`
- enrichissement de la réponse `POST /api/import/csv` avec `historyEntry`

### Frontend
- chargement de l’historique depuis l’API au montage de la page Import CSV
- suppression de la dépendance à l’historique local non persistant
- ajout immédiat de l’entrée retournée après import réussi
- conservation du design existant

## Fichiers concernés

- `prisma/schema.prisma`
- `prisma/migrations/20260424044406_add_csv_import_log/migration.sql`
- `apps/api/src/controllers/import.controller.ts`
- `apps/api/src/routes/import.routes.ts`
- `apps/web/src/pages/ImportCsvPage.tsx`
- `apps/web/src/lib/api.ts`
- `apps/web/src/types/import.ts`

## Vérifications

- [x] `npx tsc --noEmit -p apps/api/tsconfig.json`
- [x] `npm exec -w apps/web -- tsc -b`
- [x] `npm run build -w apps/web`
- [x] `npm run dev:api`
- [x] `npm run dev:web`

## Validation fonctionnelle

- [x] import CSV valide
- [x] historique visible après import
- [x] arrêt complet API + frontend
- [x] relance complète API + frontend
- [x] historique toujours présent
- [x] second import du même fichier avec `duplicateRows: 1`
- [x] historique trié du plus récent au plus ancien
- [x] données de test supprimées après validation

## Résultat

L’historique d’import CSV est maintenant réellement persistant et fiable après redémarrage complet de l’application.