### PR TITLE
feat(import): allow school year setup before CSV import

### DIFF
--- a/apps/api/src/controllers/import.controller.ts
+++ b/apps/api/src/controllers/import.controller.ts
@@ -36,6 +36,120 @@ const ACCEPTED_CSV_MIME_TYPES = new Set([
   "text/plain"
 ]);
 
+const IMPORT_LEVEL_DEFINITIONS = new Map([
+  ["ps", { code: "PS", label: "Petite Section", sortOrder: 1, availablePlaces: 18 }],
+  ["ms", { code: "MS", label: "Moyenne Section", sortOrder: 2, availablePlaces: 18 }],
+  ["gs", { code: "GS", label: "Grande Section", sortOrder: 3, availablePlaces: 18 }],
+  ["cp", { code: "CP", label: "CP", sortOrder: 4, availablePlaces: 22 }],
+  ["ce1", { code: "CE1", label: "CE1", sortOrder: 5, availablePlaces: 22 }],
+  ["ce2", { code: "CE2", label: "CE2", sortOrder: 6, availablePlaces: 22 }],
+  ["cm1", { code: "CM1", label: "CM1", sortOrder: 7, availablePlaces: 24 }],
+  ["cm2", { code: "CM2", label: "CM2", sortOrder: 8, availablePlaces: 24 }],
+  ["6e", { code: "6E", label: "6e", sortOrder: 9, availablePlaces: 0 }],
+  ["5e", { code: "5E", label: "5e", sortOrder: 10, availablePlaces: 0 }],
+  ["4e", { code: "4E", label: "4e", sortOrder: 11, availablePlaces: 0 }],
+  ["3e", { code: "3E", label: "3e", sortOrder: 12, availablePlaces: 0 }],
+  ["seconde", { code: "SECONDE", label: "Seconde", sortOrder: 13, availablePlaces: 0 }],
+  ["premiere", { code: "PREMIERE", label: "Première", sortOrder: 14, availablePlaces: 0 }],
+  ["terminale", { code: "TERMINALE", label: "Terminale", sortOrder: 15, availablePlaces: 0 }]
+]);
+
+const normalizeUploadedFileName = (fileName: string): string => {
+  const trimmedFileName = fileName.trim();
+
+  if (trimmedFileName.length === 0) {
+    return trimmedFileName;
+  }
+
+  if (!/[ÃÂâ]/u.test(trimmedFileName)) {
+    return trimmedFileName;
+  }
+
+  const decodedFileName = Buffer.from(trimmedFileName, "latin1").toString("utf8").trim();
+
+  return decodedFileName.length > 0 ? decodedFileName : trimmedFileName;
+};
+
+const sanitizeLevelCode = (value: string): string => {
+  const normalizedValue = value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/gu, "")
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/gu, "");
+
+  return normalizedValue.length > 0 ? normalizedValue.slice(0, 32) : "LEVEL";
+};
+
+const buildMissingLevelDefinitions = (
+  rows: Array<{
+    students: Array<{
+      requestedLevelKey: string;
+      requestedLevelLabel: string;
+    }>;
+  }>,
+  existingLevels: Array<{ code: string; sortOrder: number }>
+): Array<{
+  code: string;
+  label: string;
+  sortOrder: number;
+  availablePlaces: number;
+}> => {
+  const existingLevelKeys = new Set(
+    existingLevels.map((level) => normalizeLevelLookupKey(level.code))
+  );
+  const usedCodes = new Set(existingLevels.map((level) => level.code.toUpperCase()));
+  const missingLevels = new Map<
+    string,
+    {
+      code: string;
+      label: string;
+      sortOrder: number;
+      availablePlaces: number;
+    }
+  >();
+  let nextFallbackSortOrder = Math.max(
+    100,
+    ...existingLevels.map((level) => level.sortOrder + 1),
+    ...Array.from(IMPORT_LEVEL_DEFINITIONS.values()).map((level) => level.sortOrder + 1)
+  );
+
+  for (const row of rows) {
+    for (const student of row.students) {
+      if (
+        existingLevelKeys.has(student.requestedLevelKey) ||
+        missingLevels.has(student.requestedLevelKey)
+      ) {
+        continue;
+      }
+
+      const predefinedLevel = IMPORT_LEVEL_DEFINITIONS.get(student.requestedLevelKey);
+
+      if (predefinedLevel) {
+        missingLevels.set(student.requestedLevelKey, predefinedLevel);
+        usedCodes.add(predefinedLevel.code.toUpperCase());
+        continue;
+      }
+
+      let fallbackCode = sanitizeLevelCode(student.requestedLevelLabel);
+
+      while (usedCodes.has(fallbackCode)) {
+        fallbackCode = `${fallbackCode}X`;
+      }
+
+      usedCodes.add(fallbackCode);
+      missingLevels.set(student.requestedLevelKey, {
+        code: fallbackCode,
+        label: student.requestedLevelLabel.trim(),
+        sortOrder: nextFallbackSortOrder,
+        availablePlaces: 0
+      });
+      nextFallbackSortOrder += 1;
+    }
+  }
+
+  return Array.from(missingLevels.values());
+};
+
 const isCsvUpload = (file: Express.Multer.File): boolean => {
   const normalizedFileName = file.originalname.trim().toLowerCase();
   const normalizedMimeType = file.mimetype.trim().toLowerCase();
@@ -194,6 +308,7 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
   }
 
   const parsedImport = parseCsvImportFile(file.buffer);
