### PR TITLE
feat(devops): add docker development setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+node_modules
+**/node_modules
+dist
+**/dist
+build
+**/build
+.git
+.gitignore
+.env
+.env.*
+!.env.example
+Dockerfile
+docker-compose*.yml
+npm-debug.log*
+coverage
+**/coverage
+.DS_Store

--- a/.env.example
+++ b/.env.example
@@ -3,14 +3,24 @@ PORT=3000
 FRONTEND_URL=http://localhost:5173
 DATABASE_URL="postgresql://ece:ecepassword@localhost:5432/ece_db?schema=public"
 
+# Docker/PostgreSQL
+POSTGRES_USER=ece
+POSTGRES_PASSWORD=ecepassword
+POSTGRES_DB=ece_db
+POSTGRES_PORT=5432
+API_PORT=3000
+WEB_PORT=5173
+RUN_PRISMA_SEED=true
+SYNC_ADMIN_PASSWORD_ON_SEED=true
+
 # SMTP email sending
-# SMTP_HOST=smtp.example.com
-# SMTP_PORT=587
-# SMTP_SECURE=false
-# SMTP_USER=notifications@example.com
-# SMTP_PASS=change-me
-# SMTP_FROM="ECE Admissions <notifications@example.com>"
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=notifications@example.com
+SMTP_PASS=change-me
+SMTP_FROM="ECE Admissions <notifications@example.com>"
 
 # Admin authentication
 ADMIN_EMAIL=admin@example.com
-ADMIN_PASSWORD=change-me
+ADMIN_PASSWORD=change-me-now

--- a/README.md
+++ b/README.md
@@ -1,2 +1,138 @@
 # ece-admin-app
  Application web de gestion des demandes d'inscription - Projet ECE
