### PR TITLE
feat(applications): add student-level admission decisions

### DIFF
--- a/apps/api/src/controllers/application.controller.ts
+++ b/apps/api/src/controllers/application.controller.ts
@@ -35,6 +35,18 @@ const isApplicationStatus = (value: string): value is ApplicationStatus => {
   return Object.values(ApplicationStatus).includes(value as ApplicationStatus);
 };
 
+type StudentAdmissionStatus = "PENDING" | "ACCEPTED" | "REFUSED" | "WAITLISTED";
+const studentAdmissionStatuses: StudentAdmissionStatus[] = [
+  "PENDING",
+  "ACCEPTED",
+  "REFUSED",
+  "WAITLISTED"
+];
+
+const isStudentAdmissionStatus = (value: string): value is StudentAdmissionStatus => {
+  return studentAdmissionStatuses.includes(value as StudentAdmissionStatus);
+};
+
 type ApplicationDecisionStatus = "ACCEPTED" | "REFUSED";
 type ApplicationEmailType = "ACCEPTANCE" | "REFUSAL" | "CUSTOM";
 
@@ -50,6 +62,55 @@ const isApplicationEmailType = (value: string): value is ApplicationEmailType =>
     value === EmailType.REFUSAL ||
     value === EmailType.CUSTOM
   );
+};
+
+const getRecalculatedApplicationStatus = (
+  currentStatus: ApplicationStatus,
+  students: Array<{ admissionStatus: StudentAdmissionStatus }>
+): ApplicationStatus => {
+  if (students.length === 0) {
+    return currentStatus;
+  }
+
+  const allPending = students.every(
+    (student) => student.admissionStatus === "PENDING"
+  );
+
+  if (allPending) {
+    return currentStatus === ApplicationStatus.RECEIVED ||
+      currentStatus === ApplicationStatus.IN_REVIEW
+      ? currentStatus
+      : ApplicationStatus.IN_REVIEW;
+  }
+
+  const allAccepted = students.every(
+    (student) => student.admissionStatus === "ACCEPTED"
+  );
+
+  if (allAccepted) {
+    return ApplicationStatus.ACCEPTED;
+  }
+
+  const allRefused = students.every(
+    (student) => student.admissionStatus === "REFUSED"
+  );
+
+  if (allRefused) {
+    return ApplicationStatus.REFUSED;
+  }
+
+  const hasAccepted = students.some(
+    (student) => student.admissionStatus === "ACCEPTED"
+  );
+  const hasRefused = students.some(
+    (student) => student.admissionStatus === "REFUSED"
+  );
+
+  if (hasAccepted || hasRefused) {
+    return ApplicationStatus.PARTIALLY_ACCEPTED;
+  }
+
+  return ApplicationStatus.IN_REVIEW;
 };
 
 export const getApplications = async (req: Request, res: Response): Promise<void> => {
@@ -268,16 +329,86 @@ export const updateApplicationDecision = async (req: Request, res: Response): Pr
     throw notFound("Application not found");
   }
 
