### PR TITLE
perf(web): optimize rerenders on main pages

### DIFF
--- a/apps/web/src/pages/ApplicationDetailPage.tsx
+++ b/apps/web/src/pages/ApplicationDetailPage.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useState,
   type CSSProperties,
   type ReactNode
@@ -827,6 +828,62 @@ const ApplicationDetailPage = () => {
     [application, showError, showSuccess]
   );
 
+  const timelineEntries = useMemo(() => {
+    return application ? buildTimelineEntries(application, emailLogs) : [];
+  }, [application, emailLogs]);
+  const familyLastNameTitle = useMemo(
+    () => (application ? getFamilyLastNameTitle(application) : "Famille non renseignée"),
+    [application]
+  );
+  const familyAvatarLabel =
+    familyLastNameTitle === "Famille non renseignée"
+      ? familyLastNameTitle
+      : `Famille ${familyLastNameTitle}`;
+  const applicationLevels = useMemo(
+    () => (application ? getApplicationLevels(application) : []),
+    [application]
+  );
+  const fatherName = useMemo(() => {
+    return application
+      ? formatParentName(
+          application.family.fatherFirstName,
+          application.family.fatherLastName
+        )
+      : "Non renseigné";
+  }, [application]);
+  const motherName = useMemo(() => {
+    return application
+      ? formatParentName(
+          application.family.motherFirstName,
+          application.family.motherLastName
+        )
+      : "Non renseigné";
+  }, [application]);
+  const studentAdmissionSummary = useMemo(() => {
+    return application ? getStudentAdmissionSummary(application.students) : "";
+  }, [application]);
+
+  const handleSelectedStatusChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>): void => {
+      setSelectedStatus(event.target.value as ApplicationStatus);
+    },
+    []
+  );
+
+  const handleSelectedDecisionStatusChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>): void => {
+      setSelectedDecisionStatus(event.target.value as ApplicationDecisionStatus);
+    },
+    []
+  );
+
+  const handleDecisionNoteChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>): void => {
+      setDecisionNote(event.target.value);
+    },
+    []
+  );
+
   const pageTopBar = (
     <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
       <div
@@ -909,22 +966,6 @@ const ApplicationDetailPage = () => {
       </>
     );
   }
-
-  const timelineEntries = buildTimelineEntries(application, emailLogs);
-  const familyLastNameTitle = getFamilyLastNameTitle(application);
-  const familyAvatarLabel =
-    familyLastNameTitle === "Famille non renseignée"
-      ? familyLastNameTitle
-      : `Famille ${familyLastNameTitle}`;
-  const applicationLevels = getApplicationLevels(application);
-  const fatherName = formatParentName(
-    application.family.fatherFirstName,
-    application.family.fatherLastName
-  );
-  const motherName = formatParentName(
-    application.family.motherFirstName,
-    application.family.motherLastName
-  );
 
   return (
     <>
@@ -1043,9 +1084,7 @@ const ApplicationDetailPage = () => {
                     id="application-status"
                     aria-label="Nouveau statut"
                     value={selectedStatus}
-                    onChange={(event) =>
-                      setSelectedStatus(event.target.value as ApplicationStatus)
-                    }
+                    onChange={handleSelectedStatusChange}
                     disabled={isStatusSubmitting}
                     className="min-w-[170px] rounded-2xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm font-medium text-slate-900 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
                   >
@@ -1075,7 +1114,7 @@ const ApplicationDetailPage = () => {
                 Décision des élèves
               </p>
               <p className="mt-2 text-sm font-semibold leading-6 text-slate-900">
-                {getStudentAdmissionSummary(application.students)}
+                {studentAdmissionSummary}
               </p>
               <div className="mt-3 flex flex-wrap items-center gap-2">
                 <span className="text-sm font-medium text-slate-600">
@@ -1139,11 +1178,7 @@ const ApplicationDetailPage = () => {
                 <select
                   id="application-decision-status"
                   value={selectedDecisionStatus}
-                  onChange={(event) =>
-                    setSelectedDecisionStatus(
-                      event.target.value as ApplicationDecisionStatus
-                    )
-                  }
+                  onChange={handleSelectedDecisionStatusChange}
                   disabled={isDecisionSubmitting}
                   className="w-full rounded-2xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm font-medium text-slate-900 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
                 >
@@ -1165,7 +1200,7 @@ const ApplicationDetailPage = () => {
                 <textarea
                   id="application-decision-note"
                   value={decisionNote}
-                  onChange={(event) => setDecisionNote(event.target.value)}
+                  onChange={handleDecisionNoteChange}
                   disabled={isDecisionSubmitting}
                   rows={2}
                   className="w-full rounded-2xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm text-slate-900 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"

--- a/apps/web/src/pages/ApplicationEmailPage.tsx
+++ b/apps/web/src/pages/ApplicationEmailPage.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useState,
   type CSSProperties,
   type ReactNode
@@ -477,11 +478,43 @@ const ApplicationEmailPage = () => {
     }
   }, [isEmailSubmitting]);
 
+  const handleEmailSubjectChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>): void => {
+      setEmailSubject(event.target.value);
+      setIsEmailSubjectDirty(true);
+    },
+    []
+  );
+
+  const handleEmailBodyChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>): void => {
+      setEmailBody(event.target.value);
+      setIsEmailBodyDirty(true);
+    },
+    []
+  );
+
   useEffect(() => {
     setIsSendConfirmationOpen(false);
   }, [selectedEmailType, emailSubject, emailBody]);
 
   const detailPath = applicationId ? `/applications/${applicationId}` : "/applications";