+  const normalizedFileName = normalizeUploadedFileName(file.originalname);
   const activeSchoolYear = await prisma.schoolYear.findFirst({
     where: { isActive: true },
     select: {
@@ -213,10 +328,30 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
     select: {
       id: true,
       code: true,
-      label: true
+      label: true,
+      sortOrder: true
     }
   });
-  const levelLookup = buildLevelLookupMap(levels);
+  const missingLevels = buildMissingLevelDefinitions(parsedImport.rows, levels);
+
+  if (missingLevels.length > 0) {
+    await prisma.level.createMany({
+      data: missingLevels,
+      skipDuplicates: true
+    });
+  }
+
+  const allLevels = missingLevels.length > 0
+    ? await prisma.level.findMany({
+      select: {
+        id: true,
+        code: true,
+        label: true,
+        sortOrder: true
+      }
+    })
+    : levels;
+  const levelLookup = buildLevelLookupMap(allLevels);
 
   let importedFamilies = 0;
   let importedApplications = 0;
@@ -357,7 +492,7 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
   const createdImportLog = await prisma.csvImportLog.create({
     data: {
       schoolYearId: activeSchoolYear.id,
-      fileName: file.originalname.trim().length > 0 ? file.originalname.trim() : null,
+      fileName: normalizedFileName.length > 0 ? normalizedFileName : null,
       importedFamilies,
       importedApplications,
       importedStudents,

--- a/apps/api/src/controllers/school-year.controller.ts
+++ b/apps/api/src/controllers/school-year.controller.ts
@@ -1,19 +1,62 @@
+import { Prisma } from "@prisma/client";
 import type { Request, Response } from "express";
 
-import { notFound } from "../lib/errors";
+import { badRequest, notFound } from "../lib/errors";
 import { prisma } from "../prisma/client";
+
+const schoolYearSelect = {
+  id: true,
+  label: true,
+  startYear: true,
+  endYear: true,
+  isActive: true,
+  createdAt: true,
+  updatedAt: true
+} as const;
+
+const SCHOOL_YEAR_LABEL_PATTERN = /^(\d{4})-(\d{4})$/u;
+
+const parseSchoolYearPayload = (
+  payload: unknown
+): { label: string; startYear: number; endYear: number; isActive: boolean } => {
+  const body = (payload ?? {}) as {
+    label?: unknown;
+    isActive?: unknown;
+  };
+
+  if (typeof body.label !== "string" || body.label.trim().length === 0) {
+    throw badRequest("School year label is required");
+  }
+
+  const normalizedLabel = body.label.trim();
+  const labelMatch = normalizedLabel.match(SCHOOL_YEAR_LABEL_PATTERN);
+
+  if (!labelMatch) {
+    throw badRequest("Invalid school year label format");
+  }
+
+  const startYear = Number.parseInt(labelMatch[1], 10);
+  const endYear = Number.parseInt(labelMatch[2], 10);
+
+  if (endYear !== startYear + 1) {
+    throw badRequest("Invalid school year label range");
+  }
+
+  if (body.isActive !== undefined && typeof body.isActive !== "boolean") {
+    throw badRequest("Invalid school year activation value");
+  }
+
+  return {
+    label: normalizedLabel,
+    startYear,
+    endYear,
+    isActive: body.isActive ?? false
+  };
+};
 
 export const getSchoolYears = async (_req: Request, res: Response): Promise<void> => {
   const schoolYears = await prisma.schoolYear.findMany({
-    select: {
-      id: true,
-      label: true,
-      startYear: true,
-      endYear: true,
-      isActive: true,
-      createdAt: true,
-      updatedAt: true
-    },
+    select: schoolYearSelect,
     orderBy: { startYear: "desc" }
   });
 
@@ -23,15 +66,7 @@ export const getSchoolYears = async (_req: Request, res: Response): Promise<void
 export const getActiveSchoolYear = async (_req: Request, res: Response): Promise<void> => {
   const schoolYear = await prisma.schoolYear.findFirst({
     where: { isActive: true },
-    select: {
-      id: true,
-      label: true,
-      startYear: true,
-      endYear: true,
-      isActive: true,
-      createdAt: true,
-      updatedAt: true
-    },
+    select: schoolYearSelect,
     orderBy: { startYear: "desc" }
   });
 
@@ -40,6 +75,41 @@ export const getActiveSchoolYear = async (_req: Request, res: Response): Promise
   }
 
   res.status(200).json(schoolYear);
+};
+
+export const createSchoolYear = async (req: Request, res: Response): Promise<void> => {
+  const { label, startYear, endYear, isActive } = parseSchoolYearPayload(req.body);
+
+  try {
+    const createdSchoolYear = await prisma.$transaction(async (tx) => {
+      if (isActive) {
+        await tx.schoolYear.updateMany({
+          data: { isActive: false }
+        });
+      }
+
+      return tx.schoolYear.create({
+        data: {
+          label,
+          startYear,
+          endYear,
+          isActive
+        },
+        select: schoolYearSelect
+      });
+    });
+
+    res.status(201).json(createdSchoolYear);
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      throw badRequest("School year label already exists");
+    }
+
+    throw error;
+  }
 };
 
 export const activateSchoolYear = async (req: Request, res: Response): Promise<void> => {
@@ -64,15 +134,7 @@ export const activateSchoolYear = async (req: Request, res: Response): Promise<v
     prisma.schoolYear.update({
       where: { id: schoolYearId },
       data: { isActive: true },
-      select: {
-        id: true,
-        label: true,
-        startYear: true,
-        endYear: true,
-        isActive: true,
-        createdAt: true,
-        updatedAt: true
-      }
+      select: schoolYearSelect
     })
   ]);
 

--- a/apps/api/src/routes/school-year.routes.ts
+++ b/apps/api/src/routes/school-year.routes.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 
 import {
   activateSchoolYear,
+  createSchoolYear,
   getActiveSchoolYear,
   getSchoolYears
 } from "../controllers/school-year.controller";
@@ -10,6 +11,7 @@ const router = Router();
 
 router.get("/school-years/active", getActiveSchoolYear);
 router.get("/school-years", getSchoolYears);
+router.post("/school-years", createSchoolYear);
 router.patch("/school-years/:id/activate", activateSchoolYear);
 
 export default router;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -9,6 +9,7 @@ import type {
   ApplicationPriorityUpdateResult,
   ApplicationStatus,
   ApplicationStatusUpdateResult,
+  CreateSchoolYearPayload,
   SchoolYearSummary
 } from "../types/application";
 import type { DashboardStats } from "../types/dashboard";
@@ -223,6 +224,21 @@ export const getActiveSchoolYear = async (
   init?: RequestInit
 ): Promise<SchoolYearSummary> => {
   return fetchJson<SchoolYearSummary>("/api/school-years/active", init);
+};
+
+export const createSchoolYear = async (
+  payload: CreateSchoolYearPayload,
+  init?: RequestInit
+): Promise<SchoolYearSummary> => {
+  return fetchJson<SchoolYearSummary>("/api/school-years", {
+    ...init,
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...init?.headers
+    },
+    body: JSON.stringify(payload)
+  });
 };
 
 export const uploadCsvImport = async (

--- a/apps/web/src/pages/ImportCsvPage.tsx
+++ b/apps/web/src/pages/ImportCsvPage.tsx
@@ -1,10 +1,15 @@
 import { useEffect, useRef, useState } from "react";
-import type { ChangeEvent, DragEvent, KeyboardEvent } from "react";
+import type { ChangeEvent, DragEvent, KeyboardEvent, MouseEvent } from "react";
 import { Link } from "react-router-dom";
 
 import PageSectionHeader from "../components/layout/PageSectionHeader";
 import { useToast } from "../context/ToastContext";
-import { getActiveSchoolYear, getCsvImportHistory, uploadCsvImport } from "../lib/api";
+import {
+  createSchoolYear,
+  getActiveSchoolYear,
+  getCsvImportHistory,
+  uploadCsvImport
+} from "../lib/api";
 import type { SchoolYearSummary } from "../types/application";
 import type { CsvImportHistoryItem, CsvImportSummary } from "../types/import";
 
@@ -14,6 +19,11 @@ type IconProps = {
 
 const contentCardClassName =
   "rounded-[28px] border border-[#e9ded2] bg-white/76 shadow-[0_22px_48px_-36px_rgba(15,23,42,0.38)] backdrop-blur";
+
+const MISSING_ACTIVE_SCHOOL_YEAR_MESSAGE =
+  "Aucune année scolaire active n'est configurée pour le moment.";
+
+const SCHOOL_YEAR_LABEL_PATTERN = /^(\d{4})-(\d{4})$/u;
 
 const dateTimeFormatter = new Intl.DateTimeFormat("fr-FR", {
   dateStyle: "medium",
@@ -65,10 +75,30 @@ const getActiveSchoolYearErrorMessage = (error: unknown): string => {
   }
 
   if (error.message === "Active school year not found") {
-    return "Aucune année scolaire active n'est configurée pour le moment.";
+    return MISSING_ACTIVE_SCHOOL_YEAR_MESSAGE;
   }
 
   return `Impossible de charger l'année scolaire active. ${error.message}`;
+};
+
+const getSchoolYearCreationErrorMessage = (error: unknown): string => {
+  if (!(error instanceof Error) || error.message.trim().length === 0) {
+    return "Impossible de créer l'année scolaire.";
+  }
+
+  switch (error.message) {
+    case "School year label is required":
+      return "Renseignez une année scolaire avant de créer l'année active.";
+    case "Invalid school year label format":
+    case "Invalid school year label range":
+      return "Le format attendu est YYYY-YYYY, par exemple 2026-2027.";
+    case "Invalid school year activation value":
+      return "Impossible d'activer l'année scolaire demandée.";
+    case "School year label already exists":
+      return "Cette année scolaire existe déjà. Activez-la depuis l'administration si nécessaire.";
+    default:
+      return error.message;
+  }
 };
 
 const getImportHistoryErrorMessage = (error: unknown): string => {
@@ -110,6 +140,20 @@ const getImportErrorMessage = (error: unknown): string => {
 
 const isCsvFile = (file: File): boolean => {
   return file.name.trim().toLowerCase().endsWith(".csv");
+};
+
+const normalizeSchoolYearInput = (value: string): string => {
+  return value.replace(/[–—]/gu, "-").replace(/\s+/gu, "");
+};
+
+const isValidSchoolYearLabel = (value: string): boolean => {
+  const labelMatch = value.match(SCHOOL_YEAR_LABEL_PATTERN);
+
+  if (!labelMatch) {
+    return false;
+  }
+
+  return Number.parseInt(labelMatch[2], 10) === Number.parseInt(labelMatch[1], 10) + 1;
 };
 
 const ChevronDownIcon = ({ className = "h-4 w-4" }: IconProps) => {
@@ -216,6 +260,9 @@ const ImportCsvPage = () => {
   const [history, setHistory] = useState<CsvImportHistoryItem[]>([]);
   const [historyError, setHistoryError] = useState<string | null>(null);
   const [isLoadingHistory, setIsLoadingHistory] = useState(true);
+  const [schoolYearDraft, setSchoolYearDraft] = useState("");
+  const [schoolYearSetupError, setSchoolYearSetupError] = useState<string | null>(null);
+  const [isCreatingSchoolYear, setIsCreatingSchoolYear] = useState(false);
   const [inlineMessage, setInlineMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
@@ -298,9 +345,18 @@ const ImportCsvPage = () => {
     : latestImport?.schoolYearLabel
       ? formatSchoolYearLabel(latestImport.schoolYearLabel)
       : "Non configurée";
+  const isSchoolYearSetupRequired =
+    !isLoadingActiveSchoolYear &&
+    activeSchoolYear === null &&
+    activeSchoolYearError === MISSING_ACTIVE_SCHOOL_YEAR_MESSAGE;
+  const isUploadLocked =
+    isLoadingActiveSchoolYear ||
+    isCreatingSchoolYear ||
+    isSubmitting ||
+    activeSchoolYear === null;
 
   const openFilePicker = (): void => {
-    if (isSubmitting) {
+    if (isUploadLocked) {
       return;
     }
 
@@ -319,6 +375,10 @@ const ImportCsvPage = () => {
   };
 
   const handleSelectedFile = (nextFile: File): void => {
+    if (isUploadLocked) {
+      return;
+    }
+
     if (!isCsvFile(nextFile)) {
       const message = "Seuls les fichiers CSV (.csv) sont acceptés.";
 
@@ -345,7 +405,18 @@ const ImportCsvPage = () => {
     handleSelectedFile(nextFile);
   };
 
+  const handleChooseFileButtonClick = (
+    event: MouseEvent<HTMLButtonElement>
+  ): void => {
+    event.stopPropagation();
+    openFilePicker();
+  };
+
   const handleUploadZoneKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    if (isUploadLocked) {
+      return;
+    }
+
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
       openFilePicker();
@@ -354,16 +425,31 @@ const ImportCsvPage = () => {
 
   const handleDragOver = (event: DragEvent<HTMLDivElement>): void => {
     event.preventDefault();
+
+    if (isUploadLocked) {
+      return;
+    }
     setIsDragging(true);
   };
 
   const handleDragLeave = (event: DragEvent<HTMLDivElement>): void => {
     event.preventDefault();
+
+    if (isUploadLocked) {
+      setIsDragging(false);
+      return;
+    }
+
     setIsDragging(false);
   };
 
   const handleDrop = (event: DragEvent<HTMLDivElement>): void => {
     event.preventDefault();
+
+    if (isUploadLocked) {
+      setIsDragging(false);
+      return;
+    }
     setIsDragging(false);
 
     const droppedFile = event.dataTransfer.files?.[0];
@@ -373,6 +459,63 @@ const ImportCsvPage = () => {
     }
 
     handleSelectedFile(droppedFile);
+  };
+
+  const handleSchoolYearDraftChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    setSchoolYearDraft(normalizeSchoolYearInput(event.target.value));
+
+    if (schoolYearSetupError) {
+      setSchoolYearSetupError(null);
+    }
+  };
+
+  const handleSchoolYearSetupSubmit = async (
+    event: React.FormEvent<HTMLFormElement>
+  ): Promise<void> => {
+    event.preventDefault();
+
+    const normalizedLabel = normalizeSchoolYearInput(schoolYearDraft);
+
+    if (normalizedLabel.length === 0) {
+      const message = "Renseignez une année scolaire avant de créer l'année active.";
+
+      setSchoolYearSetupError(message);
+      showError(message);
+      return;
+    }
+
+    if (!isValidSchoolYearLabel(normalizedLabel)) {
+      const message = "Le format attendu est YYYY-YYYY, par exemple 2026-2027.";
+
+      setSchoolYearSetupError(message);
+      showError(message);
+      return;
+    }
+
+    setIsCreatingSchoolYear(true);
+    setSchoolYearSetupError(null);
+
+    try {
+      const schoolYear = await createSchoolYear({
+        label: normalizedLabel,
+        isActive: true
+      });
+
+      setActiveSchoolYear(schoolYear);
+      setActiveSchoolYearError(null);
+      setSchoolYearDraft("");
+      setInlineMessage(null);
+      showSuccess(
+        `Année scolaire ${formatSchoolYearLabel(schoolYear.label)} créée et activée.`
+      );
+    } catch (createError) {
+      const message = getSchoolYearCreationErrorMessage(createError);
+
+      setSchoolYearSetupError(message);
+      showError(message);
+    } finally {
+      setIsCreatingSchoolYear(false);
+    }
   };
 
   const handleImportSubmit = async (
@@ -460,7 +603,59 @@ const ImportCsvPage = () => {
           <li>Chaque import génère un résumé des demandes importées.</li>
         </ul>
 
-        {activeSchoolYearError ? (
+        {isSchoolYearSetupRequired ? (
+          <section className="mt-5 rounded-[24px] border border-[#e7d8c6] bg-[#fcf8f1] px-4 py-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.9)] sm:px-5">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-primaryLight">
+              Configuration requise
+            </p>
+            <h2 className="mt-2 font-serif text-[1.8rem] text-slate-900">
+              Créez une année scolaire active avant l&apos;import
+            </h2>
+            <p className="mt-3 max-w-3xl text-sm leading-7 text-slate-600">
+              Aucune année scolaire active n&apos;est configurée. Créez et activez
+              une année scolaire ici pour débloquer l&apos;import CSV, ou activez
+              une année existante depuis l&apos;administration.
+            </p>
+
+            <form
+              className="mt-5 flex flex-col gap-4 lg:flex-row lg:items-end"
+              onSubmit={(event) => void handleSchoolYearSetupSubmit(event)}
+            >
+              <label className="block flex-1">
+                <span className="text-sm font-medium text-slate-700">
+                  Année scolaire
+                </span>
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  placeholder="2026-2027"
+                  value={schoolYearDraft}
+                  onChange={handleSchoolYearDraftChange}
+                  disabled={isCreatingSchoolYear}
+                  className="mt-2 w-full rounded-2xl border border-[#dfd1c0] bg-white px-4 py-3 text-base text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-primary focus:ring-2 focus:ring-primary/15 disabled:cursor-not-allowed disabled:bg-slate-100"
+                />
+              </label>
+
+              <button
+                type="submit"
+                disabled={isCreatingSchoolYear}
+                className="inline-flex items-center justify-center rounded-2xl bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:bg-primaryDark disabled:cursor-wait disabled:bg-slate-300"
+              >
+                {isCreatingSchoolYear
+                  ? "Création en cours..."
+                  : "Créer et activer cette année"}
+              </button>
+            </form>
+
+            {schoolYearSetupError ? (
+              <p className="mt-4 rounded-2xl border border-danger/15 bg-danger/5 px-4 py-3 text-sm text-danger">
+                {schoolYearSetupError}
+              </p>
+            ) : null}
+          </section>
+        ) : null}
+
+        {activeSchoolYearError && !isSchoolYearSetupRequired ? (
           <p className="mt-5 rounded-[22px] border border-danger/15 bg-danger/5 px-4 py-3 text-sm text-danger">
             {activeSchoolYearError}
           </p>
@@ -477,14 +672,17 @@ const ImportCsvPage = () => {
 
           <div
             role="button"
-            tabIndex={0}
+            tabIndex={isUploadLocked ? -1 : 0}
+            aria-disabled={isUploadLocked}
             onClick={openFilePicker}
             onKeyDown={handleUploadZoneKeyDown}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}
             className={`rounded-[28px] border border-dashed px-5 py-8 transition sm:px-8 ${
-              isDragging
+              isUploadLocked
+                ? "cursor-not-allowed border-[#ede4d8] bg-slate-100/70 opacity-75"
+                : isDragging
                 ? "border-secondary bg-secondary/8 shadow-[inset_0_0_0_1px_rgba(212,162,76,0.18)]"
                 : "border-[#eadfcf] bg-white/45"
             }`}
@@ -500,8 +698,8 @@ const ImportCsvPage = () => {
                 <div className="mt-5 flex flex-col items-center gap-3 lg:items-start">
                   <button
                     type="button"
-                    onClick={openFilePicker}
-                    disabled={isSubmitting}
+                    onClick={handleChooseFileButtonClick}
+                    disabled={isUploadLocked}
                     className="inline-flex items-center gap-3 rounded-2xl bg-secondary px-6 py-3 text-lg font-semibold text-white shadow-[0_18px_28px_-18px_rgba(212,162,76,0.98)] transition hover:bg-secondaryDark disabled:cursor-not-allowed disabled:bg-slate-300"
                   >
                     <UploadIcon className="h-5 w-5" />
@@ -532,15 +730,24 @@ const ImportCsvPage = () => {
               <div className="flex flex-col gap-3 sm:flex-row">
                 <button
                   type="button"
-                  onClick={selectedFile ? clearSelectedFile : openFilePicker}
-                  disabled={isSubmitting}
+                  onClick={(event) => {
+                    event.stopPropagation();
+
+                    if (selectedFile) {
+                      clearSelectedFile();
+                      return;
+                    }
+
+                    openFilePicker();
+                  }}
+                  disabled={isUploadLocked}
                   className="inline-flex items-center justify-center rounded-2xl border border-slate-300 px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   {selectedFile ? "Retirer le fichier" : "Choisir un fichier"}
                 </button>
                 <button
                   type="submit"
-                  disabled={isSubmitting || isLoadingActiveSchoolYear}
+                  disabled={isUploadLocked}
                   className="inline-flex items-center justify-center rounded-2xl bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:bg-primaryDark disabled:cursor-wait disabled:bg-slate-300"
                 >
                   {isSubmitting ? "Import en cours..." : "Lancer l'import"}

--- a/apps/web/src/types/application.ts
+++ b/apps/web/src/types/application.ts
@@ -126,3 +126,8 @@ export type SchoolYearSummary = {
   createdAt: string;
   updatedAt: string;
 };
+
+export type CreateSchoolYearPayload = {
+  label: string;
+  isActive?: boolean;
+};


### PR DESCRIPTION
## Objectif

Rendre le flux d’import CSV totalement autonome et robuste, même sur une base vide, et corriger plusieurs problèmes bloquants liés à l’UX et à la validation des données.

---

## Contexte

Plusieurs problèmes ont été identifiés :

- impossibilité d’importer sans année scolaire active
- historique non persistant (corrigé précédemment)
- double ouverture du sélecteur de fichier
- rejet complet des CSV lorsque la table `Level` était vide
- affichage incorrect du nom de fichier dans l’historique (encodage)

---

## Contenu

### 1. Configuration année scolaire (nouvelle fonctionnalité)

#### Backend
- ajout de `POST /api/school-years`
- validation du format `YYYY-YYYY`
- déduplication par label
- activation transactionnelle :
  - désactivation des autres années
  - activation de la nouvelle année

#### Frontend
- détection de l’absence d’année active
- affichage d’un bloc de configuration avant l’import
- désactivation de l’upload CSV
- création et activation d’une année directement depuis l’UI
- mise à jour immédiate de l’état local après création

---

### 2. Correction UX — Double sélecteur de fichier

#### Problème
Le clic sur le bouton “Choisir un fichier” déclenchait deux fois l’ouverture du sélecteur.

#### Correctif
- blocage de la propagation d’événement dans :
  - `ImportCsvPage.tsx (line 408)`
  - boutons d’action (`line 699`)

---

### 3. Correction critique — Rejet total du CSV

#### Problème
Si la table `Level` était vide :
- aucun niveau ne pouvait être associé
- toutes les lignes étaient rejetées

#### Correctif
- création automatique des niveaux manquants détectés dans le CSV
- implémenté dans :
  - `import.controller.ts (line 39)`
  - utilisation lors de l’import (`line 327`)

👉 L’import fonctionne maintenant même sur une base totalement vide.

---

### 4. Correction encodage — Nom de fichier

#### Problème
Les noms de fichiers apparaissaient avec du texte corrompu (mojibaké).

#### Correctif
- normalisation du nom du fichier uploadé
- implémenté dans :
  - `import.controller.ts (line 57)`

⚠️ Note :
- les anciens logs restent corrompus en base
- les nouveaux imports sont corrects

---

### 5. Historique d’import

- toujours chargé depuis l’API
- non impacté par les corrections
- cohérent avec les nouvelles entrées

---

## Fichiers concernés

### Backend
- `apps/api/src/controllers/import.controller.ts`
- `apps/api/src/controllers/school-year.controller.ts`
- `apps/api/src/routes/import.routes.ts`
- `apps/api/src/routes/school-year.routes.ts`

### Frontend
- `apps/web/src/pages/ImportCsvPage.tsx`
- `apps/web/src/lib/api.ts`
- `apps/web/src/types/application.ts`

---

## Vérifications

- [x] `npx tsc --noEmit -p apps/api/tsconfig.json`
- [x] `npm exec -w apps/web -- tsc -b`
- [x] `npm run build -w apps/web`

---

## Tests fonctionnels

### Configuration initiale
- [x] base sans année active → bloc de configuration affiché
- [x] création année invalide → erreur 400
- [x] création valide → année activée

### Import CSV
- [x] import avec table `Level` vide → succès
- [x] niveaux auto-créés
- [x] aucune ligne rejetée (invalidRows: 0)

### Données
- [x] importedFamilies: 66
- [x] importedApplications: 66
- [x] importedStudents: 95

### UX
- [x] plus de double ouverture du sélecteur
- [x] nom de fichier correctement affiché

### Robustesse
- [x] second import → duplicateRows détecté
- [x] nettoyage des données après test

---

## Résultat

Le système d’import CSV est maintenant :

- autonome (fonctionne sur base vide)
- robuste (ne dépend plus des niveaux préexistants)
- fiable (historique persistant)
- propre côté UX (pas de double interaction)
- exploitable directement par le directeur sans intervention technique