-  const updatedApplication = await prisma.application.update({
-    where: { id: applicationId },
-    data: {
-      status,
-      decisionAt: new Date(),
-      decisionNote
-    }
+  const updatedApplication = await prisma.$transaction(async (transaction) => {
+    await transaction.student.updateMany({
+      where: { applicationId },
+      data: { admissionStatus: status }
+    });
+
+    return transaction.application.update({
+      where: { id: applicationId },
+      data: {
+        status,
+        decisionAt: new Date(),
+        decisionNote
+      }
+    });
   });
 
   res.status(200).json(updatedApplication);
+};
+
+export const updateStudentAdmissionStatus = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  const studentId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const admissionStatus = getQueryParam(req.body?.admissionStatus);
+
+  if (!admissionStatus || !isStudentAdmissionStatus(admissionStatus)) {
+    throw badRequest("Invalid student admission status");
+  }
+
+  const updateResult = await prisma.$transaction(async (transaction) => {
+    const existingStudent = await transaction.student.findUnique({
+      where: { id: studentId },
+      select: {
+        id: true,
+        applicationId: true,
+        application: {
+          select: {
+            status: true
+          }
+        }
+      }
+    });
+
+    if (!existingStudent) {
+      throw notFound("Student not found");
+    }
+
+    const updatedStudent = await transaction.student.update({
+      where: { id: studentId },
+      data: { admissionStatus },
+      include: {
+        level: true
+      }
+    });
+
+    const applicationStudents = await transaction.student.findMany({
+      where: { applicationId: existingStudent.applicationId },
+      select: { admissionStatus: true }
+    });
+    const recalculatedStatus = getRecalculatedApplicationStatus(
+      existingStudent.application.status,
+      applicationStudents
+    );
+    const updatedApplication = await transaction.application.update({
+      where: { id: existingStudent.applicationId },
+      data: { status: recalculatedStatus },
+      select: {
+        id: true,
+        status: true
+      }
+    });
+
+    return {
+      student: updatedStudent,
+      applicationStatus: updatedApplication.status
+    };
+  });
+
+  res.status(200).json(updateResult);
 };
 
 export const sendApplicationEmail = async (req: Request, res: Response): Promise<void> => {

--- a/apps/api/src/controllers/dashboard.controller.ts
+++ b/apps/api/src/controllers/dashboard.controller.ts
@@ -8,6 +8,7 @@ type DashboardStatusCounts = {
   IN_REVIEW: number;
   ACCEPTED: number;
   REFUSED: number;
+  PARTIALLY_ACCEPTED: number;
 };
 
 export const getDashboardStats = async (_req: Request, res: Response): Promise<void> => {
@@ -35,7 +36,8 @@ export const getDashboardStats = async (_req: Request, res: Response): Promise<v
         [ApplicationStatus.RECEIVED]: 0,
         [ApplicationStatus.IN_REVIEW]: 0,
         [ApplicationStatus.ACCEPTED]: 0,
-        [ApplicationStatus.REFUSED]: 0
+        [ApplicationStatus.REFUSED]: 0,
+        [ApplicationStatus.PARTIALLY_ACCEPTED]: 0
       },
       byLevel: levels.map((level) => ({
         code: level.code,
@@ -130,7 +132,8 @@ export const getDashboardStats = async (_req: Request, res: Response): Promise<v
     [ApplicationStatus.RECEIVED]: 0,
     [ApplicationStatus.IN_REVIEW]: 0,
     [ApplicationStatus.ACCEPTED]: 0,
-    [ApplicationStatus.REFUSED]: 0
+    [ApplicationStatus.REFUSED]: 0,
+    [ApplicationStatus.PARTIALLY_ACCEPTED]: 0
   };
 
   for (const statusCount of statusCounts) {

--- a/apps/api/src/routes/application.routes.ts
+++ b/apps/api/src/routes/application.routes.ts
@@ -6,6 +6,7 @@ import {
   getApplicationById,
   getApplications,
   sendApplicationEmail,
+  updateStudentAdmissionStatus,
   updateApplicationPriority,
   updateApplicationStatus
 } from "../controllers/application.controller";
@@ -19,5 +20,6 @@ router.patch("/applications/:id/status", updateApplicationStatus);
 router.patch("/applications/:id/priority", updateApplicationPriority);
 router.patch("/applications/:id/decision", updateApplicationDecision);
 router.post("/applications/:id/send-email", sendApplicationEmail);
+router.patch("/students/:id/admission-status", updateStudentAdmissionStatus);
 
 export default router;

--- a/apps/web/src/components/ui/StatusBadge.tsx
+++ b/apps/web/src/components/ui/StatusBadge.tsx
@@ -82,6 +82,25 @@ const RefusedIcon = () => {
   );
 };
 
+const PartialIcon = () => {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      className="h-3.5 w-3.5 flex-none"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M3.5 8h9" />
+      <path d="m4.25 5.25 2 2-2 2" />
+      <path d="m11.75 5.25-2 2 2 2" />
+    </svg>
+  );
+};
+
 const statusBadgeConfig: Record<ApplicationStatus, StatusBadgeConfig> = {
   RECEIVED: {
     badgeClassName: "bg-slate-100 text-slate-700 ring-slate-200",
@@ -102,6 +121,11 @@ const statusBadgeConfig: Record<ApplicationStatus, StatusBadgeConfig> = {
     badgeClassName: "bg-danger/15 text-danger ring-danger/20",
     label: "Refusée",
     Icon: RefusedIcon
+  },
+  PARTIALLY_ACCEPTED: {
+    badgeClassName: "bg-secondary/15 text-secondaryDark ring-secondary/25",
+    label: "Décision partielle",
+    Icon: PartialIcon
   }
 };
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -10,7 +10,9 @@ import type {
   ApplicationStatus,
   ApplicationStatusUpdateResult,
   CreateSchoolYearPayload,
-  SchoolYearSummary
+  SchoolYearSummary,
+  StudentAdmissionStatus,
+  StudentAdmissionStatusUpdateResult
 } from "../types/application";
 import type { DashboardStats } from "../types/dashboard";
 import type { CsvImportHistoryItem, CsvImportSummary } from "../types/import";
@@ -215,6 +217,25 @@ export const updateApplicationDecision = async (
         ...init?.headers
       },
       body: JSON.stringify(payload)
+    }
+  );
+};
+
+export const updateStudentAdmissionStatus = async (
+  studentId: string,
+  admissionStatus: StudentAdmissionStatus,
+  init?: RequestInit
+): Promise<StudentAdmissionStatusUpdateResult> => {
+  return fetchJson<StudentAdmissionStatusUpdateResult>(
+    `/api/students/${encodeURIComponent(studentId)}/admission-status`,
+    {
+      ...init,
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        ...init?.headers
+      },
+      body: JSON.stringify({ admissionStatus })
     }
   );
 };