+  const latestEmailLogs = useMemo(() => emailLogs.slice(0, 4), [emailLogs]);
+  const decisionEmailContext = useMemo(() => {
+    return application ? getApplicationDecisionEmailContext(application) : null;
+  }, [application]);
+  const recommendedEmailType =
+    decisionEmailContext?.recommendedEmailType ?? selectedEmailType;
+  const applicationFamilyTitle = useMemo(
+    () => getApplicationFamilyTitle(application),
+    [application]
+  );
+  const isCustomEmail = selectedEmailType === "CUSTOM";
+  const isEmailTypeMismatch = selectedEmailType !== recommendedEmailType;
+  const requiresSendConfirmation = getRequiresSendConfirmation(
+    selectedEmailType,
+    recommendedEmailType
+  );
   const pageTopBar = (
     <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
       <div
@@ -564,15 +597,9 @@ const ApplicationEmailPage = () => {
     );
   }
 
-  const latestEmailLogs = emailLogs.slice(0, 4);
-  const decisionEmailContext = getApplicationDecisionEmailContext(application);
-  const recommendedEmailType = decisionEmailContext.recommendedEmailType;
-  const isCustomEmail = selectedEmailType === "CUSTOM";
-  const isEmailTypeMismatch = selectedEmailType !== recommendedEmailType;
-  const requiresSendConfirmation = getRequiresSendConfirmation(
-    selectedEmailType,
-    recommendedEmailType
-  );
+  if (!decisionEmailContext) {
+    return null;
+  }
 
   return (
     <>
@@ -581,9 +608,7 @@ const ApplicationEmailPage = () => {
           topBar={pageTopBar}
           eyebrow="Email de décision"
           title="Envoyer un email à la famille"
-          description={`${getApplicationFamilyTitle(
-            application
-          )} · destinataire ${formatOptionalText(application.family.contactEmail)}.`}
+          description={`${applicationFamilyTitle} · destinataire ${formatOptionalText(application.family.contactEmail)}.`}
           aside={pageHeaderAside}
         />
       </div>
@@ -658,10 +683,7 @@ const ApplicationEmailPage = () => {
                 <input
                   type="text"
                   value={emailSubject}
-                  onChange={(event) => {
-                    setEmailSubject(event.target.value);
-                    setIsEmailSubjectDirty(true);
-                  }}
+                  onChange={handleEmailSubjectChange}
                   disabled={isEmailSubmitting}
                   className="mt-2 w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
                   placeholder={
@@ -716,10 +738,7 @@ const ApplicationEmailPage = () => {
               </span>
               <textarea
                 value={emailBody}
-                onChange={(event) => {
-                  setEmailBody(event.target.value);
-                  setIsEmailBodyDirty(true);
-                }}
+                onChange={handleEmailBodyChange}
                 disabled={isEmailSubmitting}
                 rows={10}
                 className="mt-2 min-h-[320px] flex-1 resize-y rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm leading-6 text-slate-900 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
@@ -759,7 +778,7 @@ const ApplicationEmailPage = () => {
         >
           <div className="space-y-4">
             <DetailField label="Famille">
-              {getApplicationFamilyTitle(application)}
+              {applicationFamilyTitle}
             </DetailField>
             <DetailField label="Année scolaire">
               {formatSchoolYearLabel(application.schoolYear.label)}

--- a/apps/web/src/pages/ApplicationsPage.tsx
+++ b/apps/web/src/pages/ApplicationsPage.tsx
@@ -1,4 +1,5 @@
 import {
+  memo,
   useCallback,
   useDeferredValue,
   useEffect,
@@ -272,11 +273,11 @@ const FilterField = ({ label, className, children }: FilterFieldProps) => {
   );
 };
 
-const PaginationControls = ({
+const PaginationControls = memo(function PaginationControls({
   currentPage,
   totalPages,
   onPageChange
-}: PaginationControlsProps) => {
+}: PaginationControlsProps) {
   if (totalPages <= 1) {
     return null;
   }
@@ -341,7 +342,7 @@ const PaginationControls = ({
       </div>
     </div>
   );
-};
+});
 
 const ApplicationsPage = () => {
   const [searchParams] = useSearchParams();
@@ -408,17 +409,34 @@ const ApplicationsPage = () => {
     return displayedApplications.slice(startIndex, startIndex + pageSize);
   }, [displayedApplications, pageSize, resolvedCurrentPage]);
 
-  const hasActiveFilters =
-    filters.status !== "" ||
-    filters.schoolYearId !== defaultSchoolYearId ||
-    filters.isPriority !== "" ||
-    filters.search.trim().length > 0;
-  const activeFilterCount = [
-    filters.status,
-    filters.schoolYearId !== defaultSchoolYearId ? filters.schoolYearId : "",
+  const hasActiveFilters = useMemo(() => {
+    return (
+      filters.status !== "" ||
+      filters.schoolYearId !== defaultSchoolYearId ||
+      filters.isPriority !== "" ||
+      filters.search.trim().length > 0
+    );
+  }, [
+    defaultSchoolYearId,
     filters.isPriority,
-    filters.search.trim()
-  ].filter((value) => value !== "").length;
+    filters.schoolYearId,
+    filters.search,
+    filters.status
+  ]);
+  const activeFilterCount = useMemo(() => {
+    return [
+      filters.status,
+      filters.schoolYearId !== defaultSchoolYearId ? filters.schoolYearId : "",
+      filters.isPriority,
+      filters.search.trim()
+    ].filter((value) => value !== "").length;
+  }, [
+    defaultSchoolYearId,
+    filters.isPriority,
+    filters.schoolYearId,
+    filters.search,
+    filters.status
+  ]);
   const visibleStart = displayedApplications.length === 0
     ? 0
     : (resolvedCurrentPage - 1) * pageSize + 1;
@@ -438,7 +456,7 @@ const ApplicationsPage = () => {
   const isWaitingForDefaultSchoolYear =
     requestedSchoolYearId.length === 0 && !hasInitializedSchoolYearFilter;
 
-  const resetFilters = (): void => {
+  const resetFilters = useCallback((): void => {
     setFilters({
       status: "",
       schoolYearId: defaultSchoolYearId,
@@ -446,7 +464,68 @@ const ApplicationsPage = () => {
       search: ""
     });
     setSort("createdAtDesc");
-  };
+  }, [defaultSchoolYearId]);
+
+  const handleStatusFilterChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>): void => {
+      setFilters((currentFilters) => ({
+        ...currentFilters,
+        status: event.target.value as FilterState["status"]
+      }));
+    },
+    []
+  );
+
+  const handleSchoolYearFilterChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>): void => {
+      setFilters((currentFilters) => ({
+        ...currentFilters,
+        schoolYearId: event.target.value
+      }));
+    },
+    []
+  );
+
+  const handlePriorityFilterChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>): void => {
+      setFilters((currentFilters) => ({
+        ...currentFilters,
+        isPriority: event.target.value as FilterState["isPriority"]
+      }));
+    },
+    []
+  );
+
+  const handleSortChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>): void => {
+      setSort(event.target.value as SortOption);
+    },
+    []
+  );
+
+  const handleSearchFilterChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>): void => {
+      setFilters((currentFilters) => ({
+        ...currentFilters,
+        search: event.target.value
+      }));
+    },
+    []
+  );
+
+  const handlePageSizeChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>): void => {
+      setPageSize(Number(event.target.value) as PageSize);
+    },
+    []
+  );
+
+  const handlePageChange = useCallback(
+    (page: number): void => {
+      setCurrentPage(Math.min(totalPages, Math.max(1, page)));
+    },
+    [totalPages]
+  );
 
   const loadApplications = useCallback(async (signal?: AbortSignal): Promise<void> => {
     setIsLoading(true);
@@ -686,12 +765,7 @@ const ApplicationsPage = () => {
           <FilterField label="Statut" className="block">
             <select
               value={filters.status}
-              onChange={(event) =>
-                setFilters((currentFilters) => ({
-                  ...currentFilters,
-                  status: event.target.value as FilterState["status"]
-                }))
-              }
+              onChange={handleStatusFilterChange}
               className={inputClassName}
             >
               {statusOptions.map((option) => (
@@ -705,12 +779,7 @@ const ApplicationsPage = () => {
           <FilterField label="Année scolaire" className="block">
             <select
               value={filters.schoolYearId}
-              onChange={(event) =>
-                setFilters((currentFilters) => ({
-                  ...currentFilters,
-                  schoolYearId: event.target.value
-                }))
-              }
+              onChange={handleSchoolYearFilterChange}
               disabled={isSchoolYearsLoading}
               className={`${inputClassName} disabled:cursor-wait disabled:bg-slate-50`}
             >
@@ -731,12 +800,7 @@ const ApplicationsPage = () => {
           <FilterField label="Priorité" className="block">
             <select
               value={filters.isPriority}
-              onChange={(event) =>
-                setFilters((currentFilters) => ({
-                  ...currentFilters,
-                  isPriority: event.target.value as FilterState["isPriority"]
-                }))
-              }
+              onChange={handlePriorityFilterChange}
               className={inputClassName}
             >
               <option value="">Toutes les demandes</option>
@@ -747,7 +811,7 @@ const ApplicationsPage = () => {
           <FilterField label="Tri" className="block">
             <select
               value={sort}
-              onChange={(event) => setSort(event.target.value as SortOption)}
+              onChange={handleSortChange}
               className={inputClassName}
             >
               {sortOptions.map((option) => (
@@ -766,12 +830,7 @@ const ApplicationsPage = () => {
               <input
                 type="search"
                 value={filters.search}
-                onChange={(event) =>
-                  setFilters((currentFilters) => ({
-                    ...currentFilters,
-                    search: event.target.value
-                  }))
-                }
+                onChange={handleSearchFilterChange}
                 placeholder="Famille, élève ou email..."
                 className={`${inputClassName} pl-11`}
               />
@@ -840,9 +899,7 @@ const ApplicationsPage = () => {
                     <span className="whitespace-nowrap">Demandes par page</span>
                     <select
                       value={pageSize}
-                      onChange={(event) =>
-                        setPageSize(Number(event.target.value) as PageSize)
-                      }
+                      onChange={handlePageSizeChange}
                       className="w-[4.25rem] rounded-full border border-slate-200 bg-white px-2.5 py-1 text-sm font-semibold text-slate-900 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
                     >
                       {pageSizeOptions.map((option) => (
@@ -986,7 +1043,7 @@ const ApplicationsPage = () => {
               <PaginationControls
                 currentPage={resolvedCurrentPage}
                 totalPages={totalPages}
-                onPageChange={(page) => setCurrentPage(Math.min(totalPages, Math.max(1, page)))}
+                onPageChange={handlePageChange}
               />
             </div>
           </section>

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useState, type CSSProperties, type JSX } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type JSX
+} from "react";
 import { Link } from "react-router-dom";
 
 import PageSectionHeader from "../components/layout/PageSectionHeader";
@@ -299,7 +306,7 @@ const DashboardPage = () => {
   );
   const [isLoadingActiveSchoolYear, setIsLoadingActiveSchoolYear] = useState(true);
 
-  const loadDashboard = async (signal?: AbortSignal): Promise<void> => {
+  const loadDashboard = useCallback(async (signal?: AbortSignal): Promise<void> => {
     setIsLoading(true);
     setError(null);
 
@@ -327,7 +334,7 @@ const DashboardPage = () => {
         setIsLoading(false);
       }
     }
-  };
+  }, []);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -360,7 +367,7 @@ const DashboardPage = () => {
     return () => {
       controller.abort();
     };
-  }, []);
+  }, [loadDashboard]);
 
   useEffect(() => {
     const totalPages = Math.max(
@@ -370,6 +377,45 @@ const DashboardPage = () => {
 
     setCurrentPriorityPage((currentPage) => Math.min(currentPage, totalPages));
   }, [data?.priorityApplications.length]);
+
+  const dashboardView = useMemo(() => {
+    if (!data) {
+      return null;
+    }
+
+    const totalPriorityPages = Math.max(
+      1,
+      Math.ceil(data.priorityApplications.length / PRIORITY_DISPLAY_LIMIT)
+    );
+    const priorityStartIndex = (currentPriorityPage - 1) * PRIORITY_DISPLAY_LIMIT;
+    const visiblePriorityApplications = data.priorityApplications.slice(
+      priorityStartIndex,
+      priorityStartIndex + PRIORITY_DISPLAY_LIMIT
+    );
+
+    return {
+      maxLevelCount: Math.max(...data.byLevel.map((level) => level.count), 0),
+      totalStudents: data.byLevel.reduce((sum, level) => sum + level.count, 0),
+      totalPriorityPages,
+      visiblePriorityApplications,
+      visiblePriorityStart:
+        data.priorityApplications.length === 0 ? 0 : priorityStartIndex + 1,
+      visiblePriorityEnd: Math.min(
+        currentPriorityPage * PRIORITY_DISPLAY_LIMIT,
+        data.priorityApplications.length
+      )
+    };
+  }, [currentPriorityPage, data]);
+
+  const handlePreviousPriorityPage = useCallback((): void => {
+    setCurrentPriorityPage((page) => Math.max(1, page - 1));
+  }, []);
+
+  const handleNextPriorityPage = useCallback((): void => {
+    setCurrentPriorityPage((page) =>
+      Math.min(dashboardView?.totalPriorityPages ?? 1, page + 1)
+    );
+  }, [dashboardView?.totalPriorityPages]);
 
   const pageTopBar = (
     <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
@@ -449,23 +495,9 @@ const DashboardPage = () => {
     );
   }
 
-  const maxLevelCount = Math.max(...data.byLevel.map((level) => level.count), 0);
-  const totalStudents = data.byLevel.reduce((sum, level) => sum + level.count, 0);
-  const totalPriorityPages = Math.max(
-    1,
-    Math.ceil(data.priorityApplications.length / PRIORITY_DISPLAY_LIMIT)
-  );
-  const priorityStartIndex = (currentPriorityPage - 1) * PRIORITY_DISPLAY_LIMIT;
-  const visiblePriorityApplications = data.priorityApplications.slice(
-    priorityStartIndex,
-    priorityStartIndex + PRIORITY_DISPLAY_LIMIT
-  );
-  const visiblePriorityStart =
-    data.priorityApplications.length === 0 ? 0 : priorityStartIndex + 1;
-  const visiblePriorityEnd = Math.min(
-    currentPriorityPage * PRIORITY_DISPLAY_LIMIT,
-    data.priorityApplications.length
-  );
+  if (!dashboardView) {
+    return null;
+  }
 
   return (
     <>
@@ -565,7 +597,7 @@ const DashboardPage = () => {
                 Total
               </p>
               <p className="mt-3 text-4xl font-semibold tracking-tight text-slate-900">
-                {totalStudents}
+                {dashboardView.totalStudents}
               </p>
               <p className="mt-1 text-sm text-slate-500">élèves répartis</p>
             </div>
@@ -579,13 +611,13 @@ const DashboardPage = () => {
             ) : (
               data.byLevel.map((level, index) => {
                 const share =
-                  totalStudents === 0
+                  dashboardView.totalStudents === 0
                     ? 0
-                    : Math.round((level.count / totalStudents) * 100);
+                    : Math.round((level.count / dashboardView.totalStudents) * 100);
                 const width =
-                  maxLevelCount === 0 || level.count === 0
+                  dashboardView.maxLevelCount === 0 || level.count === 0
                     ? 0
-                    : Math.max((level.count / maxLevelCount) * 100, 6);
+                    : Math.max((level.count / dashboardView.maxLevelCount) * 100, 6);
                 const visual = getLevelVisualStyle(level.code, level.label, index);
                 const levelCardClassName = isWideLevelCard(level.code)
                   ? "xl:col-span-6"
@@ -673,7 +705,7 @@ const DashboardPage = () => {
                 Aucune demande prioritaire pour le moment.
               </p>
             ) : (
-              visiblePriorityApplications.map((application, index) => {
+              dashboardView.visiblePriorityApplications.map((application, index) => {
                 const priorityLevels = getPriorityLevels(application);
 
                 return (
@@ -795,32 +827,26 @@ const DashboardPage = () => {
           {data.priorityApplications.length > 0 ? (
             <div className="mt-6 flex flex-col gap-4 border-t border-slate-200 pt-5 sm:flex-row sm:items-center sm:justify-between">
               <div className="text-sm text-slate-500">
-                Affichage de {visiblePriorityStart} à {visiblePriorityEnd} sur{" "}
+                Affichage de {dashboardView.visiblePriorityStart} à {dashboardView.visiblePriorityEnd} sur{" "}
                 {data.priorityApplications.length} demande
                 {data.priorityApplications.length > 1 ? "s" : ""}.
               </div>
               <div className="flex flex-wrap items-center gap-2">
                 <button
                   type="button"
-                  onClick={() =>
-                    setCurrentPriorityPage((page) => Math.max(1, page - 1))
-                  }
+                  onClick={handlePreviousPriorityPage}
                   disabled={currentPriorityPage === 1}
                   className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   Précédent
                 </button>
                 <span className="min-w-[96px] text-center text-sm font-medium text-slate-600">
-                  Page {currentPriorityPage} / {totalPriorityPages}
+                  Page {currentPriorityPage} / {dashboardView.totalPriorityPages}
                 </span>
                 <button
                   type="button"
-                  onClick={() =>
-                    setCurrentPriorityPage((page) =>
-                      Math.min(totalPriorityPages, page + 1)
-                    )
-                  }
-                  disabled={currentPriorityPage === totalPriorityPages}
+                  onClick={handleNextPriorityPage}
+                  disabled={currentPriorityPage === dashboardView.totalPriorityPages}
                   className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   Suivant

--- a/apps/web/src/pages/ImportCsvPage.tsx
+++ b/apps/web/src/pages/ImportCsvPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ChangeEvent, DragEvent, KeyboardEvent, MouseEvent } from "react";
 import { Link } from "react-router-dom";
 
@@ -361,14 +361,15 @@ const ImportCsvPage = () => {
     };
   }, []);
 
-  const latestImport = history[0] ?? null;
-  const activeSchoolYearImport = activeSchoolYear
-    ? history.find(
-      (item) =>
-        item.schoolYearId === activeSchoolYear.id &&
-        item.status === "SUCCESS"
-    ) ?? null
-    : null;
+  const latestImport = useMemo(() => history[0] ?? null, [history]);
+  const activeSchoolYearImport = useMemo(() => {
+    return activeSchoolYear
+      ? history.find(
+          (item) =>
+            item.schoolYearId === activeSchoolYear.id && item.status === "SUCCESS"
+        ) ?? null
+      : null;
+  }, [activeSchoolYear, history]);
   const activeSchoolYearLabel = activeSchoolYear
     ? formatSchoolYearLabel(activeSchoolYear.label)
     : latestImport?.schoolYearLabel
@@ -393,7 +394,7 @@ const ImportCsvPage = () => {
     activeSchoolYear === null ||
     hasCompletedImportForActiveSchoolYear;
 
-  const openFilePicker = (): void => {
+  const openFilePicker = useCallback((): void => {
     if (isUploadLocked) {
       return;
     }
@@ -402,17 +403,17 @@ const ImportCsvPage = () => {
       fileInputRef.current.value = "";
       fileInputRef.current.click();
     }
-  };
+  }, [isUploadLocked]);
 
-  const clearSelectedFile = (): void => {
+  const clearSelectedFile = useCallback((): void => {
     setSelectedFile(null);
 
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
     }
-  };
+  }, []);
 
-  const handleSelectedFile = (nextFile: File): void => {
+  const handleSelectedFile = useCallback((nextFile: File): void => {
     if (isUploadLocked) {
       return;
     }
@@ -431,9 +432,9 @@ const ImportCsvPage = () => {
 
     setSelectedFile(nextFile);
     setInlineMessage(null);
-  };
+  }, [isUploadLocked, showError]);
 
-  const handleFileInputChange = (event: ChangeEvent<HTMLInputElement>): void => {
+  const handleFileInputChange = useCallback((event: ChangeEvent<HTMLInputElement>): void => {
     const nextFile = event.target.files?.[0];
 
     if (!nextFile) {
@@ -441,16 +442,16 @@ const ImportCsvPage = () => {
     }
 
     handleSelectedFile(nextFile);
-  };
+  }, [handleSelectedFile]);
 
-  const handleChooseFileButtonClick = (
+  const handleChooseFileButtonClick = useCallback((
     event: MouseEvent<HTMLButtonElement>
   ): void => {
     event.stopPropagation();
     openFilePicker();
-  };
+  }, [openFilePicker]);
 
-  const handleUploadZoneKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+  const handleUploadZoneKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>): void => {
     if (isUploadLocked) {
       return;
     }
@@ -459,18 +460,18 @@ const ImportCsvPage = () => {
       event.preventDefault();
       openFilePicker();
     }
-  };
+  }, [isUploadLocked, openFilePicker]);
 
-  const handleDragOver = (event: DragEvent<HTMLDivElement>): void => {
+  const handleDragOver = useCallback((event: DragEvent<HTMLDivElement>): void => {
     event.preventDefault();
 
     if (isUploadLocked) {
       return;
     }
     setIsDragging(true);
-  };
+  }, [isUploadLocked]);
 
-  const handleDragLeave = (event: DragEvent<HTMLDivElement>): void => {
+  const handleDragLeave = useCallback((event: DragEvent<HTMLDivElement>): void => {
     event.preventDefault();
 
     if (isUploadLocked) {
@@ -479,9 +480,9 @@ const ImportCsvPage = () => {
     }
 
     setIsDragging(false);
-  };
+  }, [isUploadLocked]);
 
-  const handleDrop = (event: DragEvent<HTMLDivElement>): void => {
+  const handleDrop = useCallback((event: DragEvent<HTMLDivElement>): void => {
     event.preventDefault();
 
     if (isUploadLocked) {
@@ -497,15 +498,15 @@ const ImportCsvPage = () => {
     }
 
     handleSelectedFile(droppedFile);
-  };
+  }, [handleSelectedFile, isUploadLocked]);
 
-  const handleSchoolYearDraftChange = (event: ChangeEvent<HTMLInputElement>): void => {
+  const handleSchoolYearDraftChange = useCallback((event: ChangeEvent<HTMLInputElement>): void => {
     setSchoolYearDraft(normalizeSchoolYearInput(event.target.value));
 
     if (schoolYearSetupError) {
       setSchoolYearSetupError(null);
     }
-  };
+  }, [schoolYearSetupError]);
 
   const handleSchoolYearSetupSubmit = async (
     event: React.FormEvent<HTMLFormElement>


### PR DESCRIPTION
## ⚡ Perf — Optimisation des re-renders frontend

### 🎯 Objectif

Améliorer la fluidité de l’application en optimisant les rendus inutiles sur les pages principales du back-office.

---

## ✅ Optimisations appliquées

### Dashboard

- Métriques dérivées mémorisées avec `useMemo`
- Pagination des demandes prioritaires stabilisée
- Handlers de chargement et pagination stabilisés avec `useCallback`

### Liste des demandes

- Tri et pagination mémorisés
- Handlers stables pour :
  - filtres
  - recherche
  - tri
  - taille de page
  - pagination
- `PaginationControls` mémorisé

### Détail demande

- Timeline, niveaux, noms famille/parents et résumé admissions mémorisés
- Handlers de formulaire stabilisés

### Page email

- Contexte de décision email mémorisé
- Type recommandé mémorisé
- Historique récent mémorisé
- Handlers sujet/message stabilisés

### Import CSV

- Dernier import et import actif mémorisés
- Handlers fichier / drag / drop stabilisés

---

## 🛡️ Périmètre respecté

Aucun changement sur :

- Backend
- API
- Prisma
- Routes
- Design
- Logique métier des statuts/emails
- Comportement fonctionnel existant

---

## 🧪 Vérifications effectuées

```bash
npm exec -w apps/web -- tsc -b
npm run build -w apps/web
npm exec -w apps/web -- eslint src/pages/...

Résultat : ✅ OK sur les pages modifiées.

⸻

⚠️ Note lint

npm run lint -w apps/web

Le lint global échoue encore sur des problèmes préexistants dans :

* AuthContext.tsx
* ToastContext.tsx

Ces fichiers sont hors périmètre de cette PR.

✅ Résultat

* Application plus fluide sur les pages principales
* Moins de recalculs inutiles
* Handlers plus stables
* Aucun changement fonctionnel attendu