### PR TITLE
feat(onboarding): guide first run school year setup

### DIFF
--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from "react";
 import { NavLink, Outlet, useNavigate } from "react-router-dom";
 
 import { useAuth } from "../../hooks/useAuth";
+import FirstRunOnboarding from "./FirstRunOnboarding";
 
 type IconProps = {
   className?: string;
@@ -169,6 +170,8 @@ const AppLayout = () => {
 
   return (
     <div className="min-h-screen bg-background text-slate-900">
+      <FirstRunOnboarding />
+
       <header
         className="fixed inset-x-0 top-0 z-40 border-b-4 border-secondary shadow-[0_20px_55px_-35px_rgba(15,23,42,0.65)]"
         style={brandTextureStyle}

--- a/apps/web/src/components/layout/FirstRunOnboarding.tsx
+++ b/apps/web/src/components/layout/FirstRunOnboarding.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useState } from "react";
+
+import { useLocation, useNavigate } from "react-router-dom";
+
+import { getSchoolYears } from "../../lib/api";
+
+const isAbortError = (error: unknown): boolean => {
+  return error instanceof DOMException && error.name === "AbortError";
+};
+
+const getSchoolYearsLoadErrorMessage = (error: unknown): string => {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  return "Impossible de charger les années scolaires pour le moment.";
+};
+
+const FirstRunOnboarding = () => {
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const [checkedPath, setCheckedPath] = useState<string | null>(null);
+  const [hasSchoolYears, setHasSchoolYears] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const isOnImportSetupPage = pathname === "/imports" || pathname === "/imports/new";
+  const shouldShowErrorBanner = checkedPath === pathname && errorMessage !== null;
+  const shouldShowModal =
+    checkedPath === pathname &&
+    errorMessage === null &&
+    !hasSchoolYears &&
+    !isOnImportSetupPage;
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    setCheckedPath(null);
+    setErrorMessage(null);
+
+    const loadSchoolYears = async (): Promise<void> => {
+      try {
+        const schoolYears = await getSchoolYears({ signal: controller.signal });
+
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        setHasSchoolYears(schoolYears.length > 0);
+      } catch (loadError) {
+        if (isAbortError(loadError) || controller.signal.aborted) {
+          return;
+        }
+
+        setHasSchoolYears(true);
+        setErrorMessage(getSchoolYearsLoadErrorMessage(loadError));
+      } finally {
+        if (!controller.signal.aborted) {
+          setCheckedPath(pathname);
+        }
+      }
+    };
+
+    void loadSchoolYears();
+
+    return () => {
+      controller.abort();
+    };
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!shouldShowModal) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [shouldShowModal]);
+
+  return (
+    <>
+      {shouldShowErrorBanner ? (
+        <div className="pointer-events-none fixed inset-x-4 top-[144px] z-[65] flex justify-center sm:top-[156px]">
+          <section
+            role="alert"
+            className="pointer-events-auto w-full max-w-3xl rounded-[28px] border border-danger/20 bg-white/95 px-5 py-5 text-slate-900 shadow-[0_24px_50px_-34px_rgba(15,23,42,0.34)] backdrop-blur sm:px-6"
+          >
+            <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-danger">
+              Initialisation
+            </p>
+            <h2 className="mt-2 font-serif text-[1.9rem] leading-tight text-slate-900">
+              Vérification des années scolaires indisponible
+            </h2>
+            <p className="mt-3 text-sm leading-7 text-slate-700">
+              Impossible de vérifier si une année scolaire existe déjà. {errorMessage}
+            </p>
+          </section>
+        </div>
+      ) : null}
+
+      {shouldShowModal ? (
+        <div className="fixed inset-0 z-[70] flex items-center justify-center bg-[rgba(15,23,42,0.22)] px-4 backdrop-blur-[3px]">
+          <section
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="first-run-onboarding-title"
+            aria-describedby="first-run-onboarding-description"
+            className="w-full max-w-2xl rounded-[32px] border border-white/80 bg-white/96 px-6 py-7 text-slate-900 shadow-[0_28px_70px_-36px_rgba(15,23,42,0.42)] backdrop-blur sm:px-8 sm:py-9"
+          >
+            <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-primaryLight">
+              Premier démarrage
+            </p>
+            <h2
+              id="first-run-onboarding-title"
+              className="mt-3 font-serif text-[2.3rem] leading-tight text-slate-900 sm:text-[2.7rem]"
+            >
+              Configurez votre première année scolaire
+            </h2>
+            <div
+              id="first-run-onboarding-description"
+              className="mt-5 space-y-3 text-base leading-8 text-slate-700 sm:text-[1.02rem]"
+            >
+              <p>Bienvenue dans l&apos;application ECE de gestion des inscriptions.</p>
+              <p>
+                Pour commencer, veuillez créer une année scolaire avant
+                d&apos;importer les demandes.
+              </p>
+            </div>
+
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm leading-6 text-slate-500">
+                Cette étape est nécessaire avant le premier import des demandes.
+              </p>
+              <button
+                type="button"
+                autoFocus
+                onClick={() => {
+                  navigate("/imports/new");
+                }}
+                className="inline-flex items-center justify-center rounded-2xl bg-secondary px-6 py-3 text-sm font-semibold text-white shadow-[0_18px_28px_-18px_rgba(212,162,76,0.98)] transition hover:bg-secondaryDark"
+              >
+                Créer une campagne d&apos;inscription
+              </button>
+            </div>
+          </section>
+        </div>
+      ) : null}
+    </>
+  );
+};
+
+export default FirstRunOnboarding;