+
+# Docker Setup
+
+Configuration de developpement locale pour lancer l'application complete avec Docker Desktop.
+
+## Prerequis
+
+- Docker Desktop installe et lance
+- Port `5432`, `3000` et `5173` disponibles sur la machine
+- Aucun `npm install` local requis pour lancer via Docker
+
+## Installation
+
+1. Cloner le depot.
+2. Creer un fichier `.env` depuis le modele :
+
+```bash
+cp .env.example .env
+```
+
+3. Renseigner les variables Mailtrap dans `.env` si l'envoi mail doit etre teste :
+
+```env
+SMTP_HOST=sandbox.smtp.mailtrap.io
+SMTP_PORT=2525
+SMTP_USER=your-mailtrap-user
+SMTP_PASS=your-mailtrap-password
+SMTP_FROM="ECE Admissions <no-reply@ece.test>"
+```
+
+4. Lancer toute la stack :
+
+```bash
+docker compose up --build
+```
+
+Au demarrage du service `api`, Docker execute automatiquement :
+
+- `npx prisma migrate deploy`
+- `npx prisma generate`
+- `npx prisma db seed` si `RUN_PRISMA_SEED=true`
+- `npm run dev -w apps/api`
+
+Le service `web` lance Vite en mode dev avec HMR.
+
+## Acces
+
+- Application web : http://localhost:5173
+- API : http://localhost:3000
+- Healthcheck API : http://localhost:3000/health
+- PostgreSQL : `localhost:5432`
+
+Identifiants admin par defaut en dev :
+
+```text
+Email: admin@example.com
+Password: change-me-now
+```
+
+Ces valeurs se changent avec `ADMIN_EMAIL` et `ADMIN_PASSWORD` dans `.env`.
+
+## Commandes Utiles
+
+Demarrer la stack :
+
+```bash
+docker compose up --build
+```
+
+Demarrer en arriere-plan :
+
+```bash
+docker compose up --build -d
+```
+
+Voir les logs :
+
+```bash
+docker compose logs -f api
+docker compose logs -f web
+docker compose logs -f postgres
+```
+
+Arreter les containers :
+
+```bash
+docker compose down
+```
+
+## Prisma
+
+Executer les migrations dans le container API :
+
+```bash
+docker compose exec api npx prisma migrate deploy
+```
+
+Generer le client Prisma :
+
+```bash
+docker compose exec api npx prisma generate
+```
+
+Relancer le seed :
+
+```bash
+docker compose exec api npx prisma db seed
+```
+
+Ouvrir Prisma Studio :
+
+```bash
+docker compose exec api npx prisma studio --hostname 0.0.0.0
+```
+
+## Reset Docker Propre
+
+Supprimer les containers et le volume PostgreSQL :
+
+```bash
+docker compose down -v
+```
+
+Reconstruire sans cache :
+
+```bash
+docker compose build --no-cache
+docker compose up
+```
+
+## Notes De Developpement
+
+- Les sources du monorepo sont montees dans `/app` pour le hot reload frontend et backend.
+- Le volume Docker `node_modules` conserve les dependances installees dans les images et evite de melanger les `node_modules` macOS avec ceux des containers Linux.
+- Dans Docker, le frontend proxifie `/api` vers `http://api:3000`. Hors Docker, Vite garde le proxy local vers `http://localhost:3000`.
+- Le service `api` surcharge `DATABASE_URL` pour utiliser l'hote Docker `postgres`, tandis que `.env.example` garde une URL `localhost` compatible avec le developpement hors Docker.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:24-bookworm-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY package.json package-lock.json prisma.config.ts ./
+COPY apps/api/package.json ./apps/api/package.json
+COPY apps/web/package.json ./apps/web/package.json
+COPY prisma ./prisma
+
+RUN npm ci
+
+COPY apps/api ./apps/api
+
+EXPOSE 3000
+
+CMD ["npm", "run", "dev", "-w", "apps/api"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:24-bookworm-slim
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY apps/api/package.json ./apps/api/package.json
+COPY apps/web/package.json ./apps/web/package.json
+
+RUN npm ci
+
+COPY apps/web ./apps/web
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "-w", "apps/web", "--", "--host", "0.0.0.0", "--port", "5173"]

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,13 +1,23 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const port = Number(process.env.VITE_PORT ?? 5173)
+const hmrClientPort = Number(process.env.VITE_HMR_CLIENT_PORT ?? port)
+const proxyTarget = process.env.VITE_PROXY_TARGET ?? "http://localhost:3000"
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   server: {
+    host: "0.0.0.0",
+    port,
+    strictPort: true,
+    hmr: {
+      clientPort: hmrClientPort,
+    },
     proxy: {
       "/api": {
-        target: "http://localhost:3000",
+        target: proxyTarget,
         changeOrigin: true,
       },
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,80 @@
 services:
-  db:
-    image: postgres:15
-    container_name: ece-postgres
+  postgres:
+    image: postgres:15-alpine
     restart: unless-stopped
     environment:
-      POSTGRES_USER: ece
-      POSTGRES_PASSWORD: ecepassword
-      POSTGRES_DB: ece_db
+      POSTGRES_USER: ${POSTGRES_USER:-ece}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-ecepassword}
+      POSTGRES_DB: ${POSTGRES_DB:-ece_db}
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      NODE_ENV: development
+      PORT: 3000
+      FRONTEND_URL: http://localhost:${WEB_PORT:-5173}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-ece}:${POSTGRES_PASSWORD:-ecepassword}@postgres:5432/${POSTGRES_DB:-ece_db}?schema=public
+      SMTP_HOST: ${SMTP_HOST:-}
+      SMTP_PORT: ${SMTP_PORT:-}
+      SMTP_SECURE: ${SMTP_SECURE:-false}
+      SMTP_USER: ${SMTP_USER:-}
+      SMTP_PASS: ${SMTP_PASS:-}
+      SMTP_FROM: ${SMTP_FROM:-}
+      ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@example.com}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD:-change-me-now}
+      RUN_PRISMA_SEED: ${RUN_PRISMA_SEED:-true}
+      SYNC_ADMIN_PASSWORD_ON_SEED: ${SYNC_ADMIN_PASSWORD_ON_SEED:-true}
+      CHOKIDAR_USEPOLLING: "true"
+    ports:
+      - "${API_PORT:-3000}:3000"
+    volumes:
+      - .:/app
+      - node_modules:/app/node_modules
+    command: >
+      sh -c "npx prisma migrate deploy
+      && npx prisma generate
+      && if [ \"${RUN_PRISMA_SEED:-true}\" = \"true\" ]; then npx prisma db seed; fi
+      && npm run dev -w apps/api"
+
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+    restart: unless-stopped
+    depends_on:
+      - api
+    environment:
+      NODE_ENV: development
+      VITE_PORT: ${WEB_PORT:-5173}
+      VITE_HMR_CLIENT_PORT: ${WEB_PORT:-5173}
+      VITE_PROXY_TARGET: http://api:3000
+      CHOKIDAR_USEPOLLING: "true"
+      WATCHPACK_POLLING: "true"
+    ports:
+      - "${WEB_PORT:-5173}:5173"
+    volumes:
+      - .:/app
+      - node_modules:/app/node_modules
+    command: npm run dev -w apps/web -- --host 0.0.0.0 --port 5173
 
 volumes:
   postgres_data:
+  node_modules:

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -475,17 +475,20 @@ const ensureApplicationBundle = async (levelIdsByCode, schoolYearId, seedRecord)
 const ensureAdminAccount = async () => {
   const email = process.env.ADMIN_EMAIL?.trim();
   const password = process.env.ADMIN_PASSWORD?.trim();
+  const shouldSyncPassword = process.env.SYNC_ADMIN_PASSWORD_ON_SEED === "true";
 
   if (!email || !password) {
     return null;
   }
 
+  const passwordHash = hashPassword(password);
+
   return prisma.adminAccount.upsert({
     where: { email: normalizeAdminEmail(email) },
-    update: {},
+    update: shouldSyncPassword ? { passwordHash } : {},
     create: {
       email: normalizeAdminEmail(email),
-      passwordHash: hashPassword(password)
+      passwordHash
     }
   });
 };


### PR DESCRIPTION
## Résumé

- Ajout d’un setup Docker Compose complet pour l’environnement de développement
- Ajout des services postgres, api et web
- Configuration du hot reload frontend/backend
- Configuration Prisma dans le container API
- Ajout d’un `.env.example`
- Mise à jour du README avec les commandes Docker utiles
- Adaptation de Vite pour l’exécution en container Docker

## Vérifications

- `docker compose config`
- `docker compose up --build -d --remove-orphans`
- `docker compose exec -T api npx prisma migrate deploy`
- `curl http://localhost:3001/health`
- `curl http://localhost:5173`
- Test login admin
- Test reset password via SMTP/Mailtrap
- Test preview/import CSV
- Test connexion Prisma
- `npm run build -w apps/api`
- `npm run build -w apps/web`

## Notes

- Test réalisé avec `API_PORT=3001` car le port 3000 était déjà utilisé localement.
- Sur une machine neuve, le port 3000 peut rester utilisé comme prévu par la configuration par défaut.