### PR TITLE
feat(import): gérer les doublons familles lors de l'import CSV

### DIFF
--- a/apps/api/src/controllers/import.controller.ts
+++ b/apps/api/src/controllers/import.controller.ts
@@ -13,6 +13,7 @@ const csvImportLogSelect = {
   importedStudents: true,
   skippedRows: true,
   duplicateRows: true,
+  duplicateFamilies: true,
   invalidRows: true,
   totalRows: true,
   status: true,
@@ -28,6 +29,11 @@ const csvImportLogSelect = {
 type CsvImportLogResponse = Prisma.CsvImportLogGetPayload<{
   select: typeof csvImportLogSelect;
 }>;
+
+type CsvImportDuplicateRow = {
+  rowNumber: number;
+  reason: string;
+};
 
 const ACCEPTED_CSV_MIME_TYPES = new Set([
   "application/csv",
@@ -174,6 +180,111 @@ const buildLevelLookupMap = (
   return levelLookup;
 };
 
+const parseMergeDuplicateFamiliesFlag = (value: unknown): boolean => {
+  if (typeof value !== "string") {
+    return true;
+  }
+
+  return value !== "false";
+};
+
+const getUploadedCsvFile = (file: Express.Multer.File | undefined): Express.Multer.File => {
+  if (!file) {
+    throw badRequest("CSV file is required");
+  }
+
+  if (!isCsvUpload(file)) {
+    throw badRequest("Invalid CSV file format");
+  }
+
+  return file;
+};
+
+const getActiveImportSchoolYear = async (): Promise<{ id: string; label: string }> => {
+  const activeSchoolYear = await prisma.schoolYear.findFirst({
+    where: { isActive: true },
+    select: {
+      id: true,
+      label: true
+    },
+    orderBy: {
+      startYear: "desc"
+    }
+  });
+
+  if (!activeSchoolYear) {
+    throw notFound("Active school year not found");
+  }
+
+  return activeSchoolYear;
+};
+
+const ensureNoSuccessfulImportForSchoolYear = async (schoolYearId: string): Promise<void> => {
+  const existingSuccessfulImport = await prisma.csvImportLog.findFirst({
+    where: {
+      schoolYearId,
+      status: "SUCCESS"
+    },
+    select: {
+      id: true
+    }
+  });
+
+  if (existingSuccessfulImport) {
+    throw badRequest("CSV import already completed for active school year");
+  }
+};
+
+const getDuplicateRowWarnings = async (
+  schoolYearId: string,
+  rows: ReturnType<typeof parseCsvImportFile>["rows"]
+): Promise<CsvImportDuplicateRow[]> => {
+  const rowHashes = rows.map((row) => ({
+    rowNumber: row.rowNumber,
+    hash: buildApplicationImportHash(schoolYearId, row)
+  }));
+  const existingHashSet = new Set(
+    (
+      await prisma.application.findMany({
+        where: {
+          rawCsvRowHash: {
+            in: rowHashes.map((rowHash) => rowHash.hash)
+          }
+        },
+        select: {
+          rawCsvRowHash: true
+        }
+      })
+    )
+      .map((application) => application.rawCsvRowHash)
+      .filter((hash): hash is string => typeof hash === "string")
+  );
+  const seenHashes = new Set<string>();
+  const duplicateRows: CsvImportDuplicateRow[] = [];
+
+  for (const rowHash of rowHashes) {
+    if (existingHashSet.has(rowHash.hash)) {
+      duplicateRows.push({
+        rowNumber: rowHash.rowNumber,
+        reason: "Ligne déjà importée"
+      });
+      continue;
+    }
+
+    if (seenHashes.has(rowHash.hash)) {
+      duplicateRows.push({
+        rowNumber: rowHash.rowNumber,
+        reason: "Ligne identique déjà présente dans ce fichier"
+      });
+      continue;
+    }
+
+    seenHashes.add(rowHash.hash);
+  }
+
+  return duplicateRows;
+};
+
 const buildFamilyCreateData = (
   family: {
     fatherLastName: string | null;
@@ -275,6 +386,9 @@ const mapCsvImportLog = (log: CsvImportLogResponse) => {
     importedStudents: log.importedStudents,
     skippedRows: log.skippedRows,
     duplicateRows: log.duplicateRows,
+    duplicateRowsCount: log.duplicateRows,
+    duplicateFamilies: log.duplicateFamilies,
+    duplicateFamiliesCount: log.duplicateFamilies,
     invalidRows: log.invalidRows,
     totalRows: log.totalRows,
     status: log.status,
@@ -296,47 +410,35 @@ export const getCsvImportHistory = async (_req: Request, res: Response): Promise
   res.status(200).json(importLogs.map(mapCsvImportLog));
 };
 
+export const previewCsvImport = async (req: Request, res: Response): Promise<void> => {
+  const file = getUploadedCsvFile(req.file);
+  const parsedImport = parseCsvImportFile(file.buffer);
+  const activeSchoolYear = await getActiveImportSchoolYear();
+
+  await ensureNoSuccessfulImportForSchoolYear(activeSchoolYear.id);
+
+  const duplicateRows = await getDuplicateRowWarnings(activeSchoolYear.id, parsedImport.rows);
+
+  res.status(200).json({
+    totalRows: parsedImport.totalRows,
+    invalidRows: parsedImport.invalidRows.length,
+    duplicateRows,
+    duplicateRowsCount: duplicateRows.length,
+    duplicateFamilies: parsedImport.duplicateFamilies,
+    duplicateFamiliesCount: parsedImport.duplicateFamiliesCount,
+    activeSchoolYear: activeSchoolYear.label,
+    delimiter: parsedImport.detectedDelimiter
+  });
+};
+
 export const importCsv = async (req: Request, res: Response): Promise<void> => {
-  const file = req.file;
-
-  if (!file) {
-    throw badRequest("CSV file is required");
-  }
-
-  if (!isCsvUpload(file)) {
-    throw badRequest("Invalid CSV file format");
-  }
-
+  const file = getUploadedCsvFile(req.file);
   const parsedImport = parseCsvImportFile(file.buffer);
   const normalizedFileName = normalizeUploadedFileName(file.originalname);
-  const activeSchoolYear = await prisma.schoolYear.findFirst({
-    where: { isActive: true },
-    select: {
-      id: true,
-      label: true
-    },
-    orderBy: {
-      startYear: "desc"
-    }
-  });
+  const mergeDuplicateFamilies = parseMergeDuplicateFamiliesFlag(req.body?.mergeDuplicateFamilies);
+  const activeSchoolYear = await getActiveImportSchoolYear();
 
-  if (!activeSchoolYear) {
-    throw notFound("Active school year not found");
-  }
-
-  const existingSuccessfulImport = await prisma.csvImportLog.findFirst({
-    where: {
-      schoolYearId: activeSchoolYear.id,
-      status: "SUCCESS"
-    },
-    select: {
-      id: true
-    }
-  });
-
-  if (existingSuccessfulImport) {
-    throw badRequest("CSV import already completed for active school year");
-  }
+  await ensureNoSuccessfulImportForSchoolYear(activeSchoolYear.id);
 
   const levels = await prisma.level.findMany({
     select: {
@@ -372,9 +474,23 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
   let importedApplications = 0;
   let importedStudents = 0;
   let duplicateRows = 0;
+  const duplicateFamilies = parsedImport.duplicateFamilies;
+  const duplicateFamiliesCount = parsedImport.duplicateFamiliesCount;
+  const duplicateFamilyRows = new Set(duplicateFamilies.flatMap((family) => family.rows));
+  const duplicateFamilyRowsToMerge = new Set(
+    mergeDuplicateFamilies
+      ? duplicateFamilies.flatMap((family) => family.rows.slice(1))
+      : []
+  );
+  let mergedDuplicateFamilyRows = 0;
   let invalidRows = parsedImport.invalidRows.length;
 
   for (const row of parsedImport.rows) {
+    if (duplicateFamilyRowsToMerge.has(row.rowNumber)) {
+      mergedDuplicateFamilyRows += 1;
+      continue;
+    }
+
     const resolvedStudents = row.students.map((student) => {
       const levelId = levelLookup.get(student.requestedLevelKey);
 
@@ -394,6 +510,11 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
     const applicationHash = buildApplicationImportHash(activeSchoolYear.id, row);
 
     const importResult = await prisma.$transaction(async (tx) => {
+      // Existing "duplicateRows" semantics:
+      // this counter only covers exact imported applications whose rawCsvRowHash
+      // already exists for the school year. Potential duplicate families are
+      // reported separately; when the admin confirms a merge, only the first
+      // request of each duplicate family group is imported.
       // MVP dedupe rule:
       // - Family is matched by contact email (case-insensitive)
       // - Application is matched by a hash built from school year + contact email
@@ -417,17 +538,20 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
         };
       }
 
-      const existingFamily = await tx.family.findFirst({
-        where: {
-          contactEmail: {
-            equals: row.family.contactEmail,
-            mode: "insensitive"
+      const shouldMergeFamily = mergeDuplicateFamilies || !duplicateFamilyRows.has(row.rowNumber);
+      const existingFamily = shouldMergeFamily
+        ? await tx.family.findFirst({
+          where: {
+            contactEmail: {
+              equals: row.family.contactEmail,
+              mode: "insensitive"
+            }
+          },
+          select: {
+            id: true
           }
-        },
-        select: {
-          id: true
-        }
-      });
+        })
+        : null;
 
       let familyId = existingFamily?.id;
 
@@ -503,6 +627,7 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
   }
 
   importedFamilies = importedFamilyIds.size;
+  const skippedRows = invalidRows + duplicateRows + mergedDuplicateFamilyRows;
 
   const createdImportLog = await prisma.csvImportLog.create({
     data: {
@@ -511,8 +636,9 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
       importedFamilies,
       importedApplications,
       importedStudents,
-      skippedRows: invalidRows + duplicateRows,
+      skippedRows,
       duplicateRows,
+      duplicateFamilies: duplicateFamiliesCount,
       invalidRows,
       totalRows: parsedImport.totalRows
     },
@@ -523,8 +649,13 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
     importedFamilies,
     importedApplications,
     importedStudents,
-    skippedRows: invalidRows + duplicateRows,
+    skippedRows,
     duplicateRows,
+    duplicateRowsCount: duplicateRows,
+    duplicateFamilies,
+    duplicateFamiliesCount,
+    mergedDuplicateFamilyRows,
+    mergeDuplicateFamilies,
     invalidRows,
     totalRows: parsedImport.totalRows,
     activeSchoolYear: activeSchoolYear.label,

--- a/apps/api/src/lib/csv-import.ts
+++ b/apps/api/src/lib/csv-import.ts
@@ -151,11 +151,25 @@ export type CsvImportInvalidRow = {
   reason: string;
 };
 
+export type CsvImportDuplicateFamily = {
+  key: string;
+  reason: string;
+  rows: number[];
+  familyPreview: {
+    fatherFullName: string | null;
+    motherFullName: string | null;
+    contactEmail: string;
+    contactPhone: string | null;
+  };
+};
+
 export type ParseCsvImportResult = {
   rows: ParsedCsvImportRow[];
   invalidRows: CsvImportInvalidRow[];
   totalRows: number;
   detectedDelimiter: string;
+  duplicateFamilies: CsvImportDuplicateFamily[];
+  duplicateFamiliesCount: number;
 };
 
 const normalizeWhitespace = (value: string): string => {
@@ -177,6 +191,26 @@ const normalizeLookupValue = (value: string): string => {
 
 const normalizeCompactLookupValue = (value: string): string => {
   return normalizeLookupValue(value).replace(/\s+/g, "");
+};
+
+const normalizeDuplicateFamilyText = (value: string | null): string | null => {
+  if (value === null) {
+    return null;
+  }
+
+  const normalizedValue = normalizeWhitespace(value).toLowerCase();
+
+  return normalizedValue.length > 0 ? normalizedValue : null;
+};
+
+const normalizeDuplicateFamilyPhone = (value: string | null): string | null => {
+  if (value === null) {
+    return null;
+  }
+
+  const normalizedPhone = value.replace(/[\s.\-()]/gu, "").trim();
+
+  return normalizedPhone.length > 0 ? normalizedPhone : null;
 };
 
 const getCellValue = (cells: string[], index: number | undefined): string | null => {
@@ -664,6 +698,156 @@ export const buildApplicationImportHash = (
     .digest("hex");
 };
 
+const formatFullName = (lastName: string | null, firstName: string | null): string | null => {
+  const fullName = [lastName, firstName]
+    .map((value) => normalizeWhitespace(value ?? ""))
+    .filter((value) => value.length > 0)
+    .join(" ");
+
+  return fullName.length > 0 ? fullName : null;
+};
+
+const buildDuplicateFamilyEntry = (
+  key: string,
+  reason: string,
+  rows: ParsedCsvImportRow[]
+): CsvImportDuplicateFamily => {
+  const previewRow = rows[0];
+
+  return {
+    key,
+    reason,
+    rows: rows.map((row) => row.rowNumber).sort((left, right) => left - right),
+    familyPreview: {
+      fatherFullName: formatFullName(
+        previewRow.family.fatherLastName,
+        previewRow.family.fatherFirstName
+      ),
+      motherFullName: formatFullName(
+        previewRow.family.motherLastName,
+        previewRow.family.motherFirstName
+      ),
+      contactEmail: previewRow.family.contactEmail,
+      contactPhone: previewRow.family.contactPhone
+    }
+  };
+};
+
+const getDuplicateFamilyCompositeKey = (row: ParsedCsvImportRow): string | null => {
+  const fatherLastName = normalizeDuplicateFamilyText(row.family.fatherLastName);
+  const fatherFirstName = normalizeDuplicateFamilyText(row.family.fatherFirstName);
+  const motherLastName = normalizeDuplicateFamilyText(row.family.motherLastName);
+  const motherFirstName = normalizeDuplicateFamilyText(row.family.motherFirstName);
+  const postalAddress = normalizeDuplicateFamilyText(row.family.postalAddress);
+
+  if (
+    !fatherLastName ||
+    !fatherFirstName ||
+    !motherLastName ||
+    !motherFirstName ||
+    !postalAddress
+  ) {
+    return null;
+  }
+
+  return [
+    fatherLastName,
+    fatherFirstName,
+    motherLastName,
+    motherFirstName,
+    postalAddress
+  ].join("|");
+};
+
+const addDuplicateFamilyCandidate = (
+  candidates: Map<string, { reason: string; rows: ParsedCsvImportRow[] }>,
+  key: string | null,
+  reason: string,
+  row: ParsedCsvImportRow
+): void => {
+  if (!key) {
+    return;
+  }
+
+  const currentCandidate = candidates.get(key);
+
+  if (currentCandidate) {
+    currentCandidate.rows.push(row);
+    return;
+  }
+
+  candidates.set(key, {
+    reason,
+    rows: [row]
+  });
+};
+
+export const detectDuplicateFamilies = (
+  rows: ParsedCsvImportRow[]
+): CsvImportDuplicateFamily[] => {
+  const candidates = new Map<string, { reason: string; rows: ParsedCsvImportRow[] }>();
+
+  for (const row of rows) {
+    const normalizedPhone = normalizeDuplicateFamilyPhone(row.family.contactPhone);
+    const compositeKey = getDuplicateFamilyCompositeKey(row);
+
+    addDuplicateFamilyCandidate(
+      candidates,
+      `email:${normalizeDuplicateFamilyText(row.family.contactEmail) ?? ""}`,
+      "Même email de contact",
+      row
+    );
+    addDuplicateFamilyCandidate(
+      candidates,
+      normalizedPhone ? `phone:${normalizedPhone}` : null,
+      "Même téléphone de contact",
+      row
+    );
+    addDuplicateFamilyCandidate(
+      candidates,
+      compositeKey ? `family:${compositeKey}` : null,
+      "Même combinaison parents et adresse",
+      row
+    );
+  }
+
+  const duplicateFamilies: CsvImportDuplicateFamily[] = [];
+  const coveredRows = new Set<number>();
+  const candidatePriority = ["email:", "phone:", "family:"];
+  const sortedCandidates = Array.from(candidates.entries()).sort(([leftKey], [rightKey]) => {
+    const leftPriority = candidatePriority.findIndex((prefix) => leftKey.startsWith(prefix));
+    const rightPriority = candidatePriority.findIndex((prefix) => rightKey.startsWith(prefix));
+
+    return leftPriority - rightPriority || leftKey.localeCompare(rightKey);
+  });
+
+  for (const [key, candidate] of sortedCandidates) {
+    const distinctRows = Array.from(
+      new Map(candidate.rows.map((row) => [row.rowNumber, row])).values()
+    ).sort((left, right) => left.rowNumber - right.rowNumber);
+
+    if (distinctRows.length < 2) {
+      continue;
+    }
+
+    if (new Set(distinctRows.map((row) => row.duplicateFingerprint)).size < 2) {
+      continue;
+    }
+
+    if (distinctRows.some((row) => coveredRows.has(row.rowNumber))) {
+      continue;
+    }
+
+    for (const row of distinctRows) {
+      coveredRows.add(row.rowNumber);
+    }
+
+    duplicateFamilies.push(buildDuplicateFamilyEntry(key, candidate.reason, distinctRows));
+  }
+
+  return duplicateFamilies;
+};
+
 const parseStudentRow = (
   cells: string[],
   childColumns: ChildColumnIndexes,
@@ -862,10 +1046,14 @@ export const parseCsvImportFile = (buffer: Buffer): ParseCsvImportResult => {
     }
   }
 
+  const duplicateFamilies = detectDuplicateFamilies(rows);
+
   return {
     rows,
     invalidRows,
     totalRows: parsedRows.length - 1,
-    detectedDelimiter
+    detectedDelimiter,
+    duplicateFamilies,
+    duplicateFamiliesCount: duplicateFamilies.length
   };
 };

--- a/apps/api/src/routes/import.routes.ts
+++ b/apps/api/src/routes/import.routes.ts
@@ -2,7 +2,7 @@ import type { RequestHandler } from "express";
 import { Router } from "express";
 import multer from "multer";
 
-import { getCsvImportHistory, importCsv } from "../controllers/import.controller";
+import { getCsvImportHistory, importCsv, previewCsvImport } from "../controllers/import.controller";
 import { badRequest } from "../lib/errors";
 
 const router = Router();
@@ -26,6 +26,7 @@ const uploadCsvFile: RequestHandler = (req, res, next) => {
 };
 
 router.get("/import/csv/history", getCsvImportHistory);
+router.post("/import/csv/preview", uploadCsvFile, previewCsvImport);
 router.post("/import/csv", uploadCsvFile, importCsv);
 
 export default router;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,6 +2,7 @@ import { Link, Navigate, Route, Routes } from "react-router-dom";
 
 import PrivateRoute from "./components/auth/PrivateRoute";
 import AppLayout from "./components/layout/AppLayout";
+import ScrollToTop from "./components/layout/ScrollToTop";
 import SiteFooter from "./components/layout/SiteFooter";
 import ToastViewport from "./components/ui/ToastViewport";
 import { ToastProvider } from "./context/ToastContext";
@@ -55,6 +56,7 @@ const NotFoundPage = () => {
 function App() {
   return (
     <ToastProvider>
+      <ScrollToTop />
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/forgot-password" element={<ForgotPasswordPage />} />

--- a/apps/web/src/components/layout/ScrollToTop.tsx
+++ b/apps/web/src/components/layout/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const ScrollToTop = () => {
+  const { pathname, search } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: "auto" });
+  }, [pathname, search]);
+
+  return null;
+};
+
+export default ScrollToTop;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -16,7 +16,7 @@ import type {
   StudentAdmissionStatusUpdateResult
 } from "../types/application";
 import type { DashboardStats } from "../types/dashboard";
-import type { CsvImportHistoryItem, CsvImportSummary } from "../types/import";
+import type { CsvImportHistoryItem, CsvImportPreview, CsvImportSummary } from "../types/import";
 
 const API_BASE_URL = (import.meta.env.VITE_API_URL ?? "").replace(/\/$/, "");
 
@@ -345,15 +345,20 @@ export const deleteSchoolYear = async (
   );
 };
 
-export const uploadCsvImport = async (
+const postCsvImportFile = async <TResponse>(
   file: File,
+  path: string,
+  fields?: Record<string, string>,
   init?: RequestInit
-): Promise<CsvImportSummary> => {
+): Promise<TResponse> => {
   const formData = new FormData();
 
   formData.set("file", file);
+  for (const [key, value] of Object.entries(fields ?? {})) {
+    formData.set(key, value);
+  }
 
-  const response = await fetch(buildApiUrl("/api/import/csv"), {
+  const response = await fetch(buildApiUrl(path), {
     ...init,
     method: "POST",
     headers: {
@@ -367,7 +372,31 @@ export const uploadCsvImport = async (
     throw new Error(await getErrorMessage(response));
   }
 
-  return (await response.json()) as CsvImportSummary;
+  return (await response.json()) as TResponse;
+};
+
+export const previewCsvImport = async (
+  file: File,
+  init?: RequestInit
+): Promise<CsvImportPreview> => {
+  return postCsvImportFile<CsvImportPreview>(file, "/api/import/csv/preview", undefined, init);
+};
+
+export const uploadCsvImport = async (
+  file: File,
+  options?: {
+    mergeDuplicateFamilies?: boolean;
+  },
+  init?: RequestInit
+): Promise<CsvImportSummary> => {
+  return postCsvImportFile<CsvImportSummary>(
+    file,
+    "/api/import/csv",
+    {
+      mergeDuplicateFamilies: String(options?.mergeDuplicateFamilies ?? true)
+    },
+    init
+  );
 };
 
 export const getCsvImportHistory = async (

--- a/apps/web/src/pages/ImportCsvPage.tsx
+++ b/apps/web/src/pages/ImportCsvPage.tsx
@@ -17,10 +17,11 @@ import {
   createSchoolYear,
   getActiveSchoolYear,
   getCsvImportHistory,
+  previewCsvImport,
   uploadCsvImport
 } from "../lib/api";
 import type { SchoolYearSummary } from "../types/application";
-import type { CsvImportHistoryItem, CsvImportSummary } from "../types/import";
+import type { CsvImportHistoryItem, CsvImportPreview, CsvImportSummary } from "../types/import";
 
 type IconProps = {
   className?: string;
@@ -81,6 +82,18 @@ const getImportedFamiliesCount = (
   return item.importedApplications;
 };
 
+const getDuplicateRowsCount = (
+  item: Pick<CsvImportHistoryItem, "duplicateRows" | "duplicateRowsCount">
+): number => {
+  return item.duplicateRowsCount ?? item.duplicateRows ?? 0;
+};
+
+const getDuplicateFamiliesCount = (
+  item: Pick<CsvImportHistoryItem, "duplicateFamilies" | "duplicateFamiliesCount">
+): number => {
+  return item.duplicateFamiliesCount ?? item.duplicateFamilies ?? 0;
+};
+
 const getImportHistoryResult = (item: CsvImportHistoryItem): string => {
   return [
     pluralize(getImportedFamiliesCount(item), "famille", "familles"),
@@ -92,6 +105,10 @@ const getImportHistoryResult = (item: CsvImportHistoryItem): string => {
 
 const getImportSuccessMessage = (summary: CsvImportSummary): string => {
   return `Import terminé : ${pluralize(summary.importedApplications, "demande", "demandes")} et ${pluralize(summary.importedStudents, "élève", "élèves")} traités.`;
+};
+
+const getDuplicatePreviewCount = (preview: CsvImportPreview): number => {
+  return preview.duplicateRowsCount + preview.duplicateFamiliesCount;
 };
 
 const getActiveSchoolYearErrorMessage = (error: unknown): string => {
@@ -280,6 +297,152 @@ const SummaryMetric = ({
   );
 };
 
+const DuplicateImportModal = ({
+  preview,
+  isSubmitting,
+  onCancel,
+  onConfirm
+}: {
+  preview: CsvImportPreview;
+  isSubmitting: boolean;
+  onCancel: () => void;
+  onConfirm: (mergeDuplicateFamilies: boolean) => void;
+}) => {
+  const duplicateCount = getDuplicatePreviewCount(preview);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="duplicate-import-title"
+    >
+      <section className="max-h-[88vh] w-full max-w-4xl overflow-y-auto rounded-[28px] border border-[#e8dccf] bg-white p-5 shadow-[0_30px_80px_-35px_rgba(15,23,42,0.55)] sm:p-6">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-secondaryDark">
+              Vérification avant import
+            </p>
+            <h2 id="duplicate-import-title" className="mt-2 font-serif text-[2rem] text-slate-900">
+              Doublons détectés
+            </h2>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+              {pluralize(duplicateCount, "doublon a été détecté", "doublons ont été détectés")}
+              . Choisissez si les familles signalées doivent être fusionnées avant
+              l&apos;import définitif du fichier CSV.
+            </p>
+          </div>
+          <div className="grid grid-cols-2 gap-2 text-center sm:min-w-72">
+            <div className="rounded-2xl border border-[#eee3d7] px-3 py-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+                Doublons exacts
+              </p>
+              <p className="mt-2 text-2xl font-semibold text-primary">
+                {numberFormatter.format(preview.duplicateRowsCount)}
+              </p>
+            </div>
+            <div className="rounded-2xl border border-[#eee3d7] px-3 py-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+                Familles
+              </p>
+              <p className="mt-2 text-2xl font-semibold text-primary">
+                {numberFormatter.format(preview.duplicateFamiliesCount)}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {preview.duplicateRows.length > 0 ? (
+          <section className="mt-5">
+            <h3 className="text-sm font-semibold text-slate-900">Doublons exacts</h3>
+            <div className="mt-3 grid gap-2">
+              {preview.duplicateRows.map((duplicateRow) => (
+                <div
+                  key={`${duplicateRow.rowNumber}-${duplicateRow.reason}`}
+                  className="rounded-2xl border border-[#eee3d7] bg-[#fffdf8] px-4 py-3 text-sm text-slate-700"
+                >
+                  Ligne CSV {duplicateRow.rowNumber} · {duplicateRow.reason}
+                </div>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {preview.duplicateFamilies.length > 0 ? (
+          <section className="mt-5">
+            <h3 className="text-sm font-semibold text-slate-900">
+              Familles potentiellement en double
+            </h3>
+            <div className="mt-3 grid gap-3">
+              {preview.duplicateFamilies.map((duplicateFamily) => (
+                <article
+                  key={duplicateFamily.key}
+                  className="rounded-2xl border border-[#eee3d7] bg-[#fffdf8] px-4 py-3 text-sm text-slate-700"
+                >
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <p className="font-semibold text-slate-900">
+                        {duplicateFamily.reason}
+                      </p>
+                      <p className="mt-1">
+                        Lignes CSV {duplicateFamily.rows.join(", ")}
+                      </p>
+                    </div>
+                    <p className="break-all text-slate-600">
+                      {duplicateFamily.familyPreview.contactEmail}
+                    </p>
+                  </div>
+                  <p className="mt-2 text-slate-600">
+                    Père : {duplicateFamily.familyPreview.fatherFullName ?? "Non renseigné"}
+                    {" · "}
+                    Mère : {duplicateFamily.familyPreview.motherFullName ?? "Non renseignée"}
+                    {" · "}
+                    Téléphone : {duplicateFamily.familyPreview.contactPhone ?? "Non renseigné"}
+                  </p>
+                </article>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        <p className="mt-5 rounded-2xl border border-primary/15 bg-primary/5 px-4 py-3 text-sm leading-6 text-slate-700">
+          Fusionner conserve une seule demande pour chaque famille signalée et
+          ignore les autres lignes du groupe. Importer sans fusion crée des
+          fiches familles séparées pour ces demandes. Les doublons exacts restent
+          ignorés dans les deux cas.
+        </p>
+
+        <div className="mt-5 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isSubmitting}
+            className="inline-flex items-center justify-center rounded-2xl border border-slate-300 px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Annuler
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm(false)}
+            disabled={isSubmitting}
+            className="inline-flex items-center justify-center rounded-2xl border border-secondary/50 px-5 py-3 text-sm font-semibold text-secondaryDark transition hover:bg-secondary/10 disabled:cursor-wait disabled:opacity-60"
+          >
+            Importer sans fusion
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm(true)}
+            disabled={isSubmitting}
+            className="inline-flex items-center justify-center rounded-2xl bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:bg-primaryDark disabled:cursor-wait disabled:bg-slate-300"
+          >
+            {isSubmitting ? "Import en cours..." : "Fusionner et importer"}
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+};
+
 const ImportCsvPage = () => {
   const { showError, showSuccess } = useToast();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -296,6 +459,8 @@ const ImportCsvPage = () => {
   const [inlineMessage, setInlineMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
+  const [lastImportSummary, setLastImportSummary] = useState<CsvImportSummary | null>(null);
+  const [pendingImportPreview, setPendingImportPreview] = useState<CsvImportPreview | null>(null);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -394,6 +559,7 @@ const ImportCsvPage = () => {
     isLoadingActiveSchoolYear || isCreatingSchoolYear || isSubmitting;
   const schoolYearDraftPlaceholder = getSchoolYearDraftPlaceholder(activeSchoolYear);
   const hasCompletedImportForActiveSchoolYear = activeSchoolYearImport !== null;
+  const lastDuplicateFamilies = lastImportSummary?.duplicateFamilies ?? [];
   const isUploadLocked =
     isLoadingActiveSchoolYear ||
     isLoadingHistory ||
@@ -415,6 +581,7 @@ const ImportCsvPage = () => {
 
   const clearSelectedFile = useCallback((): void => {
     setSelectedFile(null);
+    setPendingImportPreview(null);
 
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
@@ -440,6 +607,7 @@ const ImportCsvPage = () => {
 
     setSelectedFile(nextFile);
     setInlineMessage(null);
+    setPendingImportPreview(null);
   }, [isUploadLocked, showError]);
 
   const handleFileInputChange = useCallback((event: ChangeEvent<HTMLInputElement>): void => {
@@ -458,6 +626,44 @@ const ImportCsvPage = () => {
     event.stopPropagation();
     openFilePicker();
   }, [openFilePicker]);
+
+  const finalizeCsvImport = async (mergeDuplicateFamilies: boolean): Promise<void> => {
+    if (!selectedFile) {
+      const message = "Sélectionnez un fichier CSV avant de lancer l'import.";
+
+      setInlineMessage(message);
+      setPendingImportPreview(null);
+      showError(message);
+      return;
+    }
+
+    setIsSubmitting(true);
+    setInlineMessage(null);
+
+    try {
+      const summary = await uploadCsvImport(selectedFile, { mergeDuplicateFamilies });
+
+      setLastImportSummary(summary);
+      setPendingImportPreview(null);
+
+      if (summary.historyEntry) {
+        setHistory((currentHistory) => [
+          summary.historyEntry as CsvImportHistoryItem,
+          ...currentHistory.filter((item) => item.id !== summary.historyEntry?.id)
+        ]);
+      }
+
+      clearSelectedFile();
+      showSuccess(getImportSuccessMessage(summary));
+    } catch (submitError) {
+      const message = getImportErrorMessage(submitError);
+
+      setInlineMessage(message);
+      showError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   const handleUploadZoneKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>): void => {
     if (isUploadLocked) {
@@ -600,19 +806,17 @@ const ImportCsvPage = () => {
 
     setIsSubmitting(true);
     setInlineMessage(null);
+    setPendingImportPreview(null);
 
     try {
-      const summary = await uploadCsvImport(selectedFile);
+      const preview = await previewCsvImport(selectedFile);
 
-      if (summary.historyEntry) {
-        setHistory((currentHistory) => [
-          summary.historyEntry as CsvImportHistoryItem,
-          ...currentHistory.filter((item) => item.id !== summary.historyEntry?.id)
-        ]);
+      if (getDuplicatePreviewCount(preview) > 0) {
+        setPendingImportPreview(preview);
+        return;
       }
 
-      clearSelectedFile();
-      showSuccess(getImportSuccessMessage(summary));
+      await finalizeCsvImport(true);
     } catch (submitError) {
       const message = getImportErrorMessage(submitError);
 
@@ -645,6 +849,19 @@ const ImportCsvPage = () => {
 
   return (
     <>
+      {pendingImportPreview ? (
+        <DuplicateImportModal
+          preview={pendingImportPreview}
+          isSubmitting={isSubmitting}
+          onCancel={() => {
+            setPendingImportPreview(null);
+          }}
+          onConfirm={(mergeDuplicateFamilies) => {
+            void finalizeCsvImport(mergeDuplicateFamilies);
+          }}
+        />
+      ) : null}
+
       <div className="ui-animate-in ui-animate-in--subtle" style={getEnterStyle(120)}>
         <PageSectionHeader topBar={pageTopBar} title="Import CSV" />
       </div>
@@ -659,7 +876,12 @@ const ImportCsvPage = () => {
         </p>
 
         <ul className="mt-5 space-y-3 pl-5 text-[1.02rem] leading-7 text-slate-700 marker:text-primary">
-          <li>Les doublons sont détectés automatiquement.</li>
+          <li>
+            Les doublons exacts concernent les lignes déjà importées.
+          </li>
+          <li>
+            Les familles multiples concernent les familles ayant soumis plusieurs demandes.
+          </li>
           <li>
             Le fichier importé sera rattaché à l&apos;année scolaire{" "}
             {activeSchoolYear ? activeSchoolYearLabel : "active configurée"}.
@@ -882,6 +1104,77 @@ const ImportCsvPage = () => {
           </div>
         </form>
 
+        {lastDuplicateFamilies.length > 0 ? (
+          <section className="mt-5 rounded-[24px] border border-[#ebdfd2] bg-white/82 px-4 py-4 sm:px-5">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-primaryLight">
+                Contrôle métier
+              </p>
+              <h2 className="mt-2 font-serif text-[1.7rem] text-slate-900">
+                Familles potentiellement en double
+              </h2>
+            </div>
+
+            <div className="mt-4 grid gap-3">
+              {lastDuplicateFamilies.map((duplicateFamily) => (
+                <article
+                  key={duplicateFamily.key}
+                  className="rounded-[20px] border border-[#eee3d7] bg-white/88 px-4 py-4"
+                >
+                  <div className="flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between">
+                    <div>
+                      <p className="font-semibold text-slate-900">
+                        {duplicateFamily.reason}
+                      </p>
+                      <p className="mt-1 text-sm text-slate-600">
+                        Cette famille possède plusieurs demandes dans le fichier.
+                      </p>
+                    </div>
+                    <div className="w-fit rounded-full border border-primary/15 bg-primary/8 px-3 py-1 text-xs font-semibold text-primaryDark">
+                      Lignes CSV {duplicateFamily.rows.join(", ")}
+                    </div>
+                  </div>
+
+                  <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2 xl:grid-cols-4">
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                        Père
+                      </dt>
+                      <dd className="mt-1 text-slate-900">
+                        {duplicateFamily.familyPreview.fatherFullName ?? "Non renseigné"}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                        Mère
+                      </dt>
+                      <dd className="mt-1 text-slate-900">
+                        {duplicateFamily.familyPreview.motherFullName ?? "Non renseigné"}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                        Email
+                      </dt>
+                      <dd className="mt-1 break-all text-slate-900">
+                        {duplicateFamily.familyPreview.contactEmail}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">
+                        Téléphone
+                      </dt>
+                      <dd className="mt-1 text-slate-900">
+                        {duplicateFamily.familyPreview.contactPhone ?? "Non renseigné"}
+                      </dd>
+                    </div>
+                  </dl>
+                </article>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
         {latestImport ? (
           <section
             className="ui-animate-in mt-6 rounded-[26px] border border-[#ebdfd3] bg-white/78 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.9)] sm:p-5"
@@ -907,7 +1200,7 @@ const ImportCsvPage = () => {
               </div>
             </div>
 
-            <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+            <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-6">
               <SummaryMetric
                 label="Familles"
                 value={getImportedFamiliesCount(latestImport)}
@@ -919,10 +1212,19 @@ const ImportCsvPage = () => {
               <SummaryMetric label="Élèves" value={latestImport.importedStudents} />
               <SummaryMetric label="Ignorées" value={latestImport.skippedRows} />
               <SummaryMetric
-                label="Doublons"
-                value={latestImport.duplicateRows ?? 0}
+                label="Doublons exacts"
+                value={getDuplicateRowsCount(latestImport)}
+              />
+              <SummaryMetric
+                label="Familles en double"
+                value={getDuplicateFamiliesCount(latestImport)}
               />
             </div>
+
+            <p className="mt-4 text-sm leading-6 text-slate-600">
+              Les doublons exacts concernent les lignes déjà importées.
+              Les familles multiples concernent les familles ayant soumis plusieurs demandes.
+            </p>
 
             {typeof latestImport.invalidRows === "number" ? (
               <p className="mt-4 text-sm text-slate-600">
@@ -1007,8 +1309,9 @@ const ImportCsvPage = () => {
                       </div>
                       <div className="mt-1 text-slate-500">
                         {typeof item.duplicateRows === "number"
-                          ? `${pluralize(item.duplicateRows, "doublon", "doublons")} détecté${item.duplicateRows > 1 ? "s" : ""}`
+                          ? `${pluralize(getDuplicateRowsCount(item), "doublon exact", "doublons exacts")} détecté${getDuplicateRowsCount(item) > 1 ? "s" : ""}`
                           : "Aucun doublon signalé"}
+                        {` · ${pluralize(getDuplicateFamiliesCount(item), "famille en double", "familles en double")}`}
                         {typeof item.invalidRows === "number"
                           ? ` · ${pluralize(item.invalidRows, "ligne invalide", "lignes invalides")}`
                           : ""}

--- a/apps/web/src/types/import.ts
+++ b/apps/web/src/types/import.ts
@@ -1,5 +1,17 @@
 export type CsvImportStatus = "SUCCESS" | "FAILED";
 
+export type CsvImportDuplicateFamily = {
+  key: string;
+  reason: string;
+  rows: number[];
+  familyPreview: {
+    fatherFullName: string | null;
+    motherFullName: string | null;
+    contactEmail: string;
+    contactPhone: string | null;
+  };
+};
+
 export type CsvImportHistoryItem = {
   id: string;
   fileName: string | null;
@@ -8,6 +20,9 @@ export type CsvImportHistoryItem = {
   importedStudents: number;
   skippedRows: number;
   duplicateRows: number;
+  duplicateRowsCount?: number;
+  duplicateFamilies: number;
+  duplicateFamiliesCount?: number;
   invalidRows: number;
   totalRows: number;
   status: CsvImportStatus;
@@ -22,9 +37,30 @@ export type CsvImportSummary = {
   importedStudents: number;
   skippedRows: number;
   duplicateRows?: number;
+  duplicateRowsCount?: number;
+  duplicateFamilies?: CsvImportDuplicateFamily[];
+  duplicateFamiliesCount?: number;
+  mergedDuplicateFamilyRows?: number;
   invalidRows?: number;
   totalRows?: number;
   activeSchoolYear?: string;
   delimiter?: string;
   historyEntry?: CsvImportHistoryItem;
+  mergeDuplicateFamilies?: boolean;
+};
+
+export type CsvImportDuplicateRow = {
+  rowNumber: number;
+  reason: string;
+};
+
+export type CsvImportPreview = {
+  totalRows: number;
+  invalidRows: number;
+  duplicateRows: CsvImportDuplicateRow[];
+  duplicateRowsCount: number;
+  duplicateFamilies: CsvImportDuplicateFamily[];
+  duplicateFamiliesCount: number;
+  activeSchoolYear?: string;
+  delimiter?: string;
 };

--- a/prisma/migrations/20260506000000_add_duplicate_families_to_csv_import_log/migration.sql
+++ b/prisma/migrations/20260506000000_add_duplicate_families_to_csv_import_log/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "CsvImportLog" ADD COLUMN "duplicateFamilies" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -172,6 +172,7 @@ model CsvImportLog {
   importedStudents     Int             @default(0)
   skippedRows          Int             @default(0)
   duplicateRows        Int             @default(0)
+  duplicateFamilies    Int             @default(0)
   invalidRows          Int             @default(0)
   totalRows            Int             @default(0)
   status               CsvImportStatus @default(SUCCESS)


### PR DESCRIPTION
## Objectif

Ajouter une gestion claire des doublons lors de l’import CSV, en distinguant les doublons techniques des doublons métier liés aux familles présentes plusieurs fois dans un même fichier.

## Changements réalisés

- Audit de la logique existante des doublons.
- Clarification du compteur existant : les doublons exacts correspondent aux lignes déjà importées via `rawCsvRowHash`.
- Ajout de la détection des familles potentiellement en double :
  - même email normalisé,
  - même téléphone normalisé,
  - mêmes parents + adresse.
- Ajout des compteurs :
  - `duplicateRowsCount`
  - `duplicateFamiliesCount`
  - `duplicateFamilies`
- Ajout de la persistance des familles en double dans l’historique d’import.
- Ajout d’une route de prévisualisation CSV avant import définitif.
- Ajout d’une modal de confirmation si des doublons sont détectés.
- Ajout de deux choix métier :
  - fusionner et importer,
  - importer sans fusion.
- En cas de fusion, seule la première demande du groupe famille est conservée.
- Suppression de l’alerte redondante remplacée par la modal.
- Mise à jour de l’UI du résumé d’import :
  - familles,
  - demandes,
  - ignorées,
  - doublons exacts,
  - familles en double.

## Logique métier

- `Ignorées` correspond aux lignes CSV non importées comme demandes.
- `Doublons exacts` correspond aux doublons techniques.
- `Familles en double` correspond aux doublons métier, lorsqu’une même famille semble avoir soumis plusieurs demandes.

Exemple validé :
- CSV initial : 71 lignes
- Famille en double détectée : 1
- Fusion activée : 1 ligne ignorée
- Résultat attendu : 70 familles, 70 demandes

## Vérifications

- `npm exec -w apps/api -- tsc -b` ✅
- `npm exec -w apps/web -- tsc -b` ✅
- `npm run build -w apps/web` ✅

## Note

Penser à exécuter la migration en base locale ou cible :

```bash
npx prisma migrate deploy