--- a/apps/web/src/pages/ImportCsvPage.tsx
+++ b/apps/web/src/pages/ImportCsvPage.tsx
@@ -156,6 +156,16 @@ const isValidSchoolYearLabel = (value: string): boolean => {
   return Number.parseInt(labelMatch[2], 10) === Number.parseInt(labelMatch[1], 10) + 1;
 };
 
+const getSchoolYearDraftPlaceholder = (
+  schoolYear: SchoolYearSummary | null
+): string => {
+  if (!schoolYear) {
+    return "2026-2027";
+  }
+
+  return `${schoolYear.endYear}-${schoolYear.endYear + 1}`;
+};
+
 const ChevronDownIcon = ({ className = "h-4 w-4" }: IconProps) => {
   return (
     <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.8" className={className}>
@@ -349,6 +359,12 @@ const ImportCsvPage = () => {
     !isLoadingActiveSchoolYear &&
     activeSchoolYear === null &&
     activeSchoolYearError === MISSING_ACTIVE_SCHOOL_YEAR_MESSAGE;
+  const canManageSchoolYear =
+    !isLoadingActiveSchoolYear &&
+    (activeSchoolYear !== null || isSchoolYearSetupRequired);
+  const isSchoolYearFormLocked =
+    isLoadingActiveSchoolYear || isCreatingSchoolYear || isSubmitting;
+  const schoolYearDraftPlaceholder = getSchoolYearDraftPlaceholder(activeSchoolYear);
   const isUploadLocked =
     isLoadingActiveSchoolYear ||
     isCreatingSchoolYear ||
@@ -504,6 +520,7 @@ const ImportCsvPage = () => {
       setActiveSchoolYear(schoolYear);
       setActiveSchoolYearError(null);
       setSchoolYearDraft("");
+      clearSelectedFile();
       setInlineMessage(null);
       showSuccess(
         `Année scolaire ${formatSchoolYearLabel(schoolYear.label)} créée et activée.`
@@ -603,19 +620,42 @@ const ImportCsvPage = () => {
           <li>Chaque import génère un résumé des demandes importées.</li>
         </ul>
 
-        {isSchoolYearSetupRequired ? (
-          <section className="mt-5 rounded-[24px] border border-[#e7d8c6] bg-[#fcf8f1] px-4 py-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.9)] sm:px-5">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-primaryLight">
-              Configuration requise
-            </p>
-            <h2 className="mt-2 font-serif text-[1.8rem] text-slate-900">
-              Créez une année scolaire active avant l&apos;import
-            </h2>
-            <p className="mt-3 max-w-3xl text-sm leading-7 text-slate-600">
-              Aucune année scolaire active n&apos;est configurée. Créez et activez
-              une année scolaire ici pour débloquer l&apos;import CSV, ou activez
-              une année existante depuis l&apos;administration.
-            </p>
+        {canManageSchoolYear ? (
+          <section
+            className={`mt-5 rounded-[24px] px-4 py-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.9)] sm:px-5 ${
+              isSchoolYearSetupRequired
+                ? "border border-[#e7d8c6] bg-[#fcf8f1]"
+                : "border border-[#ebdfd2] bg-white/82"
+            }`}
+          >
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+              <div className="max-w-3xl">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-primaryLight">
+                  {isSchoolYearSetupRequired
+                    ? "Configuration requise"
+                    : "Nouvelle campagne"}
+                </p>
+                <h2 className="mt-2 font-serif text-[1.8rem] text-slate-900">
+                  {isSchoolYearSetupRequired
+                    ? "Créez une année scolaire active avant l'import"
+                    : "Créez et activez la prochaine année scolaire"}
+                </h2>
+                <p className="mt-3 text-sm leading-7 text-slate-600">
+                  {isSchoolYearSetupRequired
+                    ? "Aucune année scolaire active n'est configurée. Créez et activez une année scolaire ici pour débloquer l'import CSV, ou activez une année existante depuis l'administration."
+                    : `L'année scolaire active est actuellement ${activeSchoolYearLabel}. Créez et activez ici une nouvelle année scolaire pour rattacher les prochains imports à cette nouvelle campagne d'inscription.`}
+                </p>
+              </div>
+
+              {activeSchoolYear ? (
+                <div className="inline-flex w-fit flex-col rounded-2xl border border-secondary/20 bg-secondary/10 px-4 py-3 text-sm text-secondaryDark">
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-primaryLight">
+                    Année active
+                  </span>
+                  <span className="mt-1 font-semibold">{activeSchoolYearLabel}</span>
+                </div>
+              ) : null}
+            </div>
 
             <form
               className="mt-5 flex flex-col gap-4 lg:flex-row lg:items-end"
@@ -628,17 +668,17 @@ const ImportCsvPage = () => {
                 <input
                   type="text"
                   inputMode="numeric"
-                  placeholder="2026-2027"
+                  placeholder={schoolYearDraftPlaceholder}
                   value={schoolYearDraft}
                   onChange={handleSchoolYearDraftChange}
-                  disabled={isCreatingSchoolYear}
+                  disabled={isSchoolYearFormLocked}
                   className="mt-2 w-full rounded-2xl border border-[#dfd1c0] bg-white px-4 py-3 text-base text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-primary focus:ring-2 focus:ring-primary/15 disabled:cursor-not-allowed disabled:bg-slate-100"
                 />
               </label>
 
               <button
                 type="submit"
-                disabled={isCreatingSchoolYear}
+                disabled={isSchoolYearFormLocked}
                 className="inline-flex items-center justify-center rounded-2xl bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:bg-primaryDark disabled:cursor-wait disabled:bg-slate-300"
               >
                 {isCreatingSchoolYear
@@ -655,7 +695,7 @@ const ImportCsvPage = () => {
           </section>
         ) : null}
 
-        {activeSchoolYearError && !isSchoolYearSetupRequired ? (
+        {activeSchoolYearError && !canManageSchoolYear ? (
           <p className="mt-5 rounded-[22px] border border-danger/15 bg-danger/5 px-4 py-3 text-sm text-danger">
             {activeSchoolYearError}
           </p>


### PR DESCRIPTION
## Objectif

Ajouter un onboarding de premier démarrage afin de guider l’administrateur lorsqu’aucune année scolaire n’existe encore, sans modifier le rôle de la page Années scolaires.

## Contenu

### Onboarding premier démarrage
- ajout du composant `FirstRunOnboarding`
- vérification de l’existence d’années scolaires via `GET /api/school-years`
- affichage d’une modal bloquante uniquement si aucune année scolaire n’existe
- bouton `Créer une campagne d’inscription`
- redirection vers `/imports/new`

### Conditions d’affichage
La modal ne s’affiche pas :
- sur `/login`
- si l’utilisateur n’est pas connecté
- sur `/imports/new` ou `/imports`
- si au moins une année scolaire existe déjà

### Gestion erreurs
- en cas d’erreur API lors de la vérification, aucune modal n’est affichée à tort
- un bandeau d’erreur visible est affiché pour signaler le problème

### Campagne d’inscription
- le bloc de création/activation d’année scolaire reste disponible même lorsqu’une année active existe déjà
- après un import réussi, l’administrateur peut créer une nouvelle campagne depuis la même page
- la sélection de fichier est remise à zéro lors d’un changement de campagne
- le formulaire de création est verrouillé pendant un import en cours

## Fichiers concernés

- `apps/web/src/components/layout/AppLayout.tsx`
- `apps/web/src/components/layout/FirstRunOnboarding.tsx`
- `apps/web/src/pages/ImportCsvPage.tsx`

## Vérifications

- [x] `npm exec -w apps/web -- tsc -b`
- [x] `npm run build -w apps/web`
- [x] `npm run dev:web`

## Contrôles manuels à effectuer

- [ ] base vide sans année scolaire → modal affichée après connexion
- [ ] clic sur `Créer une campagne d’inscription` → redirection vers `/imports/new`
- [ ] création d’une année scolaire → import débloqué
- [ ] import CSV réussi
- [ ] possibilité de créer une nouvelle campagne après import
- [ ] changement de campagne → fichier sélectionné remis à zéro
- [ ] retour dashboard → modal non affichée si une année existe

## Notes

- aucune modification backend
- aucune modification Prisma
- la page Années scolaires conserve son rôle futur d’historique/consultation