### PR TITLE
Fix/application status details

### DIFF
--- a/apps/api/src/controllers/application.controller.ts
+++ b/apps/api/src/controllers/application.controller.ts
@@ -138,8 +138,7 @@ const getRecalculatedApplicationStatus = (
   );
 
   if (allPending) {
-    return currentStatus === ApplicationStatus.RECEIVED ||
-      currentStatus === ApplicationStatus.IN_REVIEW
+    return currentStatus === ApplicationStatus.IN_REVIEW
       ? currentStatus
       : ApplicationStatus.IN_REVIEW;
   }
@@ -200,6 +199,10 @@ export const getApplications = async (req: Request, res: Response): Promise<void
     if (status === ApplicationStatus.WAITLISTED) {
       where.status = {
         in: [ApplicationStatus.WAITLISTED, ApplicationStatus.REFUSED]
+      };
+    } else if (status === ApplicationStatus.IN_REVIEW) {
+      where.status = {
+        in: [ApplicationStatus.IN_REVIEW, ApplicationStatus.RECEIVED]
       };
     } else {
       where.status = status;

--- a/apps/api/src/controllers/dashboard.controller.ts
+++ b/apps/api/src/controllers/dashboard.controller.ts
@@ -161,6 +161,8 @@ export const getDashboardStats = async (_req: Request, res: Response): Promise<v
     const dashboardStatus =
       statusCount.status === ApplicationStatus.REFUSED
         ? ApplicationStatus.WAITLISTED
+        : statusCount.status === ApplicationStatus.RECEIVED
+        ? ApplicationStatus.IN_REVIEW
         : statusCount.status;
 
     byStatus[dashboardStatus] += statusCount._count._all;

--- a/apps/api/src/controllers/import.controller.ts
+++ b/apps/api/src/controllers/import.controller.ts
@@ -1,4 +1,4 @@
-import type { Prisma } from "@prisma/client";
+import { ApplicationStatus, type Prisma } from "@prisma/client";
 import type { Request, Response } from "express";
 
 import { buildApplicationImportHash, normalizeLevelLookupKey, parseCsvImportFile } from "../lib/csv-import";
@@ -584,6 +584,7 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
           submittedAt: row.application.submittedAt,
           declaredChildrenCount: row.application.declaredChildrenCount,
           discoverySource: row.application.discoverySource,
+          status: ApplicationStatus.IN_REVIEW,
           rawCsvRowHash: applicationHash
         },
         select: {

--- a/apps/web/src/components/ui/StatusBadge.tsx
+++ b/apps/web/src/components/ui/StatusBadge.tsx
@@ -11,24 +11,6 @@ type StatusBadgeConfig = {
   Icon: () => JSX.Element;
 };
 
-const MailIcon = () => {
-  return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 16 16"
-      className="h-3.5 w-3.5 flex-none"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.4"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <rect x="2" y="3.25" width="12" height="9.5" rx="2" />
-      <path d="M3.25 5 8 8.5 12.75 5" />
-    </svg>
-  );
-};
-
 const ReviewIcon = () => {
   return (
     <svg
@@ -104,9 +86,9 @@ const PartialIcon = () => {
 
 const statusBadgeConfig: Record<ApplicationStatus, StatusBadgeConfig> = {
   RECEIVED: {
-    badgeClassName: "bg-slate-100 text-slate-700 ring-slate-200",
-    label: "Reçue",
-    Icon: MailIcon
+    badgeClassName: "bg-info/15 text-info ring-info/20",
+    label: "En revue",
+    Icon: ReviewIcon
   },
   IN_REVIEW: {
     badgeClassName: "bg-info/15 text-info ring-info/20",

--- a/apps/web/src/lib/applicationEmail.ts
+++ b/apps/web/src/lib/applicationEmail.ts
@@ -107,7 +107,7 @@ const applicationStatusLabels = {
   WAITLISTED: "Liste d'attente",
   REFUSED: "Liste d'attente",
   IN_REVIEW: "En revue",
-  RECEIVED: "Reçue"
+  RECEIVED: "En revue"
 } satisfies Record<ApplicationDetail["status"], string>;
 
 const decisionStatusPhraseLabels: Record<StudentAdmissionStatus, string> = {

--- a/apps/web/src/pages/ApplicationDetailPage.tsx
+++ b/apps/web/src/pages/ApplicationDetailPage.tsx
@@ -24,7 +24,6 @@ import {
   getApplicationById,
   getApplicationEmailLogs,
   updateApplicationPriority,
-  updateApplicationStatus,
   updateStudentAdmissionStatus
 } from "../lib/api";
 import {
@@ -79,17 +78,6 @@ const genderLabels: Record<ApplicationGender, string> = {
   UNKNOWN: "Non renseigné"
 };
 
-const statusOptions: Array<{
-  value: ApplicationStatus;
-  label: string;
-}> = [
-  { value: "RECEIVED", label: "Reçue" },
-  { value: "IN_REVIEW", label: "En revue" },
-  { value: "ACCEPTED", label: "Acceptée" },
-  { value: "WAITLISTED", label: "Liste d'attente" },
-  { value: "PARTIALLY_ACCEPTED", label: "Décision partielle" }
-];
-
 const studentAdmissionStatusOptions: Array<{
   value: StudentAdmissionStatus;
   label: string;
@@ -140,10 +128,6 @@ const isDecisionStatus = (
     status === "REFUSED" ||
     status === "PARTIALLY_ACCEPTED"
   );
-};
-
-const getStatusSelection = (status: ApplicationStatus): ApplicationStatus => {
-  return status === "REFUSED" ? "WAITLISTED" : status;
 };
 
 const formatSchoolYearLabel = (label: string): string => {
@@ -492,25 +476,6 @@ const MailSendAnimation = () => {
   );
 };
 
-const SaveIcon = ({ className = "h-4 w-4" }: IconProps) => {
-  return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="1.6"
-      className={className}
-    >
-      <path d="M3.25 2.75h7.6l1.9 1.9v8.6h-9.5V2.75Z" />
-      <path d="M5.25 2.75v3h5.5" />
-      <path d="M5.5 11.25h5" />
-    </svg>
-  );
-};
-
 const StarIcon = ({ className = "h-4 w-4" }: IconProps) => {
   return (
     <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor" className={className}>
@@ -648,7 +613,7 @@ const buildTimelineEntries = (
   const entries: TimelineEntry[] = [
     {
       id: `${application.id}-created`,
-      type: "Demande reçue",
+      type: "Demande importée",
       date: formatOptionalDateTime(application.createdAt),
       markerClassName: "bg-primary shadow-[0_10px_20px_-14px_rgba(31,77,58,0.75)]",
       sortDate: createdAt.getTime(),
@@ -708,8 +673,6 @@ const ApplicationDetailPage = () => {
   const [emailLogs, setEmailLogs] = useState<ApplicationEmailLog[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [selectedStatus, setSelectedStatus] = useState<ApplicationStatus>("RECEIVED");
-  const [isStatusSubmitting, setIsStatusSubmitting] = useState(false);
   const [isPrioritySubmitting, setIsPrioritySubmitting] = useState(false);
   const [updatingStudentAdmissionId, setUpdatingStudentAdmissionId] =
     useState<string | null>(null);
@@ -775,60 +738,9 @@ const ApplicationDetailPage = () => {
   }, [applicationId]);
 
   useEffect(() => {
-    if (application) {
-      setSelectedStatus(getStatusSelection(application.status));
-    }
-  }, [application]);
-
-  useEffect(() => {
     setIsExceptionalEditEnabled(false);
     setIsUnlockDecisionModalOpen(false);
   }, [application?.id, application?.decisionAt]);
-
-  const handleStatusSubmit = useCallback(
-    async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
-      event.preventDefault();
-
-      if (!application || selectedStatus === application.status) {
-        return;
-      }
-
-      if (isTreatmentReadOnly) {
-        showError(
-          "La décision est verrouillée depuis l'envoi de l'email au parent."
-        );
-        return;
-      }
-
-      setIsStatusSubmitting(true);
-
-      try {
-        const updatedApplication = await updateApplicationStatus(
-          application.id,
-          selectedStatus
-        );
-
-        setApplication((currentApplication) => {
-          if (!currentApplication || currentApplication.id !== updatedApplication.id) {
-            return currentApplication;
-          }
-
-          return {
-            ...currentApplication,
-            status: updatedApplication.status
-          };
-        });
-        showSuccess("Le statut a bien été mis à jour.");
-      } catch (updateError) {
-        showError(
-          getActionErrorMessage("Impossible de mettre à jour le statut.", updateError)
-        );
-      } finally {
-        setIsStatusSubmitting(false);
-      }
-    },
-    [application, isTreatmentReadOnly, selectedStatus, showError, showSuccess]
-  );
 
   const handlePriorityToggle = useCallback(async (): Promise<void> => {
     if (!application) {
@@ -984,13 +896,6 @@ const ApplicationDetailPage = () => {
   const studentAdmissionSummary = useMemo(() => {
     return application ? getStudentAdmissionSummary(application.students) : "";
   }, [application]);
-
-  const handleSelectedStatusChange = useCallback(
-    (event: React.ChangeEvent<HTMLSelectElement>): void => {
-      setSelectedStatus(event.target.value as ApplicationStatus);
-    },
-    []
-  );
 
   const pageTopBar = (
     <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
@@ -1212,53 +1117,17 @@ const ApplicationDetailPage = () => {
                   : "Décision verrouillée : l'email de décision a déjà été envoyé au parent."}
               </div>
             ) : null}
-            <form className="shrink-0" onSubmit={handleStatusSubmit}>
-              <div
-                className={`rounded-[22px] border border-slate-200/90 bg-slate-50/80 p-4 transition ${
-                  isTreatmentReadOnly ? "opacity-55 saturate-50" : ""
-                }`}
-              >
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <div>
-                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                      Statut actuel
-                    </p>
-                    <div className="mt-1.5">
-                      <StatusBadge status={application.status} />
-                    </div>
-                  </div>
-                  <select
-                    id="application-status"
-                    aria-label="Nouveau statut"
-                    value={selectedStatus}
-                    onChange={handleSelectedStatusChange}
-                    disabled={isTreatmentReadOnly || isStatusSubmitting}
-                    className="min-w-[170px] rounded-2xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm font-medium text-slate-900 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
-                  >
-                    {statusOptions.map((option) => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                <button
-                  type="submit"
-                  disabled={
-                    isTreatmentReadOnly ||
-                    isStatusSubmitting ||
-                    selectedStatus === application.status
-                  }
-                  className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white transition hover:bg-primaryDark disabled:cursor-not-allowed disabled:bg-slate-300"
-                >
-                  <SaveIcon />
-                  <span>
-                    {isStatusSubmitting ? "Mise à jour..." : "Mettre à jour"}
-                  </span>
-                </button>
+            <div className="shrink-0 rounded-[22px] border border-slate-200/90 bg-slate-50/80 p-4">
+              <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                Statut actuel
+              </p>
+              <div className="mt-2 flex flex-wrap items-center justify-between gap-3">
+                <StatusBadge status={application.status} />
+                <span className="text-xs font-medium leading-5 text-slate-500">
+                  Mis à jour automatiquement depuis les décisions élèves.
+                </span>
               </div>
-            </form>
+            </div>
 
             <div
               className={`shrink-0 rounded-[22px] border border-slate-200/90 bg-slate-50/80 p-4 transition ${

--- a/apps/web/src/pages/ApplicationsPage.tsx
+++ b/apps/web/src/pages/ApplicationsPage.tsx
@@ -70,7 +70,6 @@ const pageSizeOptions: PageSize[] = [4, 6, 8, 10, 12];
 
 const statusOptions: StatusOption[] = [
   { value: "", label: "Tous les statuts" },
-  { value: "RECEIVED", label: "Reçues" },
   { value: "IN_REVIEW", label: "En revue" },
   { value: "ACCEPTED", label: "Acceptées" },
   { value: "WAITLISTED", label: "Liste d'attente" },
@@ -85,6 +84,10 @@ const getRequestedStatusFilter = (
   searchParams: URLSearchParams
 ): "" | ApplicationStatus => {
   const requestedStatus = searchParams.get("status")?.trim() ?? "";
+
+  if (requestedStatus === "RECEIVED") {
+    return "IN_REVIEW";
+  }
 
   return isApplicationStatus(requestedStatus) ? requestedStatus : "";
 };

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -127,21 +127,6 @@ const getDonutSegmentPath = (
   ].join(" ");
 };
 
-const MailMetricIcon = ({ className = "h-5 w-5" }: IconProps) => {
-  return (
-    <svg
-      viewBox="0 0 20 20"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.7"
-      className={className}
-    >
-      <rect x="3.5" y="4.5" width="13" height="11" rx="2.2" />
-      <path d="M4.5 6 10 10l5.5-4" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  );
-};
-
 const ReviewMetricIcon = ({ className = "h-5 w-5" }: IconProps) => {
   return (
     <svg
@@ -222,15 +207,6 @@ const PartialMetricIcon = ({ className = "h-5 w-5" }: IconProps) => {
 
 const statusCards: StatusCardConfig[] = [
   {
-    status: "RECEIVED",
-    label: "Reçues",
-    description: "Demandes nouvellement importées.",
-    valueClassName: "text-slate-900",
-    surfaceClassName: "bg-slate-50/90",
-    iconClassName: "bg-slate-900 text-white",
-    Icon: MailMetricIcon
-  },
-  {
     status: "IN_REVIEW",
     label: "En revue",
     description: "Demandes en cours d'analyse.",
@@ -260,7 +236,7 @@ const statusCards: StatusCardConfig[] = [
   {
     status: "WAITLISTED",
     label: "Liste d'attente",
-    description: "Demandes entièrement en attente de place.",
+    description: "Liste des élèves placés en attente.",
     getValue: (dashboardData) => dashboardData.waitlistedStudents,
     valueClassName: "text-primary",
     surfaceClassName: "bg-primary/10",
@@ -380,6 +356,56 @@ const MetricCard = ({
       <p className="mt-2 text-sm font-semibold text-slate-800">{label}</p>
       <p className="mt-3 text-sm leading-6 text-slate-600">{description}</p>
     </Link>
+  );
+};
+
+const ProcessingMetricCard = ({
+  motionDelay = 0,
+  processedApplications,
+  processedShare,
+  remainingApplications,
+  totalApplications
+}: {
+  motionDelay?: number;
+  processedApplications: number;
+  processedShare: number;
+  remainingApplications: number;
+  totalApplications: number;
+}) => {
+  return (
+    <article
+      className="ui-animate-in ui-surface-hover block rounded-[28px] border border-primary/10 bg-white/90 p-5 shadow-[0_18px_40px_-30px_rgba(31,77,58,0.34)] outline-none transition"
+      style={getEnterStyle(motionDelay)}
+      aria-label={`${processedApplications} demandes traitees sur ${totalApplications}. ${remainingApplications} restantes.`}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-primaryLight">
+            Traitement
+          </p>
+          <p className="mt-2 text-sm font-semibold text-slate-800">
+            {remainingApplications} restante
+            {remainingApplications !== 1 ? "s" : ""}
+          </p>
+        </div>
+        <span className="ui-surface-hover__icon inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-success text-white">
+          <AcceptedMetricIcon className="h-5 w-5" />
+        </span>
+      </div>
+
+      <p className="mt-6 text-3xl font-semibold tracking-tight text-primaryDark">
+        {processedApplications} / {totalApplications}
+      </p>
+      <p className="mt-2 text-sm font-semibold text-slate-800">
+        traitée{processedApplications !== 1 ? "s" : ""}
+      </p>
+      <div className="mt-4 overflow-hidden rounded-full bg-primary/10 p-1">
+        <div
+          className="h-3 rounded-full bg-success shadow-[0_10px_18px_-14px_rgba(34,197,94,0.7)] transition-[width] duration-500"
+          style={{ width: `${processedShare}%` }}
+        />
+      </div>
+    </article>
   );
 };
 
@@ -535,10 +561,25 @@ const DashboardPage = () => {
       },
       null
     );
+    const processedApplications =
+      data.byStatus.ACCEPTED +
+      data.byStatus.PARTIALLY_ACCEPTED +
+      data.byStatus.WAITLISTED;
+    const remainingApplications = Math.max(
+      data.totalApplications - processedApplications,
+      0
+    );
+    const processedShare =
+      data.totalApplications === 0
+        ? 0
+        : Math.round((processedApplications / data.totalApplications) * 100);
 
     return {
       levelBreakdown,
       levelChartGradient,
+      processedApplications,
+      processedShare,
+      remainingApplications,
       topLevel,
       totalStudents,
       totalPriorityPages,
@@ -727,6 +768,13 @@ const DashboardPage = () => {
           </div>
 
           <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+            <ProcessingMetricCard
+              motionDelay={360}
+              processedApplications={dashboardView.processedApplications}
+              processedShare={dashboardView.processedShare}
+              remainingApplications={dashboardView.remainingApplications}
+              totalApplications={data.totalApplications}
+            />
             {statusCards.map((card, index) => (
               <MetricCard
                 key={card.status}
@@ -735,7 +783,7 @@ const DashboardPage = () => {
                 description={card.description}
                 Icon={card.Icon}
                 iconClassName={card.iconClassName}
-                motionDelay={360 + index * 70}
+                motionDelay={430 + index * 70}
                 surfaceClassName={card.surfaceClassName}
                 status={card.status}
                 valueClassName={card.valueClassName}

--- a/apps/web/src/pages/ImportCsvPage.tsx
+++ b/apps/web/src/pages/ImportCsvPage.tsx
@@ -286,8 +286,8 @@ const SummaryMetric = ({
   value: number;
 }) => {
   return (
-    <article className="rounded-[22px] border border-[#eee3d7] bg-white/85 px-4 py-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)]">
-      <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+    <article className="flex min-h-32 flex-col items-center justify-center rounded-[22px] border border-[#eee3d7] bg-white/85 px-4 py-4 text-center shadow-[inset_0_1px_0_rgba(255,255,255,0.85)]">
+      <p className="max-w-full text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
         {label}
       </p>
       <p className="mt-3 text-3xl font-semibold text-primary">

--- a/prisma/migrations/20260506001000_default_applications_to_in_review/migration.sql
+++ b/prisma/migrations/20260506001000_default_applications_to_in_review/migration.sql
@@ -1,0 +1,6 @@
+UPDATE "Application"
+SET "status" = 'IN_REVIEW'
+WHERE "status" = 'RECEIVED';
+
+ALTER TABLE "Application"
+ALTER COLUMN "status" SET DEFAULT 'IN_REVIEW';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -89,7 +89,7 @@ model Application {
   submittedAt           DateTime
   declaredChildrenCount Int?
   discoverySource       String?
-  status                ApplicationStatus @default(RECEIVED)
+  status                ApplicationStatus @default(IN_REVIEW)
   isPriority            Boolean           @default(false)
   decisionAt            DateTime?
   decisionNote          String?

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -76,7 +76,7 @@ const APPLICATION_SEEDS = [
       submittedAt: createUtcDate(2026, 1, 9, 8, 45),
       declaredChildrenCount: 1,
       discoverySource: "Google Forms",
-      status: ApplicationStatus.RECEIVED,
+      status: ApplicationStatus.IN_REVIEW,
       isPriority: false,
       decisionAt: null,
       decisionNote: null
@@ -308,7 +308,7 @@ const APPLICATION_SEEDS = [
       submittedAt: createUtcDate(2026, 2, 19, 13, 50),
       declaredChildrenCount: 2,
       discoverySource: "Google Forms",
-      status: ApplicationStatus.RECEIVED,
+      status: ApplicationStatus.IN_REVIEW,
       isPriority: false,
       decisionAt: null,
       decisionNote: null


### PR DESCRIPTION
## Résumé

Cette PR ajuste la gestion des statuts des demandes afin de supprimer les changements manuels incohérents et de mieux aligner le workflow avec les décisions prises au niveau des élèves.

## Changements apportés

- Suppression de la mise à jour manuelle du statut dans le bloc "Statut actuel" de la page détail d’une demande.
- Le bloc affiche désormais uniquement le statut courant de la demande.
- Ajout d’une mention indiquant que le statut est mis à jour automatiquement selon les décisions élèves.
- Réorganisation du bloc "Demandes par statut" sur le dashboard :
  - suppression du bloc "Reçues" ;
  - remplacement par le curseur de traitement ;
  - adaptation du curseur dans un bloc cohérent avec les autres cartes ;
  - conservation des blocs En revue, Acceptées, Partielles et Liste d’attente.
- Modification du texte du bloc Liste d’attente.
- Passage automatique des nouvelles demandes importées au statut `IN_REVIEW`.
- Mise à jour du défaut Prisma de `RECEIVED` vers `IN_REVIEW`.
- Ajout d’une migration pour convertir les anciennes demandes `RECEIVED` vers `IN_REVIEW`.
- Compatibilité ajoutée pour afficher et compter les anciens statuts `RECEIVED` comme `IN_REVIEW` si certains existent encore.

## Vérifications

- `npm run build --workspace apps/web`
- `npm run build --workspace apps/api`

## Note technique

Après merge, appliquer la migration Prisma sur la base concernée afin de convertir les anciennes demandes `RECEIVED` en `IN_REVIEW`.
