### PR TITLE
feat(school-years): add campaign history and lifecycle actions

### DIFF
--- a/apps/api/src/controllers/dashboard.controller.ts
+++ b/apps/api/src/controllers/dashboard.controller.ts
@@ -11,32 +11,83 @@ type DashboardStatusCounts = {
 };
 
 export const getDashboardStats = async (_req: Request, res: Response): Promise<void> => {
-  const [totalApplications, statusCounts, levels, priorityApplications] = await Promise.all([
-    prisma.application.count(),
+  const activeSchoolYear = await prisma.schoolYear.findFirst({
+    where: { isActive: true },
+    select: { id: true },
+    orderBy: { startYear: "desc" }
+  });
+
+  if (!activeSchoolYear) {
+    const levels = await prisma.level.findMany({
+      select: {
+        code: true,
+        label: true,
+        sortOrder: true
+      },
+      orderBy: {
+        sortOrder: "asc"
+      }
+    });
+
+    res.status(200).json({
+      totalApplications: 0,
+      byStatus: {
+        [ApplicationStatus.RECEIVED]: 0,
+        [ApplicationStatus.IN_REVIEW]: 0,
+        [ApplicationStatus.ACCEPTED]: 0,
+        [ApplicationStatus.REFUSED]: 0
+      },
+      byLevel: levels.map((level) => ({
+        code: level.code,
+        label: level.label,
+        count: 0
+      })),
+      priorityApplications: []
+    });
+    return;
+  }
+
+  const [totalApplications, statusCounts, levels, studentCountsByLevel, priorityApplications] = await Promise.all([
+    prisma.application.count({
+      where: {
+        schoolYearId: activeSchoolYear.id
+      }
+    }),
     prisma.application.groupBy({
       by: ["status"],
+      where: {
+        schoolYearId: activeSchoolYear.id
+      },
       _count: {
         _all: true
       }
     }),
     prisma.level.findMany({
       select: {
+        id: true,
         code: true,
         label: true,
-        sortOrder: true,
-        _count: {
-          select: {
-            students: true
-          }
-        }
+        sortOrder: true
       },
       orderBy: {
         sortOrder: "asc"
       }
     }),
+    prisma.student.groupBy({
+      by: ["levelId"],
+      where: {
+        application: {
+          schoolYearId: activeSchoolYear.id
+        }
+      },
+      _count: {
+        _all: true
+      }
+    }),
     prisma.application.findMany({
       where: {
-        isPriority: true
+        isPriority: true,
+        schoolYearId: activeSchoolYear.id
       },
       orderBy: {
         createdAt: "desc"
@@ -86,10 +137,14 @@ export const getDashboardStats = async (_req: Request, res: Response): Promise<v
     byStatus[statusCount.status] = statusCount._count._all;
   }
 
+  const studentCountsByLevelId = new Map(
+    studentCountsByLevel.map((level) => [level.levelId, level._count._all])
+  );
+
   const byLevel = levels.map((level) => ({
     code: level.code,
     label: level.label,
-    count: level._count.students
+    count: studentCountsByLevelId.get(level.id) ?? 0
   }));
 
   res.status(200).json({

--- a/apps/api/src/controllers/import.controller.ts
+++ b/apps/api/src/controllers/import.controller.ts
@@ -324,6 +324,20 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
     throw notFound("Active school year not found");
   }
 
+  const existingSuccessfulImport = await prisma.csvImportLog.findFirst({
+    where: {
+      schoolYearId: activeSchoolYear.id,
+      status: "SUCCESS"
+    },
+    select: {
+      id: true
+    }
+  });
+
+  if (existingSuccessfulImport) {
+    throw badRequest("CSV import already completed for active school year");
+  }
+
   const levels = await prisma.level.findMany({
     select: {
       id: true,
@@ -353,6 +367,7 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
     : levels;
   const levelLookup = buildLevelLookupMap(allLevels);
 
+  const importedFamilyIds = new Set<string>();
   let importedFamilies = 0;
   let importedApplications = 0;
   let importedStudents = 0;
@@ -395,8 +410,8 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
 
       if (existingApplication) {
         return {
-          createdFamily: false,
           createdApplication: false,
+          familyId: null,
           createdStudents: 0,
           skippedAsDuplicate: true
         };
@@ -415,7 +430,6 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
       });
 
       let familyId = existingFamily?.id;
-      let createdFamily = false;
 
       if (existingFamily) {
         await tx.family.update({
@@ -433,7 +447,6 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
         });
 
         familyId = createdFamilyRecord.id;
-        createdFamily = true;
       }
 
       if (!familyId) {
@@ -467,8 +480,8 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
       });
 
       return {
-        createdFamily,
         createdApplication: true,
+        familyId,
         createdStudents: resolvedStudents.length,
         skippedAsDuplicate: false
       };
@@ -479,15 +492,17 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
       continue;
     }
 
-    if (importResult.createdFamily) {
-      importedFamilies += 1;
-    }
-
     if (importResult.createdApplication) {
+      if (importResult.familyId) {
+        importedFamilyIds.add(importResult.familyId);
+      }
+
       importedApplications += 1;
       importedStudents += importResult.createdStudents;
     }
   }
+
+  importedFamilies = importedFamilyIds.size;
 
   const createdImportLog = await prisma.csvImportLog.create({
     data: {

--- a/apps/api/src/controllers/school-year.controller.ts
+++ b/apps/api/src/controllers/school-year.controller.ts
@@ -16,6 +16,16 @@ const schoolYearSelect = {
 
 const SCHOOL_YEAR_LABEL_PATTERN = /^(\d{4})-(\d{4})$/u;
 
+const getSchoolYearIdFromRequest = (req: Request): string => {
+  const schoolYearId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+
+  if (typeof schoolYearId !== "string" || schoolYearId.trim().length === 0) {
+    throw badRequest("School year id is required");
+  }
+
+  return schoolYearId;
+};
+
 const parseSchoolYearPayload = (
   payload: unknown
 ): { label: string; startYear: number; endYear: number; isActive: boolean } => {
@@ -113,7 +123,7 @@ export const createSchoolYear = async (req: Request, res: Response): Promise<voi
 };
 
 export const activateSchoolYear = async (req: Request, res: Response): Promise<void> => {
-  const schoolYearId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const schoolYearId = getSchoolYearIdFromRequest(req);
 
   const existingSchoolYear = await prisma.schoolYear.findUnique({
     where: { id: schoolYearId },
@@ -139,4 +149,100 @@ export const activateSchoolYear = async (req: Request, res: Response): Promise<v
   ]);
 
   res.status(200).json(activatedSchoolYear);
+};
+
+export const deleteSchoolYear = async (req: Request, res: Response): Promise<void> => {
+  const schoolYearId = getSchoolYearIdFromRequest(req);
+
+  const schoolYearToDelete = await prisma.schoolYear.findUnique({
+    where: { id: schoolYearId },
+    select: {
+      id: true,
+      label: true,
+      isActive: true
+    }
+  });
+
+  if (!schoolYearToDelete) {
+    throw notFound("School year not found");
+  }
+
+  const deletionResult = await prisma.$transaction(async (tx) => {
+    const linkedApplications = await tx.application.findMany({
+      where: { schoolYearId },
+      select: { familyId: true }
+    });
+    const relatedFamilyIds = [...new Set(linkedApplications.map((item) => item.familyId))];
+    const replacementSchoolYear = schoolYearToDelete.isActive
+      ? await tx.schoolYear.findFirst({
+          where: {
+            id: { not: schoolYearId }
+          },
+          orderBy: { startYear: "desc" },
+          select: { id: true }
+        })
+      : null;
+
+    await tx.csvImportLog.deleteMany({
+      where: { schoolYearId }
+    });
+
+    await tx.application.deleteMany({
+      where: { schoolYearId }
+    });
+
+    if (relatedFamilyIds.length > 0) {
+      const remainingApplications = await tx.application.findMany({
+        where: {
+          familyId: {
+            in: relatedFamilyIds
+          }
+        },
+        select: { familyId: true }
+      });
+      const remainingFamilyIds = new Set(
+        remainingApplications.map((application) => application.familyId)
+      );
+      const orphanFamilyIds = relatedFamilyIds.filter(
+        (familyId) => !remainingFamilyIds.has(familyId)
+      );
+
+      if (orphanFamilyIds.length > 0) {
+        await tx.family.deleteMany({
+          where: {
+            id: {
+              in: orphanFamilyIds
+            }
+          }
+        });
+      }
+    }
+
+    await tx.schoolYear.delete({
+      where: { id: schoolYearId }
+    });
+
+    if (schoolYearToDelete.isActive && replacementSchoolYear) {
+      await tx.schoolYear.updateMany({
+        where: {
+          id: { not: replacementSchoolYear.id }
+        },
+        data: { isActive: false }
+      });
+
+      await tx.schoolYear.update({
+        where: { id: replacementSchoolYear.id },
+        data: { isActive: true }
+      });
+    }
+
+    return {
+      id: schoolYearToDelete.id,
+      activatedSchoolYearId: schoolYearToDelete.isActive
+        ? replacementSchoolYear?.id ?? null
+        : null
+    };
+  });
+
+  res.status(200).json(deletionResult);
 };

--- a/apps/api/src/routes/school-year.routes.ts
+++ b/apps/api/src/routes/school-year.routes.ts
@@ -3,6 +3,7 @@ import { Router } from "express";
 import {
   activateSchoolYear,
   createSchoolYear,
+  deleteSchoolYear,
   getActiveSchoolYear,
   getSchoolYears
 } from "../controllers/school-year.controller";
@@ -13,5 +14,6 @@ router.get("/school-years/active", getActiveSchoolYear);
 router.get("/school-years", getSchoolYears);
 router.post("/school-years", createSchoolYear);
 router.patch("/school-years/:id/activate", activateSchoolYear);
+router.delete("/school-years/:id", deleteSchoolYear);
 
 export default router;

--- a/apps/web/src/components/layout/FirstRunOnboarding.tsx
+++ b/apps/web/src/components/layout/FirstRunOnboarding.tsx
@@ -103,26 +103,26 @@ const FirstRunOnboarding = () => {
       ) : null}
 
       {shouldShowModal ? (
-        <div className="fixed inset-0 z-[70] flex items-center justify-center bg-[rgba(15,23,42,0.22)] px-4 backdrop-blur-[3px]">
+        <div className="fixed inset-0 z-[70] flex items-center justify-center bg-[rgba(15,23,42,0.34)] px-4 backdrop-blur-[4px]">
           <section
             role="dialog"
             aria-modal="true"
             aria-labelledby="first-run-onboarding-title"
             aria-describedby="first-run-onboarding-description"
-            className="w-full max-w-2xl rounded-[32px] border border-white/80 bg-white/96 px-6 py-7 text-slate-900 shadow-[0_28px_70px_-36px_rgba(15,23,42,0.42)] backdrop-blur sm:px-8 sm:py-9"
+            className="w-full max-w-2xl rounded-[32px] border border-[#efe4d6] bg-[#fcfaf5] px-6 py-7 text-slate-950 shadow-[0_28px_70px_-36px_rgba(15,23,42,0.42)] sm:px-8 sm:py-9"
           >
-            <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-primaryLight">
+            <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-primaryDark">
               Premier démarrage
             </p>
             <h2
               id="first-run-onboarding-title"
-              className="mt-3 font-serif text-[2.3rem] leading-tight text-slate-900 sm:text-[2.7rem]"
+              className="mt-3 font-serif text-[2.3rem] leading-tight text-slate-950 sm:text-[2.7rem]"
             >
               Configurez votre première année scolaire
             </h2>
             <div
               id="first-run-onboarding-description"
-              className="mt-5 space-y-3 text-base leading-8 text-slate-700 sm:text-[1.02rem]"
+              className="mt-5 space-y-3 text-base leading-8 text-slate-800 sm:text-[1.02rem]"
             >
               <p>Bienvenue dans l&apos;application ECE de gestion des inscriptions.</p>
               <p>
@@ -132,7 +132,7 @@ const FirstRunOnboarding = () => {
             </div>
 
             <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <p className="text-sm leading-6 text-slate-500">
+              <p className="text-sm leading-6 text-slate-700">
                 Cette étape est nécessaire avant le premier import des demandes.
               </p>
               <button

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -26,6 +26,11 @@ export type LoginAdminResponse = {
   user: AuthUser;
 };
 
+type DeleteSchoolYearResult = {
+  id: string;
+  activatedSchoolYearId: string | null;
+};
+
 const buildApiUrl = (path: string): string => {
   return `${API_BASE_URL}${path}`;
 };
@@ -239,6 +244,39 @@ export const createSchoolYear = async (
     },
     body: JSON.stringify(payload)
   });
+};
+
+export const activateSchoolYear = async (
+  schoolYearId: string,
+  init?: RequestInit
+): Promise<SchoolYearSummary> => {
+  return fetchJson<SchoolYearSummary>(
+    `/api/school-years/${encodeURIComponent(schoolYearId)}/activate`,
+    {
+      ...init,
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        ...init?.headers
+      }
+    }
+  );
+};
+
+export const deleteSchoolYear = async (
+  schoolYearId: string,
+  init?: RequestInit
+): Promise<DeleteSchoolYearResult> => {
+  return fetchJson<DeleteSchoolYearResult>(
+    `/api/school-years/${encodeURIComponent(schoolYearId)}`,
+    {
+      ...init,
+      method: "DELETE",
+      headers: {
+        ...init?.headers
+      }
+    }
+  );
 };
 
 export const uploadCsvImport = async (

--- a/apps/web/src/pages/ApplicationsPage.tsx
+++ b/apps/web/src/pages/ApplicationsPage.tsx
@@ -7,7 +7,7 @@ import {
   type CSSProperties,
   type ReactNode
 } from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 
 import PageSectionHeader from "../components/layout/PageSectionHeader";
 import Breadcrumb from "../components/ui/Breadcrumb";
@@ -343,12 +343,17 @@ const PaginationControls = ({
 };
 
 const ApplicationsPage = () => {
-  const [filters, setFilters] = useState<FilterState>({
+  const [searchParams] = useSearchParams();
+  const requestedSchoolYearId = searchParams.get("schoolYearId")?.trim() ?? "";
+  const [hasInitializedSchoolYearFilter, setHasInitializedSchoolYearFilter] = useState(
+    requestedSchoolYearId.length > 0
+  );
+  const [filters, setFilters] = useState<FilterState>(() => ({
     status: "",
-    schoolYearId: "",
+    schoolYearId: requestedSchoolYearId,
     isPriority: "",
     search: ""
-  });
+  }));
   const [sort, setSort] = useState<SortOption>("createdAtDesc");
   const [applications, setApplications] = useState<ApplicationListItem[]>([]);
   const [schoolYears, setSchoolYears] = useState<SchoolYearSummary[]>([]);
@@ -391,6 +396,7 @@ const ApplicationsPage = () => {
   const activeSchoolYear = useMemo(() => {
     return schoolYears.find((schoolYear) => schoolYear.isActive) ?? null;
   }, [schoolYears]);
+  const defaultSchoolYearId = requestedSchoolYearId || activeSchoolYear?.id || "";
   const totalPages = useMemo(() => {
     return Math.max(1, Math.ceil(displayedApplications.length / pageSize));
   }, [displayedApplications.length, pageSize]);
@@ -403,12 +409,12 @@ const ApplicationsPage = () => {
 
   const hasActiveFilters =
     filters.status !== "" ||
-    filters.schoolYearId !== "" ||
+    filters.schoolYearId !== defaultSchoolYearId ||
     filters.isPriority !== "" ||
     filters.search.trim().length > 0;
   const activeFilterCount = [
     filters.status,
-    filters.schoolYearId,
+    filters.schoolYearId !== defaultSchoolYearId ? filters.schoolYearId : "",
     filters.isPriority,
     filters.search.trim()
   ].filter((value) => value !== "").length;
@@ -425,16 +431,16 @@ const ApplicationsPage = () => {
       ? selectedSchoolYear
         ? formatSchoolYearLabel(selectedSchoolYear.label)
         : "Année sélectionnée"
-      : activeSchoolYear
-        ? formatSchoolYearLabel(activeSchoolYear.label)
-        : "Toutes les années";
+      : "Toutes les années scolaires";
   const inputClassName =
     "w-full rounded-2xl border border-slate-200 bg-white/95 px-4 py-2.5 text-sm text-slate-900 shadow-[0_12px_26px_-24px_rgba(15,23,42,0.28)] outline-none transition placeholder:text-slate-400 focus:border-primary focus:ring-2 focus:ring-primary/15";
+  const isWaitingForDefaultSchoolYear =
+    requestedSchoolYearId.length === 0 && !hasInitializedSchoolYearFilter;
 
   const resetFilters = (): void => {
     setFilters({
       status: "",
-      schoolYearId: "",
+      schoolYearId: defaultSchoolYearId,
       isPriority: "",
       search: ""
     });
@@ -472,6 +478,10 @@ const ApplicationsPage = () => {
   }, [applicationQueryParams]);
 
   useEffect(() => {
+    if (isWaitingForDefaultSchoolYear) {
+      return;
+    }
+
     const controller = new AbortController();
 
     void loadApplications(controller.signal);
@@ -479,7 +489,7 @@ const ApplicationsPage = () => {
     return () => {
       controller.abort();
     };
-  }, [loadApplications]);
+  }, [isWaitingForDefaultSchoolYear, loadApplications]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -522,6 +532,40 @@ const ApplicationsPage = () => {
   }, []);
 
   useEffect(() => {
+    if (requestedSchoolYearId.length > 0) {
+      setHasInitializedSchoolYearFilter(true);
+
+      if (requestedSchoolYearId === filters.schoolYearId) {
+        return;
+      }
+
+      setFilters((currentFilters) => ({
+        ...currentFilters,
+        schoolYearId: requestedSchoolYearId
+      }));
+
+      return;
+    }
+
+    if (isSchoolYearsLoading || hasInitializedSchoolYearFilter) {
+      return;
+    }
+
+    setHasInitializedSchoolYearFilter(true);
+
+    setFilters((currentFilters) => ({
+      ...currentFilters,
+      schoolYearId: activeSchoolYear?.id ?? ""
+    }));
+  }, [
+    activeSchoolYear?.id,
+    filters.schoolYearId,
+    hasInitializedSchoolYearFilter,
+    isSchoolYearsLoading,
+    requestedSchoolYearId
+  ]);
+
+  useEffect(() => {
     setCurrentPage(1);
   }, [filters.status, filters.schoolYearId, filters.isPriority, filters.search, pageSize, sort]);
 
@@ -549,7 +593,11 @@ const ApplicationsPage = () => {
           style={getEnterStyle(90)}
         >
           <p className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-primaryLight">
-            {filters.schoolYearId ? "Année filtrée" : "Année active"}
+            {filters.schoolYearId === ""
+              ? "Toutes les années"
+              : activeSchoolYear?.id === filters.schoolYearId
+                ? "Année active"
+                : "Année filtrée"}
           </p>
           <p className="mt-1 font-semibold">{schoolYearSummaryLabel}</p>
         </div>

--- a/apps/web/src/pages/ImportCsvPage.tsx
+++ b/apps/web/src/pages/ImportCsvPage.tsx
@@ -56,9 +56,19 @@ const pluralize = (count: number, singular: string, plural: string): string => {
   return `${numberFormatter.format(count)} ${count > 1 ? plural : singular}`;
 };
 
+const getImportedFamiliesCount = (
+  item: Pick<CsvImportHistoryItem, "importedFamilies" | "importedApplications">
+): number => {
+  if (item.importedFamilies > 0 || item.importedApplications === 0) {
+    return item.importedFamilies;
+  }
+
+  return item.importedApplications;
+};
+
 const getImportHistoryResult = (item: CsvImportHistoryItem): string => {
   return [
-    pluralize(item.importedFamilies, "famille", "familles"),
+    pluralize(getImportedFamiliesCount(item), "famille", "familles"),
     pluralize(item.importedApplications, "demande", "demandes"),
     pluralize(item.importedStudents, "élève", "élèves"),
     pluralize(item.skippedRows, "ligne ignorée", "lignes ignorées")
@@ -125,6 +135,8 @@ const getImportErrorMessage = (error: unknown): string => {
       return "Le contenu du fichier CSV est invalide.";
     case "Active school year not found":
       return "Aucune année scolaire active n'est configurée pour recevoir l'import.";
+    case "CSV import already completed for active school year":
+      return "Cette campagne d'inscription possède déjà un import CSV réussi. Créez une nouvelle année scolaire avant de lancer un nouvel import.";
     default:
       if (error.message.startsWith("CSV missing ")) {
         return "Le fichier CSV ne correspond pas au format attendu du formulaire.";
@@ -350,6 +362,13 @@ const ImportCsvPage = () => {
   }, []);
 
   const latestImport = history[0] ?? null;
+  const activeSchoolYearImport = activeSchoolYear
+    ? history.find(
+      (item) =>
+        item.schoolYearId === activeSchoolYear.id &&
+        item.status === "SUCCESS"
+    ) ?? null
+    : null;
   const activeSchoolYearLabel = activeSchoolYear
     ? formatSchoolYearLabel(activeSchoolYear.label)
     : latestImport?.schoolYearLabel
@@ -365,11 +384,14 @@ const ImportCsvPage = () => {
   const isSchoolYearFormLocked =
     isLoadingActiveSchoolYear || isCreatingSchoolYear || isSubmitting;
   const schoolYearDraftPlaceholder = getSchoolYearDraftPlaceholder(activeSchoolYear);
+  const hasCompletedImportForActiveSchoolYear = activeSchoolYearImport !== null;
   const isUploadLocked =
     isLoadingActiveSchoolYear ||
+    isLoadingHistory ||
     isCreatingSchoolYear ||
     isSubmitting ||
-    activeSchoolYear === null;
+    activeSchoolYear === null ||
+    hasCompletedImportForActiveSchoolYear;
 
   const openFilePicker = (): void => {
     if (isUploadLocked) {
@@ -540,18 +562,27 @@ const ImportCsvPage = () => {
   ): Promise<void> => {
     event.preventDefault();
 
-    if (!selectedFile) {
-      const message = "Sélectionnez un fichier CSV avant de lancer l'import.";
+    if (!activeSchoolYear) {
+      const message =
+        activeSchoolYearError ??
+        "Aucune année scolaire active n'est configurée pour recevoir l'import.";
 
       setInlineMessage(message);
       showError(message);
       return;
     }
 
-    if (!activeSchoolYear) {
+    if (hasCompletedImportForActiveSchoolYear) {
       const message =
-        activeSchoolYearError ??
-        "Aucune année scolaire active n'est configurée pour recevoir l'import.";
+        "Cette campagne d'inscription possède déjà un import CSV réussi. Créez une nouvelle année scolaire avant de lancer un nouvel import.";
+
+      setInlineMessage(message);
+      showError(message);
+      return;
+    }
+
+    if (!selectedFile) {
+      const message = "Sélectionnez un fichier CSV avant de lancer l'import.";
 
       setInlineMessage(message);
       showError(message);
@@ -701,6 +732,26 @@ const ImportCsvPage = () => {
           </p>
         ) : null}
 
+        {hasCompletedImportForActiveSchoolYear ? (
+          <section className="mt-5 rounded-[24px] border border-success/15 bg-success/5 px-4 py-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.92)] sm:px-5">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-success">
+              Import terminé
+            </p>
+            <p className="mt-2 text-sm leading-7 text-slate-700">
+              Un import CSV réussi est déjà enregistré pour l&apos;année scolaire{" "}
+              <span className="font-semibold">{activeSchoolYearLabel}</span>.
+              Créez et activez une nouvelle année scolaire pour débloquer un
+              nouvel import.
+            </p>
+            {activeSchoolYearImport ? (
+              <p className="mt-2 text-sm text-slate-500">
+                Dernier import de cette campagne :{" "}
+                {dateTimeFormatter.format(new Date(activeSchoolYearImport.createdAt))}
+              </p>
+            ) : null}
+          </section>
+        ) : null}
+
         <form className="mt-6" onSubmit={(event) => void handleImportSubmit(event)}>
           <input
             ref={fileInputRef}
@@ -743,7 +794,9 @@ const ImportCsvPage = () => {
                     className="inline-flex items-center gap-3 rounded-2xl bg-secondary px-6 py-3 text-lg font-semibold text-white shadow-[0_18px_28px_-18px_rgba(212,162,76,0.98)] transition hover:bg-secondaryDark disabled:cursor-not-allowed disabled:bg-slate-300"
                   >
                     <UploadIcon className="h-5 w-5" />
-                    Choisir un fichier
+                    {hasCompletedImportForActiveSchoolYear
+                      ? "Import déjà effectué"
+                      : "Choisir un fichier"}
                   </button>
                   <p className="text-base text-slate-500">Format accepté : .csv</p>
                 </div>
@@ -790,7 +843,11 @@ const ImportCsvPage = () => {
                   disabled={isUploadLocked}
                   className="inline-flex items-center justify-center rounded-2xl bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:bg-primaryDark disabled:cursor-wait disabled:bg-slate-300"
                 >
-                  {isSubmitting ? "Import en cours..." : "Lancer l'import"}
+                  {isSubmitting
+                    ? "Import en cours..."
+                    : hasCompletedImportForActiveSchoolYear
+                      ? "Import déjà terminé"
+                      : "Lancer l'import"}
                 </button>
               </div>
             </div>
@@ -826,7 +883,10 @@ const ImportCsvPage = () => {
             </div>
 
             <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
-              <SummaryMetric label="Familles" value={latestImport.importedFamilies} />
+              <SummaryMetric
+                label="Familles"
+                value={getImportedFamiliesCount(latestImport)}
+              />
               <SummaryMetric
                 label="Demandes"
                 value={latestImport.importedApplications}

--- a/apps/web/src/pages/SchoolYearsPage.tsx
+++ b/apps/web/src/pages/SchoolYearsPage.tsx
@@ -1,7 +1,269 @@
-import Breadcrumb from "../components/ui/Breadcrumb";
+import { useCallback, useEffect, useMemo, useState, type CSSProperties } from "react";
+import { Link, useNavigate } from "react-router-dom";
+
 import PageSectionHeader from "../components/layout/PageSectionHeader";
+import Breadcrumb from "../components/ui/Breadcrumb";
+import EmptyState from "../components/ui/EmptyState";
+import ErrorState from "../components/ui/ErrorState";
+import LoadingState from "../components/ui/LoadingState";
+import { useToast } from "../context/ToastContext";
+import { activateSchoolYear, deleteSchoolYear, getSchoolYears } from "../lib/api";
+import type { SchoolYearSummary } from "../types/application";
+
+type BadgeTone = "active" | "history";
+
+const getEnterStyle = (delay: number): CSSProperties => {
+  return {
+    "--ui-enter-delay": `${delay}ms`
+  } as CSSProperties;
+};
+
+const isAbortError = (error: unknown): boolean => {
+  return error instanceof DOMException && error.name === "AbortError";
+};
+
+const formatSchoolYearLabel = (label: string): string => {
+  return label.replace(/^(\d{4})-(\d{4})$/u, "$1 - $2");
+};
+
+const createdAtFormatter = new Intl.DateTimeFormat("fr-FR", {
+  dateStyle: "long"
+});
+
+const getActivationErrorMessage = (error: unknown): string => {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  return "Impossible d'activer cette année scolaire pour le moment.";
+};
+
+const getDeletionErrorMessage = (error: unknown): string => {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  return "Impossible de supprimer cette campagne d'inscription pour le moment.";
+};
+
+const TrashIcon = ({ className = "h-4 w-4" }: { className?: string }) => {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M3.75 5.25h12.5" />
+      <path d="M7.25 5.25V4a1.25 1.25 0 0 1 1.25-1.25h3a1.25 1.25 0 0 1 1.25 1.25v1.25" />
+      <path d="M6.25 7.75v6.5" />
+      <path d="M10 7.75v6.5" />
+      <path d="M13.75 7.75v6.5" />
+      <path d="M5.75 5.25l.6 9.05a1.5 1.5 0 0 0 1.5 1.4h4.3a1.5 1.5 0 0 0 1.5-1.4l.6-9.05" />
+    </svg>
+  );
+};
+
+const StatusBadge = ({
+  label,
+  tone
+}: {
+  label: string;
+  tone: BadgeTone;
+}) => {
+  const className =
+    tone === "active"
+      ? "border-success/20 bg-success/10 text-success"
+      : "border-slate-300 bg-white text-slate-600";
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ${className}`}
+    >
+      {label}
+    </span>
+  );
+};
 
 const SchoolYearsPage = () => {
+  const navigate = useNavigate();
+  const { showError, showSuccess } = useToast();
+  const [schoolYears, setSchoolYears] = useState<SchoolYearSummary[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [activatingSchoolYearId, setActivatingSchoolYearId] = useState<string | null>(null);
+  const [deletingSchoolYearId, setDeletingSchoolYearId] = useState<string | null>(null);
+  const [schoolYearPendingDeletion, setSchoolYearPendingDeletion] =
+    useState<SchoolYearSummary | null>(null);
+  const activeSchoolYear = useMemo(() => {
+    return schoolYears.find((schoolYear) => schoolYear.isActive) ?? null;
+  }, [schoolYears]);
+  const replacementSchoolYearAfterDeletion = useMemo(() => {
+    if (!schoolYearPendingDeletion?.isActive) {
+      return null;
+    }
+
+    return (
+      schoolYears.find((schoolYear) => schoolYear.id !== schoolYearPendingDeletion.id) ?? null
+    );
+  }, [schoolYearPendingDeletion, schoolYears]);
+
+  const loadSchoolYears = useCallback(async (signal?: AbortSignal): Promise<void> => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await getSchoolYears({ signal });
+
+      if (signal?.aborted) {
+        return;
+      }
+
+      setSchoolYears(data);
+    } catch (loadError) {
+      if (isAbortError(loadError) || signal?.aborted) {
+        return;
+      }
+
+      setSchoolYears([]);
+      setError(
+        loadError instanceof Error
+          ? loadError.message
+          : "Impossible de charger les années scolaires."
+      );
+    } finally {
+      if (!signal?.aborted) {
+        setIsLoading(false);
+        setHasLoadedOnce(true);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    void loadSchoolYears(controller.signal);
+
+    return () => {
+      controller.abort();
+    };
+  }, [loadSchoolYears]);
+
+  useEffect(() => {
+    if (!schoolYearPendingDeletion) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [schoolYearPendingDeletion]);
+
+  const handleActivateSchoolYear = async (
+    schoolYearToActivate: SchoolYearSummary
+  ): Promise<void> => {
+    if (
+      schoolYearToActivate.isActive ||
+      activatingSchoolYearId !== null ||
+      deletingSchoolYearId !== null
+    ) {
+      return;
+    }
+
+    setActivatingSchoolYearId(schoolYearToActivate.id);
+
+    try {
+      const activatedSchoolYear = await activateSchoolYear(schoolYearToActivate.id);
+
+      setSchoolYears((currentSchoolYears) =>
+        currentSchoolYears.map((schoolYear) => ({
+          ...schoolYear,
+          isActive: schoolYear.id === activatedSchoolYear.id
+        }))
+      );
+      showSuccess(
+        `Année scolaire ${formatSchoolYearLabel(activatedSchoolYear.label)} activée.`
+      );
+    } catch (activationError) {
+      showError(getActivationErrorMessage(activationError));
+    } finally {
+      setActivatingSchoolYearId(null);
+    }
+  };
+
+  const handleRequestDeleteSchoolYear = (schoolYear: SchoolYearSummary): void => {
+    if (activatingSchoolYearId !== null || deletingSchoolYearId !== null) {
+      return;
+    }
+
+    setSchoolYearPendingDeletion(schoolYear);
+  };
+
+  const handleCancelDeletion = (): void => {
+    if (deletingSchoolYearId !== null) {
+      return;
+    }
+
+    setSchoolYearPendingDeletion(null);
+  };
+
+  const handleConfirmDeletion = async (): Promise<void> => {
+    if (!schoolYearPendingDeletion || deletingSchoolYearId !== null) {
+      return;
+    }
+
+    const schoolYearToDelete = schoolYearPendingDeletion;
+
+    setDeletingSchoolYearId(schoolYearToDelete.id);
+
+    try {
+      const deletionResult = await deleteSchoolYear(schoolYearToDelete.id);
+
+      setSchoolYears((currentSchoolYears) =>
+        currentSchoolYears
+          .filter((schoolYear) => schoolYear.id !== schoolYearToDelete.id)
+          .map((schoolYear) => ({
+            ...schoolYear,
+            isActive: schoolYearToDelete.isActive
+              ? schoolYear.id === deletionResult.activatedSchoolYearId
+              : schoolYear.isActive
+          }))
+      );
+      setSchoolYearPendingDeletion(null);
+
+      if (schoolYearToDelete.isActive && deletionResult.activatedSchoolYearId) {
+        const nextActiveSchoolYear = schoolYears.find(
+          (schoolYear) => schoolYear.id === deletionResult.activatedSchoolYearId
+        );
+
+        if (nextActiveSchoolYear) {
+          showSuccess(
+            `Campagne ${formatSchoolYearLabel(schoolYearToDelete.label)} supprimée. ${formatSchoolYearLabel(nextActiveSchoolYear.label)} est désormais active.`
+          );
+
+          return;
+        }
+      }
+
+      showSuccess(
+        `Campagne ${formatSchoolYearLabel(schoolYearToDelete.label)} supprimée.`
+      );
+    } catch (deletionError) {
+      showError(getDeletionErrorMessage(deletionError));
+    } finally {
+      setDeletingSchoolYearId(null);
+    }
+  };
+
   const pageTopBar = (
     <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
       <div className="w-fit rounded-2xl border border-primary/10 bg-white/80 px-4 py-3 text-sm text-primaryDark shadow-[0_10px_22px_-22px_rgba(15,23,42,0.18)]">
@@ -15,20 +277,257 @@ const SchoolYearsPage = () => {
     </div>
   );
 
+  const pageHeaderAside = (
+    <div className="grid gap-3 sm:grid-cols-2">
+      <div className="rounded-[24px] border border-primary/10 bg-white/82 px-4 py-4 text-sm text-primaryDark shadow-[0_14px_28px_-24px_rgba(15,23,42,0.22)]">
+        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-primaryLight">
+          Campagnes créées
+        </p>
+        <p className="mt-2 text-2xl font-semibold text-slate-900">
+          {isLoading ? "..." : schoolYears.length}
+        </p>
+      </div>
+      <div className="rounded-[24px] border border-primary/10 bg-white/82 px-4 py-4 text-sm text-primaryDark shadow-[0_14px_28px_-24px_rgba(15,23,42,0.22)]">
+        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-primaryLight">
+          Année active
+        </p>
+        <p className="mt-2 text-base font-semibold text-slate-900">
+          {isLoading
+            ? "Chargement..."
+            : activeSchoolYear
+              ? formatSchoolYearLabel(activeSchoolYear.label)
+              : "Non configurée"}
+        </p>
+      </div>
+    </div>
+  );
+
+  const pageHeader = (
+    <div className="ui-animate-in ui-animate-in--subtle" style={getEnterStyle(120)}>
+      <PageSectionHeader
+        topBar={pageTopBar}
+        eyebrow="Administration ECE"
+        title="Années scolaires"
+        description="Consultez les campagnes d’inscription créées et activez l’année à utiliser par défaut dans l’application."
+        aside={pageHeaderAside}
+      />
+    </div>
+  );
+
+  if (isLoading && !hasLoadedOnce) {
+    return (
+      <>
+        {pageHeader}
+        <LoadingState variant="page" />
+      </>
+    );
+  }
+
+  if (error && schoolYears.length === 0) {
+    return (
+      <>
+        {pageHeader}
+        <ErrorState
+          message={error}
+          actionLabel="Réessayer"
+          onAction={() => void loadSchoolYears()}
+          backLink="/"
+        />
+      </>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-8">
-      <PageSectionHeader topBar={pageTopBar} title="Années scolaires" />
+      {pageHeader}
 
-      <section className="rounded-[28px] border border-[#e9ded2] bg-white/76 p-6 shadow-[0_22px_48px_-36px_rgba(15,23,42,0.38)] backdrop-blur sm:p-8">
-        <div className="max-w-3xl">
-          <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-primaryLight">
-            Administration ECE
-          </p>
-          <p className="mt-4 text-base leading-8 text-slate-700">
-            Gestion des années scolaires à venir.
-          </p>
+      {!isLoading && schoolYears.length === 0 ? (
+        <EmptyState
+          title="Aucune année scolaire n’a encore été créée."
+          description="La création d'une nouvelle campagne d'inscription se fait depuis la page Campagne d'inscription."
+          actionLabel="Créer une campagne d’inscription"
+          onAction={() => navigate("/imports/new")}
+        />
+      ) : null}
+
+      {schoolYears.length > 0 ? (
+        <section
+          className="ui-animate-in ui-surface-hover ui-surface-hover--soft ui-surface-hover--no-accent rounded-[32px] border border-white/80 bg-white/92 p-6 shadow-[0_24px_50px_-34px_rgba(15,23,42,0.3)] sm:p-7"
+          style={getEnterStyle(180)}
+        >
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primaryLight">
+                Historique
+              </p>
+              <h2 className="mt-2 text-2xl font-semibold text-slate-900">
+                Campagnes scolaires enregistrées
+              </h2>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+                Cette page permet de consulter les campagnes déjà créées et de
+                choisir l&apos;année active utilisée par défaut. La création d&apos;une
+                nouvelle campagne reste disponible depuis Campagne d&apos;inscription.
+              </p>
+            </div>
+            <div className="inline-flex w-fit items-center rounded-full border border-secondary/20 bg-secondary/10 px-4 py-2 text-sm font-medium text-secondaryDark">
+              {schoolYears.length} année{schoolYears.length > 1 ? "s" : ""} scolaire
+              {schoolYears.length > 1 ? "s" : ""}
+            </div>
+          </div>
+
+          <div className="mt-6 flex flex-col gap-4">
+            {schoolYears.map((schoolYear, index) => {
+              const isActivating = activatingSchoolYearId === schoolYear.id;
+              const isDeleting = deletingSchoolYearId === schoolYear.id;
+              const isActionLocked =
+                (activatingSchoolYearId !== null &&
+                  activatingSchoolYearId !== schoolYear.id) ||
+                (deletingSchoolYearId !== null && deletingSchoolYearId !== schoolYear.id);
+
+              return (
+                <article
+                  key={schoolYear.id}
+                  className="ui-animate-in ui-surface-hover ui-surface-hover--soft rounded-[28px] border border-[#ebe1d6] bg-white/88 p-5 shadow-[0_18px_36px_-28px_rgba(15,23,42,0.24)]"
+                  style={getEnterStyle(230 + index * 45)}
+                >
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <div className="flex flex-wrap items-center gap-2.5">
+                        <h3 className="font-serif text-[2rem] leading-tight text-slate-900">
+                          {formatSchoolYearLabel(schoolYear.label)}
+                        </h3>
+                        <StatusBadge
+                          label={schoolYear.isActive ? "Active" : "Historique"}
+                          tone={schoolYear.isActive ? "active" : "history"}
+                        />
+                      </div>
+                      <p className="mt-3 text-sm leading-6 text-slate-600">
+                        Créée le {createdAtFormatter.format(new Date(schoolYear.createdAt))}
+                      </p>
+                    </div>
+
+                    <div className="inline-flex w-fit flex-col rounded-2xl border border-primary/10 bg-primary/5 px-4 py-3 text-sm text-primaryDark">
+                      <span className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-primaryLight">
+                        Statut
+                      </span>
+                      <span className="mt-1 font-semibold">
+                        {schoolYear.isActive
+                          ? "Utilisée par défaut"
+                          : "Disponible à l'activation"}
+                      </span>
+                    </div>
+                  </div>
+
+                  <div className="mt-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <Link
+                      to={`/applications?schoolYearId=${encodeURIComponent(schoolYear.id)}`}
+                      className="inline-flex items-center justify-center rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-primary/25 hover:text-primary"
+                    >
+                      Voir les demandes
+                    </Link>
+
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                      <button
+                        type="button"
+                        onClick={() => handleRequestDeleteSchoolYear(schoolYear)}
+                        disabled={isDeleting || isActionLocked}
+                        className="inline-flex items-center justify-center gap-2 rounded-2xl border border-danger/20 bg-danger/5 px-5 py-3 text-sm font-semibold text-danger transition hover:bg-danger/10 disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400"
+                      >
+                        <TrashIcon />
+                        {isDeleting ? "Suppression..." : "Supprimer"}
+                      </button>
+
+                      {schoolYear.isActive ? (
+                        <span className="inline-flex items-center justify-center rounded-2xl bg-success/10 px-5 py-3 text-sm font-semibold text-success">
+                          Année active
+                        </span>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => void handleActivateSchoolYear(schoolYear)}
+                          disabled={isActivating || isActionLocked}
+                          className="inline-flex items-center justify-center rounded-2xl bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:bg-primaryDark disabled:cursor-wait disabled:bg-slate-300"
+                        >
+                          {isActivating ? "Activation..." : "Activer"}
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+      ) : null}
+
+      {schoolYearPendingDeletion ? (
+        <div className="fixed inset-0 z-[80] flex items-center justify-center bg-[rgba(15,23,42,0.4)] px-4 backdrop-blur-[4px]">
+          <section
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="delete-school-year-title"
+            aria-describedby="delete-school-year-description"
+            className="w-full max-w-2xl rounded-[32px] border border-[#f0dfd8] bg-[#fffaf7] px-6 py-7 text-slate-950 shadow-[0_28px_70px_-36px_rgba(15,23,42,0.42)] sm:px-8 sm:py-8"
+          >
+            <p className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-danger">
+              Suppression de campagne
+            </p>
+            <h2
+              id="delete-school-year-title"
+              className="mt-3 font-serif text-[2rem] leading-tight text-slate-950 sm:text-[2.35rem]"
+            >
+              Supprimer la campagne {formatSchoolYearLabel(schoolYearPendingDeletion.label)} ?
+            </h2>
+            <div
+              id="delete-school-year-description"
+              className="mt-5 space-y-3 text-base leading-8 text-slate-800"
+            >
+              <p>
+                Cette action supprimera en base l&apos;année scolaire, les demandes
+                rattachées, les élèves importés et l&apos;historique d&apos;import
+                associés à cette campagne.
+              </p>
+              <p>Cette suppression est définitive et ne pourra pas être annulée.</p>
+              {schoolYearPendingDeletion.isActive ? (
+                replacementSchoolYearAfterDeletion ? (
+                  <p>
+                    Après suppression, l&apos;année{" "}
+                    {formatSchoolYearLabel(replacementSchoolYearAfterDeletion.label)} sera
+                    automatiquement activée.
+                  </p>
+                ) : (
+                  <p>
+                    Après suppression, aucune année scolaire ne restera active dans
+                    l&apos;application.
+                  </p>
+                )
+              ) : null}
+            </div>
+
+            <div className="mt-8 flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-end">
+              <button
+                type="button"
+                onClick={handleCancelDeletion}
+                disabled={deletingSchoolYearId !== null}
+                className="inline-flex items-center justify-center rounded-2xl border border-slate-300 bg-white px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-400 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
+              >
+                Annuler
+              </button>
+              <button
+                type="button"
+                autoFocus
+                onClick={() => void handleConfirmDeletion()}
+                disabled={deletingSchoolYearId !== null}
+                className="inline-flex items-center justify-center rounded-2xl bg-danger px-5 py-3 text-sm font-semibold text-white transition hover:bg-[#c43d44] disabled:cursor-wait disabled:bg-slate-300"
+              >
+                {deletingSchoolYearId !== null
+                  ? "Suppression en cours..."
+                  : "Supprimer la campagne"}
+              </button>
+            </div>
+          </section>
         </div>
-      </section>
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
## Objectif

Transformer la page Années scolaires en vraie page de consultation et gestion des campagnes d’inscription, avec historique, activation, suppression et cohérence des données par année active.

## Contenu

### Page Années scolaires
- remplacement du placeholder par une vraie page d’historique
- chargement des années scolaires depuis l’API
- affichage sous forme de cards verticales
- mise en évidence de l’année active
- affichage des années historiques
- état vide avec lien vers Campagne d’inscription
- lien `Voir les demandes` vers `/applications?schoolYearId=<id>`

### Activation d’une campagne
- ajout du client frontend pour `PATCH /api/school-years/:id/activate`
- activation depuis la page Années scolaires
- mise à jour locale après activation
- garantie visuelle d’une seule année active

### Suppression d’une campagne
- ajout de `DELETE /api/school-years/:id`
- suppression transactionnelle :
  - année scolaire
  - demandes associées
  - élèves liés
  - logs d’import de la campagne
  - familles devenues orphelines
- si l’année supprimée était active :
  - réactivation automatique de l’année restante la plus récente
- ajout d’un bouton / icône de suppression sur les cards
- ajout d’une modal de confirmation :
  - Annuler
  - Supprimer la campagne
- verrouillage des actions pendant suppression
- toasts succès / erreur

### Règle métier import CSV
- l’import CSV est verrouillé dès qu’un import réussi existe pour l’année active
- règle backend ajoutée :
  - une campagne = un import CSV réussi
- création d’une nouvelle année/campagne → import de nouveau disponible
- message explicite côté UI lorsque l’import est déjà effectué

### Dashboard par année active
- correction du calcul des statistiques dashboard
- les totaux, statuts, priorités et répartitions par niveau sont maintenant calculés sur l’année active uniquement
- fin de l’agrégation globale de toute la BDD

### Liste des demandes par année active
- la liste des demandes se cale par défaut sur l’année active
- le compteur reflète désormais les demandes de l’année active
- l’option `Toutes les années scolaires` reste disponible manuellement
- `Réinitialiser` revient sur l’année active

### Import CSV — correctif familles
- correction du résumé d’import : les familles rattachées à l’import sont correctement comptabilisées
- ajout d’un fallback d’affichage pour les anciens logs déjà enregistrés avec `0`

### Modal premier démarrage
- amélioration de la lisibilité
- overlay plus lisible
- carte moins translucide
- textes plus contrastés

## Fichiers concernés

- `apps/web/src/pages/SchoolYearsPage.tsx`
- `apps/web/src/pages/ApplicationsPage.tsx`
- `apps/web/src/pages/ImportCsvPage.tsx`
- `apps/web/src/components/layout/FirstRunOnboarding.tsx`
- `apps/web/src/lib/api.ts`
- `apps/api/src/controllers/school-year.controller.ts`
- `apps/api/src/routes/school-year.routes.ts`
- `apps/api/src/controllers/import.controller.ts`
- `apps/api/src/controllers/dashboard.controller.ts`

## Vérifications

- [x] `npx tsc --noEmit -p apps/api/tsconfig.json`
- [x] `npm exec -w apps/web -- tsc -b`
- [x] `npm run build -w apps/web`
- [x] `npm run dev:web`

## Contrôles manuels à effectuer

- [ ] `/school-years` affiche les années en cards verticales
- [ ] activation d’une année fonctionne
- [ ] une seule année reste active
- [ ] suppression demande confirmation par modal
- [ ] suppression retire bien la campagne et ses données associées
- [ ] suppression d’une année active réactive une autre année si disponible
- [ ] dashboard affiche uniquement les données de l’année active
- [ ] liste des demandes affiche par défaut l’année active
- [ ] import CSV est bloqué après un import réussi sur la même année
- [ ] création d’une nouvelle campagne débloque l’import

## Notes

- cette PR renforce le modèle métier : une campagne d’inscription correspond à une année scolaire et à un import CSV réussi
- l’application devient plus cohérente pour une utilisation réelle par le directeur