### PR TITLE
feat(ui): prepare school year navigation

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,6 +10,7 @@ import ApplicationsPage from "./pages/ApplicationsPage";
 import DashboardPage from "./pages/DashboardPage";
 import ImportCsvPage from "./pages/ImportCsvPage";
 import LoginPage from "./pages/LoginPage";
+import SchoolYearsPage from "./pages/SchoolYearsPage";
 
 const NotFoundPage = () => {
   return (
@@ -60,6 +61,7 @@ function App() {
               <Route index element={<Navigate to="new" replace />} />
               <Route path="new" element={<ImportCsvPage />} />
             </Route>
+            <Route path="school-years" element={<SchoolYearsPage />} />
           </Route>
         </Route>
 

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -9,7 +9,7 @@ type IconProps = {
 };
 
 type NavigationItem = {
-  key: "dashboard" | "applications" | "imports";
+  key: "dashboard" | "applications" | "imports" | "schoolYears";
   label: string;
   to?: string;
   end?: boolean;
@@ -67,6 +67,16 @@ const UploadIcon = ({ className = "h-5 w-5" }: IconProps) => {
   );
 };
 
+const CalendarIcon = ({ className = "h-5 w-5" }: IconProps) => {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className={className}>
+      <rect x="4" y="5.5" width="16" height="14" rx="2.5" />
+      <path d="M8 3.5v4M16 3.5v4M4 9.5h16" strokeLinecap="round" />
+      <path d="M8.5 13h3M8.5 16.5h7" strokeLinecap="round" />
+    </svg>
+  );
+};
+
 const LogoutIcon = ({ className = "h-5 w-5" }: IconProps) => {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className={className}>
@@ -100,9 +110,15 @@ const navigationItems: NavigationItem[] = [
   },
   {
     key: "imports",
-    label: "Import CSV",
+    label: "Campagne d'inscription",
     to: "/imports/new",
     icon: UploadIcon
+  },
+  {
+    key: "schoolYears",
+    label: "Années scolaires",
+    to: "/school-years",
+    icon: CalendarIcon
   }
 ];
 

--- a/apps/web/src/pages/SchoolYearsPage.tsx
+++ b/apps/web/src/pages/SchoolYearsPage.tsx
@@ -1,0 +1,36 @@
+import Breadcrumb from "../components/ui/Breadcrumb";
+import PageSectionHeader from "../components/layout/PageSectionHeader";
+
+const SchoolYearsPage = () => {
+  const pageTopBar = (
+    <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+      <div className="w-fit rounded-2xl border border-primary/10 bg-white/80 px-4 py-3 text-sm text-primaryDark shadow-[0_10px_22px_-22px_rgba(15,23,42,0.18)]">
+        <Breadcrumb
+          items={[
+            { label: "Tableau de bord", href: "/" },
+            { label: "Années scolaires" }
+          ]}
+        />
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="flex flex-col gap-8">
+      <PageSectionHeader topBar={pageTopBar} title="Années scolaires" />
+
+      <section className="rounded-[28px] border border-[#e9ded2] bg-white/76 p-6 shadow-[0_22px_48px_-36px_rgba(15,23,42,0.38)] backdrop-blur sm:p-8">
+        <div className="max-w-3xl">
+          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-primaryLight">
+            Administration ECE
+          </p>
+          <p className="mt-4 text-base leading-8 text-slate-700">
+            Gestion des années scolaires à venir.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default SchoolYearsPage;


### PR DESCRIPTION
## Objectif

Préparer la navigation de l’application pour la future gestion des années scolaires, en remplaçant la notion technique d’import CSV par une notion métier plus claire.

## Contenu

### Sidebar
- remplacement du libellé `Import CSV` par `Campagne d'inscription`
- conservation de la route existante `/imports/new`
- ajout d’un nouvel item `Années scolaires`
- nouvelle route associée : `/school-years`

### Routing
- ajout de la route protégée `/school-years`
- intégration sous `PrivateRoute` et `AppLayout`

### Nouvelle page placeholder
- création de `SchoolYearsPage.tsx`
- breadcrumb : `Tableau de bord / Années scolaires`
- titre : `Années scolaires`
- texte temporaire : `Gestion des années scolaires à venir.`

## Fichiers concernés

- `apps/web/src/components/layout/AppLayout.tsx`
- `apps/web/src/App.tsx`
- `apps/web/src/pages/SchoolYearsPage.tsx`

## Vérifications

- [x] `npm exec -w apps/web -- tsc -b`
- [x] `npm run build -w apps/web`
- [x] `npm run dev:web`

## Notes

- aucune modification backend
- aucune modification Prisma
- aucune modification de la logique d’import CSV
- préparation UX pour la future gestion des années scolaires