--- a/apps/web/src/pages/ApplicationDetailPage.tsx
+++ b/apps/web/src/pages/ApplicationDetailPage.tsx
@@ -24,7 +24,8 @@ import {
   getApplicationEmailLogs,
   updateApplicationDecision,
   updateApplicationPriority,
-  updateApplicationStatus
+  updateApplicationStatus,
+  updateStudentAdmissionStatus
 } from "../lib/api";
 import {
   applicationEmailSendStatusLabels,
@@ -38,7 +39,8 @@ import type {
   ApplicationDetailStudent,
   ApplicationEmailLog,
   ApplicationGender,
-  ApplicationStatus
+  ApplicationStatus,
+  StudentAdmissionStatus
 } from "../types/application";
 
 type IconProps = {
@@ -84,7 +86,8 @@ const statusOptions: Array<{
   { value: "RECEIVED", label: "Reçue" },
   { value: "IN_REVIEW", label: "En revue" },
   { value: "ACCEPTED", label: "Acceptée" },
-  { value: "REFUSED", label: "Refusée" }
+  { value: "REFUSED", label: "Refusée" },
+  { value: "PARTIALLY_ACCEPTED", label: "Décision partielle" }
 ];
 
 const decisionOptions: Array<{
@@ -94,6 +97,30 @@ const decisionOptions: Array<{
   { value: "ACCEPTED", label: "Acceptée" },
   { value: "REFUSED", label: "Refusée" }
 ];
+
+const studentAdmissionStatusOptions: Array<{
+  value: StudentAdmissionStatus;
+  label: string;
+}> = [
+  { value: "ACCEPTED", label: "Accepter" },
+  { value: "REFUSED", label: "Refuser" },
+  { value: "WAITLISTED", label: "Liste d'attente" },
+  { value: "PENDING", label: "Remettre en attente" }
+];
+
+const studentAdmissionStatusLabels: Record<StudentAdmissionStatus, string> = {
+  PENDING: "En attente",
+  ACCEPTED: "Accepté",
+  REFUSED: "Refusé",
+  WAITLISTED: "Liste d'attente"
+};
+
+const studentAdmissionStatusStyles: Record<StudentAdmissionStatus, string> = {
+  PENDING: "bg-slate-100 text-slate-700 ring-slate-200",
+  ACCEPTED: "bg-success/15 text-success ring-success/20",
+  REFUSED: "bg-danger/15 text-danger ring-danger/20",
+  WAITLISTED: "bg-info/15 text-info ring-info/20"
+};
 
 const dateTimeFormatter = new Intl.DateTimeFormat("fr-FR", {
   dateStyle: "medium",
@@ -291,6 +318,38 @@ const getDecisionSummary = (status: ApplicationDecisionStatus): string => {
   return status === "ACCEPTED" ? "Acceptation enregistrée" : "Refus enregistré";
 };
 
+const getStudentAdmissionStatus = (
+  student: ApplicationDetailStudent
+): StudentAdmissionStatus => {
+  return student.admissionStatus ?? "PENDING";
+};
+
+const getStudentAdmissionCounts = (students: ApplicationDetailStudent[]) => {
+  return students.reduce(
+    (counts, student) => {
+      counts[getStudentAdmissionStatus(student)] += 1;
+
+      return counts;
+    },
+    {
+      PENDING: 0,
+      ACCEPTED: 0,
+      REFUSED: 0,
+      WAITLISTED: 0
+    } satisfies Record<StudentAdmissionStatus, number>
+  );
+};
+
+const getStudentAdmissionSummary = (students: ApplicationDetailStudent[]): string => {
+  const counts = getStudentAdmissionCounts(students);
+
+  return `${counts.ACCEPTED} accepté${counts.ACCEPTED > 1 ? "s" : ""} · ${
+    counts.REFUSED
+  } refusé${counts.REFUSED > 1 ? "s" : ""} · ${counts.WAITLISTED} en liste d'attente · ${
+    counts.PENDING
+  } en attente`;
+};
+
 const BackIcon = ({ className = "h-4 w-4" }: IconProps) => {
   return (
     <svg
@@ -426,6 +485,20 @@ const ParentCard = ({
   );
 };
 
+const StudentAdmissionBadge = ({
+  status
+}: {
+  status: StudentAdmissionStatus;
+}) => {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] ring-1 ${studentAdmissionStatusStyles[status]}`}
+    >
+      {studentAdmissionStatusLabels[status]}
+    </span>
+  );
+};
+
 const buildTimelineEntries = (
   application: ApplicationDetail,
   emailLogs: ApplicationEmailLog[]
@@ -498,6 +571,8 @@ const ApplicationDetailPage = () => {
     useState<ApplicationDecisionStatus>("ACCEPTED");
   const [decisionNote, setDecisionNote] = useState("");
   const [isDecisionSubmitting, setIsDecisionSubmitting] = useState(false);
+  const [updatingStudentAdmissionId, setUpdatingStudentAdmissionId] =
+    useState<string | null>(null);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -671,7 +746,11 @@ const ApplicationDetailPage = () => {
             ...currentApplication,
             status: updatedApplication.status,
             decisionAt: updatedApplication.decisionAt,
-            decisionNote: updatedApplication.decisionNote
+            decisionNote: updatedApplication.decisionNote,
+            students: currentApplication.students.map((student) => ({
+              ...student,
+              admissionStatus: updatedApplication.status
+            }))
           };
         });
         setSelectedDecisionStatus(updatedApplication.status);
@@ -689,6 +768,56 @@ const ApplicationDetailPage = () => {
       }
     },
     [application, decisionNote, selectedDecisionStatus, showError, showSuccess]
+  );
+
+  const handleStudentAdmissionStatusUpdate = useCallback(
+    async (
+      studentId: string,
+      admissionStatus: StudentAdmissionStatus
+    ): Promise<void> => {
+      if (!application) {
+        return;
+      }
+
+      setUpdatingStudentAdmissionId(studentId);
+
+      try {
+        const updateResult = await updateStudentAdmissionStatus(
+          studentId,
+          admissionStatus
+        );
+
+        setApplication((currentApplication) => {
+          if (!currentApplication) {
+            return currentApplication;
+          }
+
+          return {
+            ...currentApplication,
+            status: updateResult.applicationStatus,
+            students: currentApplication.students.map((student) =>
+              student.id === updateResult.student.id
+                ? {
+                    ...student,
+                    admissionStatus: updateResult.student.admissionStatus
+                  }
+                : student
+            )
+          };
+        });
+        showSuccess("La décision de l'élève a bien été mise à jour.");
+      } catch (updateError) {
+        showError(
+          getActionErrorMessage(
+            "Impossible de mettre à jour la décision de l'élève.",
+            updateError
+          )
+        );
+      } finally {
+        setUpdatingStudentAdmissionId(null);
+      }
+    },
+    [application, showError, showSuccess]
   );
 
   const pageTopBar = (
@@ -935,6 +1064,21 @@ const ApplicationDetailPage = () => {
             </form>
 
             <div className="shrink-0 rounded-[22px] border border-slate-200/90 bg-slate-50/80 p-3.5">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                Décision des élèves
+              </p>
+              <p className="mt-2 text-sm font-semibold leading-6 text-slate-900">
+                {getStudentAdmissionSummary(application.students)}
+              </p>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <span className="text-sm font-medium text-slate-600">
+                  Statut global :
+                </span>
+                <StatusBadge status={application.status} />
+              </div>
+            </div>
+
+            <div className="shrink-0 rounded-[22px] border border-slate-200/90 bg-slate-50/80 p-3.5">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
@@ -1101,6 +1245,9 @@ const ApplicationDetailPage = () => {
                         <span className="text-sm font-medium text-slate-600">
                           {student.level.label}
                         </span>
+                        <StudentAdmissionBadge
+                          status={getStudentAdmissionStatus(student)}
+                        />
                       </div>
                     </div>
                   </div>
@@ -1110,6 +1257,42 @@ const ApplicationDetailPage = () => {
                     <DetailField label="Naissance">
                       {formatOptionalDate(student.birthDate)}
                     </DetailField>
+                  </div>
+
+                  <div className="mt-5 border-t border-slate-200/80 pt-4">
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                      Décision individuelle
+                    </p>
+                    <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                      {studentAdmissionStatusOptions.map((option) => {
+                        const isCurrentStatus =
+                          getStudentAdmissionStatus(student) === option.value;
+                        const isSubmitting = updatingStudentAdmissionId === student.id;
+
+                        return (
+                          <button
+                            key={option.value}
+                            type="button"
+                            onClick={() =>
+                              void handleStudentAdmissionStatusUpdate(
+                                student.id,
+                                option.value
+                              )
+                            }
+                            disabled={isSubmitting || isCurrentStatus}
+                            className={`inline-flex min-h-10 items-center justify-center rounded-full border px-3 py-2 text-xs font-semibold transition disabled:cursor-not-allowed ${
+                              isCurrentStatus
+                                ? "border-primary/20 bg-primary/10 text-primaryDark"
+                                : "border-slate-300 bg-white text-slate-700 hover:border-primary/25 hover:text-primary disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400"
+                            }`}
+                          >
+                            {isSubmitting && !isCurrentStatus
+                              ? "Mise à jour..."
+                              : option.label}
+                          </button>
+                        );
+                      })}
+                    </div>
                   </div>
                 </article>
               ))}

--- a/apps/web/src/pages/ApplicationEmailPage.tsx
+++ b/apps/web/src/pages/ApplicationEmailPage.tsx
@@ -38,7 +38,8 @@ import type {
   ApplicationEmailLog,
   ApplicationEmailSendPayload,
   ApplicationEmailType,
-  ApplicationGender
+  ApplicationGender,
+  StudentAdmissionStatus
 } from "../types/application";
 
 type IconProps = {
@@ -62,6 +63,20 @@ const dateTimeFormatter = new Intl.DateTimeFormat("fr-FR", {
   dateStyle: "medium",
   timeStyle: "short"
 });
+
+const studentAdmissionStatusLabels: Record<StudentAdmissionStatus, string> = {
+  PENDING: "En attente",
+  ACCEPTED: "Accepté",
+  REFUSED: "Refusé",
+  WAITLISTED: "Liste d'attente"
+};
+
+const studentAdmissionStatusStyles: Record<StudentAdmissionStatus, string> = {
+  PENDING: "bg-slate-100 text-slate-700 ring-slate-200",
+  ACCEPTED: "bg-success/15 text-success ring-success/20",
+  REFUSED: "bg-danger/15 text-danger ring-danger/20",
+  WAITLISTED: "bg-info/15 text-info ring-info/20"
+};
 
 const getEnterStyle = (delay: number): CSSProperties => {
   return {
@@ -144,6 +159,12 @@ const getStudentAvatarVariant = (
   }
 
   return "neutral";
+};
+
+const getStudentAdmissionStatus = (
+  student: ApplicationDetail["students"][number]
+): StudentAdmissionStatus => {
+  return student.admissionStatus ?? "PENDING";
 };
 
 const BackIcon = ({ className = "h-4 w-4" }: IconProps) => {
@@ -635,6 +656,11 @@ const ApplicationEmailPage = () => {
                       />
                       <span className="text-xs font-medium text-slate-500">
                         {student.level.label}
+                      </span>
+                      <span
+                        className={`rounded-full px-2.5 py-1 text-[0.66rem] font-semibold uppercase tracking-[0.16em] ring-1 ${studentAdmissionStatusStyles[getStudentAdmissionStatus(student)]}`}
+                      >
+                        {studentAdmissionStatusLabels[getStudentAdmissionStatus(student)]}
                       </span>
                     </div>
                   </div>

--- a/apps/web/src/pages/ApplicationsPage.tsx
+++ b/apps/web/src/pages/ApplicationsPage.tsx
@@ -71,7 +71,8 @@ const statusOptions: StatusOption[] = [
   { value: "RECEIVED", label: "Reçues" },
   { value: "IN_REVIEW", label: "En revue" },
   { value: "ACCEPTED", label: "Acceptées" },
-  { value: "REFUSED", label: "Refusées" }
+  { value: "REFUSED", label: "Refusées" },
+  { value: "PARTIALLY_ACCEPTED", label: "Décisions partielles" }
 ];
 
 const sortOptions: ApplicationsSortOption[] = [

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -142,6 +142,22 @@ const RefusedMetricIcon = ({ className = "h-5 w-5" }: IconProps) => {
   );
 };
 
+const PartialMetricIcon = ({ className = "h-5 w-5" }: IconProps) => {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      className={className}
+    >
+      <path d="M4.5 10h11" strokeLinecap="round" />
+      <path d="m5.3 6.8 2.8 3.2-2.8 3.2" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="m14.7 6.8-2.8 3.2 2.8 3.2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+};
+
 const statusCards: StatusCardConfig[] = [
   {
     status: "RECEIVED",
@@ -178,6 +194,15 @@ const statusCards: StatusCardConfig[] = [
     surfaceClassName: "bg-danger/10",
     iconClassName: "bg-danger text-white",
     Icon: RefusedMetricIcon
+  },
+  {
+    status: "PARTIALLY_ACCEPTED",
+    label: "Partielles",
+    description: "Dossiers avec des décisions différentes selon les élèves.",
+    valueClassName: "text-secondaryDark",
+    surfaceClassName: "bg-secondary/10",
+    iconClassName: "bg-secondary text-white",
+    Icon: PartialMetricIcon
   }
 ];
 

--- a/apps/web/src/types/application.ts
+++ b/apps/web/src/types/application.ts
@@ -2,9 +2,15 @@ export type ApplicationStatus =
   | "RECEIVED"
   | "IN_REVIEW"
   | "ACCEPTED"
-  | "REFUSED";
+  | "REFUSED"
+  | "PARTIALLY_ACCEPTED";
 
 export type ApplicationDecisionStatus = "ACCEPTED" | "REFUSED";
+export type StudentAdmissionStatus =
+  | "PENDING"
+  | "ACCEPTED"
+  | "REFUSED"
+  | "WAITLISTED";
 
 export type ApplicationLevel = {
   code: string;
@@ -19,6 +25,7 @@ export type ApplicationStudent = {
   id: string;
   firstName: string;
   lastName: string;
+  admissionStatus: StudentAdmissionStatus;
   level: ApplicationLevel;
 };
 
@@ -108,6 +115,11 @@ export type ApplicationDecisionUpdateResult = {
   status: ApplicationDecisionStatus;
   decisionAt: string | null;
   decisionNote: string | null;
+};
+
+export type StudentAdmissionStatusUpdateResult = {
+  student: ApplicationDetailStudent;
+  applicationStatus: ApplicationStatus;
 };
 
 export type ApplicationFilterParams = {

--- a/prisma/migrations/20260427000000_add_student_admission_status/migration.sql
+++ b/prisma/migrations/20260427000000_add_student_admission_status/migration.sql
@@ -1,0 +1,8 @@
+-- AlterEnum
+ALTER TYPE "ApplicationStatus" ADD VALUE 'PARTIALLY_ACCEPTED';
+
+-- CreateEnum
+CREATE TYPE "StudentAdmissionStatus" AS ENUM ('PENDING', 'ACCEPTED', 'REFUSED', 'WAITLISTED');
+
+-- AlterTable
+ALTER TABLE "Student" ADD COLUMN "admissionStatus" "StudentAdmissionStatus" NOT NULL DEFAULT 'PENDING';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,6 +11,14 @@ enum ApplicationStatus {
   IN_REVIEW
   ACCEPTED
   REFUSED
+  PARTIALLY_ACCEPTED
+}
+
+enum StudentAdmissionStatus {
+  PENDING
+  ACCEPTED
+  REFUSED
+  WAITLISTED
 }
 
 enum StudentGender {
@@ -99,14 +107,15 @@ model Application {
 }
 
 model Student {
-  id            String        @id @default(cuid())
-  applicationId String
-  levelId       String
-  lastName      String
-  firstName     String
-  gender        StudentGender @default(UNKNOWN)
-  birthDate     DateTime
-  rankInForm    Int?
+  id              String                 @id @default(cuid())
+  applicationId   String
+  levelId         String
+  lastName        String
+  firstName       String
+  gender          StudentGender          @default(UNKNOWN)
+  birthDate       DateTime
+  rankInForm      Int?
+  admissionStatus StudentAdmissionStatus @default(PENDING)
 
   application Application @relation(fields: [applicationId], references: [id], onDelete: Cascade)
   level       Level       @relation(fields: [levelId], references: [id], onDelete: Restrict)


### PR DESCRIPTION
## Objectif

Permettre une décision individuelle par enfant dans une même demande d’inscription, tout en conservant un statut global lisible au niveau du dossier famille.

## Contexte

Une demande peut contenir plusieurs enfants. Le statut uniquement porté par `Application` ne permettait pas de gérer les cas où certains enfants sont acceptés et d’autres refusés.

Exemple :
- enfant en CP : accepté
- enfant en CE2 : refusé
- enfant en CM2 : accepté

## Contenu

### Prisma
- ajout de l’enum `StudentAdmissionStatus`
- ajout de `Student.admissionStatus` avec valeur par défaut `PENDING`
- ajout de `ApplicationStatus.PARTIALLY_ACCEPTED`
- migration dédiée :
  - `20260427000000_add_student_admission_status`

### Backend
- ajout de l’endpoint :
  - `PATCH /api/students/:id/admission-status`
- validation du payload
- transaction Prisma
- mise à jour du statut individuel de l’élève
- recalcul automatique du statut global de la demande

### Règles métier
- tous les élèves `PENDING` → conserve `RECEIVED` / `IN_REVIEW` ou revient à `IN_REVIEW`
- tous `ACCEPTED` → demande `ACCEPTED`
- tous `REFUSED` → demande `REFUSED`
- mélange accepté / refusé → demande `PARTIALLY_ACCEPTED`
- uniquement liste d’attente / pending sans accepté ni refusé → demande `IN_REVIEW`

### Frontend
- ajout des types liés aux statuts individuels
- ajout du client API `updateStudentAdmissionStatus`
- affichage des statuts individuels dans les cards élèves
- ajout d’actions par élève :
  - accepter
  - refuser
  - liste d’attente
  - remettre en attente
- mise à jour locale du statut élève et du statut global
- adaptation du bloc `Traitement` avec résumé des décisions élèves
- prise en charge de `PARTIALLY_ACCEPTED` dans :
  - Dashboard
  - Liste des demandes
  - `StatusBadge`

### Email
- affichage des statuts individuels des élèves sur la page email
- pas de refonte des templates dans cette tâche

## Fichiers concernés

- `prisma/schema.prisma`
- `prisma/migrations/20260427000000_add_student_admission_status/migration.sql`
- backend students / applications
- `apps/web/src/pages/ApplicationDetailPage.tsx`
- `apps/web/src/pages/ApplicationEmailPage.tsx`
- `apps/web/src/components/ui/StatusBadge.tsx`
- types et client API frontend

## Vérifications

- [x] `npx prisma validate`
- [x] `npx prisma migrate dev --name add-student-admission-status`
- [x] `npx tsc --noEmit -p apps/api/tsconfig.json`
- [x] `npm exec -w apps/web -- tsc -b`
- [x] `npm run build -w apps/web`

## Contrôles manuels à effectuer

- [ ] ouvrir une demande avec plusieurs enfants
- [ ] accepter un enfant
- [ ] refuser un autre enfant
- [ ] vérifier le statut global `PARTIALLY_ACCEPTED`
- [ ] accepter tous les enfants → demande `ACCEPTED`
- [ ] refuser tous les enfants → demande `REFUSED`
- [ ] remettre les enfants en attente → statut global cohérent
- [ ] vérifier la liste des demandes
- [ ] vérifier le dashboard
- [ ] ouvrir la page email

## Résultat

Le modèle métier devient plus précis :  
`Application` représente le dossier famille, tandis que `Student` porte la décision individuelle.