### PR TITLE
feat: orienter le suivi des inscriptions autour des élèves

### DIFF
--- a/apps/api/src/controllers/student.controller.ts
+++ b/apps/api/src/controllers/student.controller.ts
@@ -1,0 +1,251 @@
+import { StudentAdmissionStatus, type Prisma } from "@prisma/client";
+import type { Request, Response } from "express";
+
+import { badRequest, notFound } from "../lib/errors";
+import { prisma } from "../prisma/client";
+
+const getQueryParam = (value: unknown): string | undefined => {
+  if (typeof value === "string") {
+    const trimmedValue = value.trim();
+
+    return trimmedValue.length > 0 ? trimmedValue : undefined;
+  }
+
+  if (Array.isArray(value)) {
+    const firstValue = value.find((item): item is string => typeof item === "string");
+
+    return firstValue?.trim() || undefined;
+  }
+
+  return undefined;
+};
+
+const visibleStatusFilterToDbFilter = (
+  status: string
+): Prisma.EnumStudentAdmissionStatusFilter<"Student"> => {
+  if (status === StudentAdmissionStatus.ACCEPTED) {
+    return { equals: StudentAdmissionStatus.ACCEPTED };
+  }
+
+  if (status === StudentAdmissionStatus.WAITLISTED) {
+    return {
+      in: [
+        StudentAdmissionStatus.WAITLISTED,
+        StudentAdmissionStatus.REFUSED
+      ]
+    };
+  }
+
+  throw badRequest("Invalid student admission status");
+};
+
+const getPaginationParam = (
+  value: unknown,
+  fallback: number,
+  maxValue: number
+): number => {
+  const parsedValue = Number(getQueryParam(value));
+
+  if (!Number.isInteger(parsedValue) || parsedValue < 1) {
+    return fallback;
+  }
+
+  return Math.min(parsedValue, maxValue);
+};
+
+const getStudentOrderBy = (
+  sortBy: string | undefined,
+  sortOrder: string | undefined
+): Prisma.StudentOrderByWithRelationInput => {
+  const direction = sortOrder === "asc" ? "asc" : "desc";
+
+  if (sortBy === "firstName") {
+    return { firstName: direction };
+  }
+
+  if (sortBy === "lastName") {
+    return { lastName: direction };
+  }
+
+  if (sortBy === "level") {
+    return { level: { sortOrder: direction } };
+  }
+
+  if (sortBy === "birthDate") {
+    return { birthDate: direction };
+  }
+
+  if (sortBy === "status") {
+    return { admissionStatus: direction };
+  }
+
+  return { application: { submittedAt: direction } };
+};
+
+const studentInclude = {
+  level: true,
+  application: {
+    include: {
+      schoolYear: true,
+      family: true
+    }
+  }
+} satisfies Prisma.StudentInclude;
+
+export const getStudents = async (req: Request, res: Response): Promise<void> => {
+  const search = getQueryParam(req.query.search);
+  const status = getQueryParam(req.query.status);
+  const levelId = getQueryParam(req.query.levelId);
+  const schoolYearId = getQueryParam(req.query.schoolYearId);
+  const isPriority = getQueryParam(req.query.isPriority);
+  const familyId = getQueryParam(req.query.familyId);
+  const sortBy = getQueryParam(req.query.sortBy);
+  const sortOrder = getQueryParam(req.query.sortOrder);
+  const page = getPaginationParam(req.query.page, 1, 100000);
+  const limit = getPaginationParam(req.query.limit, 20, 5000);
+  const where: Prisma.StudentWhereInput = {};
+
+  if (status) {
+    where.admissionStatus = visibleStatusFilterToDbFilter(status);
+  }
+
+  if (levelId) {
+    where.levelId = levelId;
+  }
+
+  if (search) {
+    where.OR = [
+      { firstName: { contains: search, mode: "insensitive" } },
+      { lastName: { contains: search, mode: "insensitive" } },
+      {
+        application: {
+          family: {
+            fatherLastName: { contains: search, mode: "insensitive" }
+          }
+        }
+      },
+      {
+        application: {
+          family: {
+            fatherFirstName: { contains: search, mode: "insensitive" }
+          }
+        }
+      },
+      {
+        application: {
+          family: {
+            motherLastName: { contains: search, mode: "insensitive" }
+          }
+        }
+      },
+      {
+        application: {
+          family: {
+            motherFirstName: { contains: search, mode: "insensitive" }
+          }
+        }
+      },
+      {
+        application: {
+          family: {
+            contactEmail: { contains: search, mode: "insensitive" }
+          }
+        }
+      },
+      {
+        application: {
+          family: {
+            contactPhone: { contains: search, mode: "insensitive" }
+          }
+        }
+      }
+    ];
+  }
+
+  const applicationWhere: Prisma.ApplicationWhereInput = {};
+
+  if (schoolYearId) {
+    applicationWhere.schoolYearId = schoolYearId;
+  }
+
+  if (familyId) {
+    applicationWhere.familyId = familyId;
+  }
+
+  if (isPriority) {
+    if (isPriority !== "true" && isPriority !== "false") {
+      throw badRequest("Invalid priority filter");
+    }
+
+    where.isPriority = isPriority === "true";
+  }
+
+  if (Object.keys(applicationWhere).length > 0) {
+    where.application = applicationWhere;
+  }
+
+  const [total, students] = await Promise.all([
+    prisma.student.count({ where }),
+    prisma.student.findMany({
+      where,
+      include: studentInclude,
+      orderBy: getStudentOrderBy(sortBy, sortOrder),
+      skip: (page - 1) * limit,
+      take: limit
+    })
+  ]);
+
+  res.status(200).json({
+    data: students,
+    meta: {
+      page,
+      limit,
+      total,
+      totalPages: Math.max(1, Math.ceil(total / limit))
+    }
+  });
+};
+
+export const getStudentById = async (req: Request, res: Response): Promise<void> => {
+  const studentId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+
+  const student = await prisma.student.findUnique({
+    where: { id: studentId },
+    include: studentInclude
+  });
+
+  if (!student) {
+    throw notFound("Student not found");
+  }
+
+  res.status(200).json(student);
+};
+
+export const updateStudentPriority = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  const studentId = Array.isArray(req.params.id) ? req.params.id[0] : req.params.id;
+  const isPriority = req.body?.isPriority;
+
+  if (typeof isPriority !== "boolean") {
+    throw badRequest("Invalid priority value");
+  }
+
+  const existingStudent = await prisma.student.findUnique({
+    where: { id: studentId },
+    select: { id: true }
+  });
+
+  if (!existingStudent) {
+    throw notFound("Student not found");
+  }
+
+  const updatedStudent = await prisma.student.update({
+    where: { id: studentId },
+    data: { isPriority },
+    include: studentInclude
+  });
+
+  res.status(200).json(updatedStudent);
+};

--- a/apps/web/src/pages/ApplicationDetailPage.tsx
+++ b/apps/web/src/pages/ApplicationDetailPage.tsx
@@ -17,13 +17,11 @@ import PersonAvatar, {
   FamilyAvatar,
   type PersonAvatarVariant
 } from "../components/ui/PersonAvatar";
-import PriorityBadge from "../components/ui/PriorityBadge";
 import StatusBadge from "../components/ui/StatusBadge";
 import { useToast } from "../context/ToastContext";
 import {
   getApplicationById,
   getApplicationEmailLogs,
-  updateApplicationPriority,
   updateStudentAdmissionStatus
 } from "../lib/api";
 import {
@@ -476,14 +474,6 @@ const MailSendAnimation = () => {
   );
 };
 
-const StarIcon = ({ className = "h-4 w-4" }: IconProps) => {
-  return (
-    <svg aria-hidden="true" viewBox="0 0 16 16" fill="currentColor" className={className}>
-      <path d="m8 2.15 1.62 3.28 3.62.52-2.62 2.55.62 3.6L8 10.4l-3.24 1.7.62-3.6L2.76 5.95l3.62-.52L8 2.15Z" />
-    </svg>
-  );
-};
-
 const ParentAvatar = ({
   label,
   variant
@@ -673,7 +663,6 @@ const ApplicationDetailPage = () => {
   const [emailLogs, setEmailLogs] = useState<ApplicationEmailLog[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [isPrioritySubmitting, setIsPrioritySubmitting] = useState(false);
   const [updatingStudentAdmissionId, setUpdatingStudentAdmissionId] =
     useState<string | null>(null);
   const [isExceptionalEditEnabled, setIsExceptionalEditEnabled] = useState(false);
@@ -741,55 +730,6 @@ const ApplicationDetailPage = () => {
     setIsExceptionalEditEnabled(false);
     setIsUnlockDecisionModalOpen(false);
   }, [application?.id, application?.decisionAt]);
-
-  const handlePriorityToggle = useCallback(async (): Promise<void> => {
-    if (!application) {
-      return;
-    }
-
-    if (isTreatmentReadOnly) {
-      showError(
-        "La décision est verrouillée depuis l'envoi de l'email au parent."
-      );
-      return;
-    }
-
-    const nextPriorityValue = !application.isPriority;
-
-    setIsPrioritySubmitting(true);
-
-    try {
-      const updatedApplication = await updateApplicationPriority(
-        application.id,
-        nextPriorityValue
-      );
-
-      setApplication((currentApplication) => {
-        if (!currentApplication || currentApplication.id !== updatedApplication.id) {
-          return currentApplication;
-        }
-
-        return {
-          ...currentApplication,
-          isPriority: updatedApplication.isPriority
-        };
-      });
-      showSuccess(
-        nextPriorityValue
-          ? "La demande est maintenant prioritaire."
-          : "La priorité a été retirée."
-      );
-    } catch (updateError) {
-      showError(
-        getActionErrorMessage(
-          "Impossible de mettre à jour la priorité.",
-          updateError
-        )
-      );
-    } finally {
-      setIsPrioritySubmitting(false);
-    }
-  }, [application, isTreatmentReadOnly, showError, showSuccess]);
 
   const handleStudentAdmissionStatusUpdate = useCallback(
     async (
@@ -926,7 +866,6 @@ const ApplicationDetailPage = () => {
 
   const pageHeaderAside = application ? (
     <div className="flex flex-wrap items-center gap-2">
-      <PriorityBadge isPriority={application.isPriority} />
       <StatusBadge status={application.status} />
     </div>
   ) : isLoading ? (
@@ -1028,7 +967,6 @@ const ApplicationDetailPage = () => {
                   </h2>
                   <div className="mt-3 flex flex-wrap items-center gap-2">
                     <StatusBadge status={application.status} />
-                    <PriorityBadge isPriority={application.isPriority} />
                     {applicationLevels.length > 0 ? (
                       applicationLevels.map((level) => (
                         <LevelBadge
@@ -1098,7 +1036,7 @@ const ApplicationDetailPage = () => {
         <div className="space-y-6 xl:col-start-2 xl:row-start-1 xl:row-span-2 xl:min-h-0 xl:self-stretch xl:[contain:size]">
           <SectionCard
             title="Traitement"
-            subtitle="Statut, priorité, décision finale et email."
+            subtitle="Statut global, décisions élèves et email."
             action={treatmentAction}
             bodyClassName="!mt-4 flex flex-1 flex-col gap-3 xl:min-h-0"
             className="!p-5 sm:!p-6 xl:flex xl:h-full xl:min-h-0 xl:flex-col"
@@ -1126,44 +1064,6 @@ const ApplicationDetailPage = () => {
                 <span className="text-xs font-medium leading-5 text-slate-500">
                   Mis à jour automatiquement depuis les décisions élèves.
                 </span>
-              </div>
-            </div>
-
-            <div
-              className={`shrink-0 rounded-[22px] border border-slate-200/90 bg-slate-50/80 p-4 transition ${
-                isTreatmentReadOnly ? "opacity-55 saturate-50" : ""
-              }`}
-            >
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <div>
-                  <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                    Priorité
-                  </p>
-                  <div className="mt-1.5">
-                    {application.isPriority ? (
-                      <PriorityBadge isPriority={application.isPriority} />
-                    ) : (
-                      <span className="text-sm font-medium text-slate-600">
-                        Non prioritaire
-                      </span>
-                    )}
-                  </div>
-                </div>
-                <button
-                  type="button"
-                  onClick={handlePriorityToggle}
-                  disabled={isTreatmentReadOnly || isPrioritySubmitting}
-                  className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 transition hover:border-primary/25 hover:text-primary disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400"
-                >
-                  <StarIcon />
-                  <span>
-                    {isPrioritySubmitting
-                      ? "Mise à jour..."
-                      : application.isPriority
-                        ? "Retirer"
-                        : "Activer"}
-                  </span>
-                </button>
               </div>
             </div>
 
@@ -1240,29 +1140,37 @@ const ApplicationDetailPage = () => {
                   key={student.id}
                   className="rounded-[28px] border border-slate-200/90 bg-slate-50/80 p-5 shadow-[0_14px_30px_-26px_rgba(15,23,42,0.2)]"
                 >
-                  <div className="flex items-start gap-4">
-                    <PersonAvatar
-                      label={`${student.firstName} ${student.lastName}`}
-                      size="md"
-                      variant={getStudentAvatarVariant(student.gender)}
-                    />
-                    <div className="min-w-0 flex-1">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <h3 className="break-words text-lg font-semibold text-slate-900">
-                          {student.firstName} {student.lastName}
-                        </h3>
-                      </div>
-                      <div className="mt-2 flex flex-wrap items-center gap-2">
-                        <LevelBadge
-                          code={student.level.code}
-                          label={student.level.label}
-                          size="sm"
-                        />
-                        <StudentAdmissionBadge
-                          status={getStudentAdmissionStatus(student)}
-                        />
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="flex min-w-0 items-start gap-4">
+                      <PersonAvatar
+                        label={`${student.firstName} ${student.lastName}`}
+                        size="md"
+                        variant={getStudentAvatarVariant(student.gender)}
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <h3 className="break-words text-lg font-semibold text-slate-900">
+                            {student.firstName} {student.lastName}
+                          </h3>
+                        </div>
+                        <div className="mt-2 flex flex-wrap items-center gap-2">
+                          <LevelBadge
+                            code={student.level.code}
+                            label={student.level.label}
+                            size="sm"
+                          />
+                          <StudentAdmissionBadge
+                            status={getStudentAdmissionStatus(student)}
+                          />
+                        </div>
                       </div>
                     </div>
+                    <Link
+                      to={`/students/${student.id}`}
+                      className="inline-flex w-fit shrink-0 items-center justify-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary/25 hover:text-primary"
+                    >
+                      Voir l'élève
+                    </Link>
                   </div>
 
                   <div className="mt-5 grid gap-3 sm:grid-cols-2">

--- a/apps/web/src/pages/ApplicationsPage.tsx
+++ b/apps/web/src/pages/ApplicationsPage.tsx
@@ -36,7 +36,7 @@ type FilterState = {
 
 type SortOption = "createdAtDesc" | "createdAtAsc" | "priorityDesc";
 
-type PageSize = 4 | 6 | 8 | 10 | 12;
+type PageSize = 4 | 6 | 8 | 10 | 12 | 15 | 18 | 20;
 
 type StatusOption = {
   value: "" | ApplicationStatus;
@@ -66,7 +66,7 @@ type PaginationControlsProps = {
   onPageChange: (page: number) => void;
 };
 
-const pageSizeOptions: PageSize[] = [4, 6, 8, 10, 12];
+const pageSizeOptions: PageSize[] = [4, 6, 8, 10, 12, 15, 18, 20];
 
 const statusOptions: StatusOption[] = [
   { value: "", label: "Tous les statuts" },

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -4,10 +4,9 @@ import {
   useMemo,
   useState,
   type CSSProperties,
-  type JSX,
-  type KeyboardEvent
+  type JSX
 } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 
 import PageSectionHeader from "../components/layout/PageSectionHeader";
 import Breadcrumb from "../components/ui/Breadcrumb";
@@ -16,14 +15,14 @@ import ErrorState from "../components/ui/ErrorState";
 import LevelBadge from "../components/ui/LevelBadge";
 import LoadingState from "../components/ui/LoadingState";
 import PriorityBadge from "../components/ui/PriorityBadge";
-import StatusBadge from "../components/ui/StatusBadge";
+import StudentStatusBadge from "../components/ui/StudentStatusBadge";
 import { fetchDashboardStats, getActiveSchoolYear } from "../lib/api";
 import { getLevelVisualStyle } from "../lib/levelVisuals";
 import type { SchoolYearSummary } from "../types/application";
+import type { VisibleStudentAdmissionStatus } from "../types/application";
 import type {
-  DashboardApplicationStatus,
   DashboardLevelStat,
-  DashboardPriorityApplication,
+  DashboardStudentStats,
   DashboardStats
 } from "../types/dashboard";
 
@@ -34,7 +33,7 @@ type IconProps = {
 type DashboardMetricIcon = (props: IconProps) => JSX.Element;
 
 type StatusCardConfig = {
-  status: DashboardApplicationStatus;
+  status: VisibleStudentAdmissionStatus;
   label: string;
   description: string;
   getValue?: (data: DashboardStats) => number;
@@ -51,7 +50,7 @@ type MetricCardProps = {
   label: string;
   motionDelay?: number;
   surfaceClassName: string;
-  status: DashboardApplicationStatus;
+  status: VisibleStudentAdmissionStatus;
   value: number;
   valueClassName?: string;
 };
@@ -127,21 +126,6 @@ const getDonutSegmentPath = (
   ].join(" ");
 };
 
-const ReviewMetricIcon = ({ className = "h-5 w-5" }: IconProps) => {
-  return (
-    <svg
-      viewBox="0 0 20 20"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.7"
-      className={className}
-    >
-      <circle cx="10" cy="10" r="6.2" />
-      <path d="M10 6.8V10l2.5 1.7" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  );
-};
-
 const AcceptedMetricIcon = ({ className = "h-5 w-5" }: IconProps) => {
   return (
     <svg
@@ -172,6 +156,24 @@ const WaitlistedMetricIcon = ({ className = "h-5 w-5" }: IconProps) => {
   );
 };
 
+const ProcessedMetricIcon = ({ className = "h-5 w-5" }: IconProps) => {
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      className={className}
+    >
+      <path d="M5 5.8h6.2" strokeLinecap="round" />
+      <path d="M5 10h4.6" strokeLinecap="round" />
+      <path d="M5 14.2h3.8" strokeLinecap="round" />
+      <path d="m12.2 12.7 1.6 1.6 3.1-3.4" strokeLinecap="round" strokeLinejoin="round" />
+      <rect x="3.4" y="3.4" width="13.2" height="13.2" rx="3" />
+    </svg>
+  );
+};
+
 const ChevronRightIcon = ({ className = "h-4 w-4" }: IconProps) => {
   return (
     <svg
@@ -189,58 +191,27 @@ const ChevronRightIcon = ({ className = "h-4 w-4" }: IconProps) => {
   );
 };
 
-const PartialMetricIcon = ({ className = "h-5 w-5" }: IconProps) => {
-  return (
-    <svg
-      viewBox="0 0 20 20"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.8"
-      className={className}
-    >
-      <path d="M4.5 10h11" strokeLinecap="round" />
-      <path d="m5.3 6.8 2.8 3.2-2.8 3.2" strokeLinecap="round" strokeLinejoin="round" />
-      <path d="m14.7 6.8-2.8 3.2 2.8 3.2" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  );
-};
-
 const statusCards: StatusCardConfig[] = [
   {
-    status: "IN_REVIEW",
-    label: "En revue",
-    description: "Demandes en cours d'analyse.",
-    valueClassName: "text-info",
-    surfaceClassName: "bg-info/10",
-    iconClassName: "bg-info text-white",
-    Icon: ReviewMetricIcon
-  },
-  {
     status: "ACCEPTED",
-    label: "Acceptées",
-    description: "Demandes entièrement acceptées.",
+    label: "Acceptés",
+    description: "Élèves acceptés pour l'année active.",
+    getValue: (dashboardData) =>
+      dashboardData.studentStats?.acceptedStudents ?? dashboardData.byStatus.ACCEPTED,
     valueClassName: "text-success",
     surfaceClassName: "bg-success/10",
     iconClassName: "bg-success text-white",
     Icon: AcceptedMetricIcon
   },
   {
-    status: "PARTIALLY_ACCEPTED",
-    label: "Partielles",
-    description: "Demandes avec acceptation partielle.",
-    valueClassName: "text-secondaryDark",
-    surfaceClassName: "bg-secondary/10",
-    iconClassName: "bg-secondary text-white",
-    Icon: PartialMetricIcon
-  },
-  {
     status: "WAITLISTED",
-    label: "Liste d'attente",
-    description: "Liste des élèves placés en attente.",
-    getValue: (dashboardData) => dashboardData.waitlistedStudents,
-    valueClassName: "text-primary",
-    surfaceClassName: "bg-primary/10",
-    iconClassName: "bg-primary text-white",
+    label: "En attente",
+    description: "Élèves explicitement mis en attente par l'administration.",
+    getValue: (dashboardData) =>
+      dashboardData.studentStats?.waitlistedStudents ?? dashboardData.waitlistedStudents,
+    valueClassName: "text-info",
+    surfaceClassName: "bg-info/10",
+    iconClassName: "bg-info text-white",
     Icon: WaitlistedMetricIcon
   }
 ];
@@ -249,57 +220,19 @@ const isAbortError = (error: unknown): boolean => {
   return error instanceof DOMException && error.name === "AbortError";
 };
 
-const getFamilyDisplayName = (
-  application: DashboardPriorityApplication
+const getPriorityStudentFamilyDisplayName = (
+  family: DashboardStudentStats["priorityStudents"][number]["application"]["family"]
 ): string => {
   const familyNames = [
-    application.family.fatherLastName,
-    application.family.motherLastName
+    family.fatherLastName,
+    family.motherLastName
   ].filter((value): value is string => typeof value === "string" && value.trim().length > 0);
 
   if (familyNames.length > 0) {
     return Array.from(new Set(familyNames)).join(" / ");
   }
 
-  const studentLastNames = application.students
-    .map((student) => student.lastName.trim())
-    .filter((value) => value.length > 0);
-
-  if (studentLastNames.length > 0) {
-    return Array.from(new Set(studentLastNames)).join(" / ");
-  }
-
-  return "Famille non renseignée";
-};
-
-const getPriorityChildrenLabel = (
-  application: DashboardPriorityApplication
-): string => {
-  if (application.students.length === 0) {
-    return "Aucun élève rattaché à cette demande.";
-  }
-
-  return application.students
-    .map((student) => `${student.firstName} ${student.lastName}`)
-    .join(" · ");
-};
-
-const getPriorityLevels = (
-  application: DashboardPriorityApplication
-): Array<{ code: string; label: string }> => {
-  const uniqueLevels = new Map<string, { code: string; label: string }>();
-
-  application.students.forEach((student) => {
-    const code = student.level.code.trim();
-    const label = student.level.label.trim();
-    const key = `${code}::${label}`;
-
-    if ((code.length > 0 || label.length > 0) && !uniqueLevels.has(key)) {
-      uniqueLevels.set(key, { code, label });
-    }
-  });
-
-  return Array.from(uniqueLevels.values());
+  return family.contactEmail ?? "Famille non renseignée";
 };
 
 const StatusOverviewIcon = ({ className = "h-5 w-5" }: IconProps) => {
@@ -335,8 +268,8 @@ const MetricCard = ({
 }: MetricCardProps) => {
   return (
     <Link
-      to={`/applications?status=${encodeURIComponent(status)}`}
-      aria-label={`Voir les demandes avec le statut ${label}`}
+      to={`/students?status=${encodeURIComponent(status)}`}
+      aria-label={`Voir les élèves avec le statut ${label}`}
       className={`ui-animate-in ui-surface-hover block rounded-[28px] border border-primary/10 p-5 shadow-[0_18px_40px_-30px_rgba(31,77,58,0.34)] outline-none transition hover:border-secondary/35 focus-visible:ring-4 focus-visible:ring-secondary/20 ${surfaceClassName}`}
       style={getEnterStyle(motionDelay)}
     >
@@ -376,7 +309,7 @@ const ProcessingMetricCard = ({
     <article
       className="ui-animate-in ui-surface-hover block rounded-[28px] border border-primary/10 bg-white/90 p-5 shadow-[0_18px_40px_-30px_rgba(31,77,58,0.34)] outline-none transition"
       style={getEnterStyle(motionDelay)}
-      aria-label={`${processedApplications} demandes traitees sur ${totalApplications}. ${remainingApplications} restantes.`}
+      aria-label={`${processedApplications} élèves traités sur ${totalApplications}. ${remainingApplications} à traiter.`}
     >
       <div className="flex items-start justify-between gap-4">
         <div>
@@ -384,12 +317,12 @@ const ProcessingMetricCard = ({
             Traitement
           </p>
           <p className="mt-2 text-sm font-semibold text-slate-800">
-            {remainingApplications} restante
+            {remainingApplications} à traiter
             {remainingApplications !== 1 ? "s" : ""}
           </p>
         </div>
-        <span className="ui-surface-hover__icon inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-success text-white">
-          <AcceptedMetricIcon className="h-5 w-5" />
+        <span className="ui-surface-hover__icon inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-secondary text-white">
+          <ProcessedMetricIcon className="h-5 w-5" />
         </span>
       </div>
 
@@ -397,11 +330,11 @@ const ProcessingMetricCard = ({
         {processedApplications} / {totalApplications}
       </p>
       <p className="mt-2 text-sm font-semibold text-slate-800">
-        traitée{processedApplications !== 1 ? "s" : ""}
+        traité{processedApplications !== 1 ? "s" : ""}
       </p>
-      <div className="mt-4 overflow-hidden rounded-full bg-primary/10 p-1">
+      <div className="mt-4 overflow-hidden rounded-full bg-secondary/15 p-1">
         <div
-          className="h-3 rounded-full bg-success shadow-[0_10px_18px_-14px_rgba(34,197,94,0.7)] transition-[width] duration-500"
+          className="h-3 rounded-full bg-secondary shadow-[0_10px_18px_-14px_rgba(212,162,76,0.75)] transition-[width] duration-500"
           style={{ width: `${processedShare}%` }}
         />
       </div>
@@ -410,7 +343,6 @@ const ProcessingMetricCard = ({
 };
 
 const DashboardPage = () => {
-  const navigate = useNavigate();
   const [data, setData] = useState<DashboardStats | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -485,33 +417,41 @@ const DashboardPage = () => {
   }, [loadDashboard]);
 
   useEffect(() => {
+    const priorityStudentsCount = data?.studentStats?.priorityStudents.length ?? 0;
     const totalPages = Math.max(
       1,
-      Math.ceil((data?.priorityApplications.length ?? 0) / PRIORITY_DISPLAY_LIMIT)
+      Math.ceil(priorityStudentsCount / PRIORITY_DISPLAY_LIMIT)
     );
 
     setCurrentPriorityPage((currentPage) => Math.min(currentPage, totalPages));
-  }, [data?.priorityApplications.length]);
+  }, [data?.studentStats?.priorityStudents.length]);
 
   const dashboardView = useMemo(() => {
     if (!data) {
       return null;
     }
 
+    const priorityStudents = data.studentStats?.priorityStudents ?? [];
+    const priorityStudentsCount = priorityStudents.length;
     const totalPriorityPages = Math.max(
       1,
-      Math.ceil(data.priorityApplications.length / PRIORITY_DISPLAY_LIMIT)
+      Math.ceil(priorityStudentsCount / PRIORITY_DISPLAY_LIMIT)
     );
     const priorityStartIndex = (currentPriorityPage - 1) * PRIORITY_DISPLAY_LIMIT;
-    const visiblePriorityApplications = data.priorityApplications.slice(
+    const visiblePriorityStudents = priorityStudents.slice(
       priorityStartIndex,
       priorityStartIndex + PRIORITY_DISPLAY_LIMIT
     );
 
-    const maxLevelCount = Math.max(...data.byLevel.map((level) => level.count), 0);
-    const totalStudents = data.byLevel.reduce((sum, level) => sum + level.count, 0);
+    const studentStats = data.studentStats;
+    const levelStats = studentStats?.byLevel ?? data.byLevel;
+    const totalStudents =
+      studentStats?.totalStudents ?? levelStats.reduce((sum, level) => sum + level.count, 0);
+    const acceptedStudents = studentStats?.acceptedStudents ?? data.byStatus.ACCEPTED;
+    const waitlistedStudents = studentStats?.waitlistedStudents ?? data.waitlistedStudents;
+    const maxLevelCount = Math.max(...levelStats.map((level) => level.count), 0);
     let chartCursor = 0;
-    const levelBreakdown: LevelBreakdownItem[] = data.byLevel.map((level, index) => {
+    const levelBreakdown: LevelBreakdownItem[] = levelStats.map((level, index) => {
       const share =
         totalStudents === 0 ? 0 : Math.round((level.count / totalStudents) * 100);
       const rawShare = totalStudents === 0 ? 0 : (level.count / totalStudents) * 100;
@@ -561,34 +501,34 @@ const DashboardPage = () => {
       },
       null
     );
-    const processedApplications =
-      data.byStatus.ACCEPTED +
-      data.byStatus.PARTIALLY_ACCEPTED +
-      data.byStatus.WAITLISTED;
+    const processedApplications = acceptedStudents + waitlistedStudents;
     const remainingApplications = Math.max(
-      data.totalApplications - processedApplications,
+      totalStudents - processedApplications,
       0
     );
     const processedShare =
-      data.totalApplications === 0
+      totalStudents === 0
         ? 0
-        : Math.round((processedApplications / data.totalApplications) * 100);
+        : Math.round((processedApplications / totalStudents) * 100);
 
     return {
       levelBreakdown,
       levelChartGradient,
       processedApplications,
       processedShare,
+      priorityStudentsCount,
       remainingApplications,
       topLevel,
       totalStudents,
+      acceptedStudents,
+      waitlistedStudents,
       totalPriorityPages,
-      visiblePriorityApplications,
+      visiblePriorityStudents,
       visiblePriorityStart:
-        data.priorityApplications.length === 0 ? 0 : priorityStartIndex + 1,
+        priorityStudentsCount === 0 ? 0 : priorityStartIndex + 1,
       visiblePriorityEnd: Math.min(
         currentPriorityPage * PRIORITY_DISPLAY_LIMIT,
-        data.priorityApplications.length
+        priorityStudentsCount
       )
     };
   }, [currentPriorityPage, data]);
@@ -602,25 +542,6 @@ const DashboardPage = () => {
       Math.min(dashboardView?.totalPriorityPages ?? 1, page + 1)
     );
   }, [dashboardView?.totalPriorityPages]);
-
-  const openApplicationDetail = useCallback(
-    (applicationId: string): void => {
-      navigate(`/applications/${applicationId}`);
-    },
-    [navigate]
-  );
-
-  const handlePriorityCardKeyDown = useCallback(
-    (event: KeyboardEvent<HTMLElement>, applicationId: string): void => {
-      if (event.key !== "Enter" && event.key !== " ") {
-        return;
-      }
-
-      event.preventDefault();
-      openApplicationDetail(applicationId);
-    },
-    [openApplicationDetail]
-  );
 
   const pageTopBar = (
     <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
@@ -688,13 +609,13 @@ const DashboardPage = () => {
     );
   }
 
-  if (!data || data.totalApplications === 0) {
+  if (!data || (data.studentStats?.totalStudents ?? data.totalApplications) === 0) {
     return (
       <>
         {pageHeader}
         <EmptyState
           title="Aucune donnée disponible"
-          description="Le dashboard s'alimentera automatiquement dès qu'une demande et des élèves seront présents en base."
+          description="Le dashboard s'alimentera automatiquement dès que des élèves seront présents en base."
         />
       </>
     );
@@ -720,14 +641,14 @@ const DashboardPage = () => {
               </span>
               <div className="min-w-0">
                 <p className="text-sm font-semibold uppercase tracking-[0.2em] text-secondary">
-                  Suivi des demandes
+                  Suivi des élèves
                 </p>
                 <h2 className="mt-2 text-3xl font-semibold tracking-tight text-white">
-                  Demandes par statut
+                  Élèves par statut
                 </h2>
                 <p className="mt-3 max-w-4xl text-[1.02rem] leading-8 text-white/80">
-                  Visualisez la répartition des dossiers selon leur état de
-                  traitement pour prioriser les prochaines actions.
+                  Visualisez la répartition des élèves selon leur statut de
+                  traitement pour prioriser les prochaines décisions.
                 </p>
               </div>
             </div>
@@ -741,10 +662,10 @@ const DashboardPage = () => {
                   Total
                 </p>
                 <p className="mt-2 text-4xl font-semibold tracking-tight">
-                  {data.totalApplications}
+                  {dashboardView.totalStudents}
                 </p>
                 <p className="mt-1 text-sm font-medium text-white/80">
-                  demandes suivies
+                  élèves suivis
                 </p>
               </div>
             </div>
@@ -758,10 +679,10 @@ const DashboardPage = () => {
                 Vue active
               </span>
               <span className="inline-flex items-center rounded-full border border-primary/15 bg-white px-3 py-1.5 text-xs font-semibold text-primaryDark">
-                {data.totalApplications} demandes
+                {dashboardView.totalStudents} élèves
               </span>
               <span className="inline-flex items-center rounded-full border border-secondary/30 bg-white px-3 py-1.5 text-xs font-semibold text-primaryDark">
-                {data.priorityApplications.length} prioritaires
+                {dashboardView.priorityStudentsCount} prioritaires
               </span>
               <span className="inline-flex items-center rounded-full border border-secondary/30 bg-white px-3 py-1.5 text-xs font-semibold text-primaryDark">
                 {data.byLevel.length} niveaux
@@ -769,13 +690,13 @@ const DashboardPage = () => {
             </div>
           </div>
 
-          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+          <div className="grid gap-4 md:grid-cols-3">
             <ProcessingMetricCard
               motionDelay={360}
               processedApplications={dashboardView.processedApplications}
               processedShare={dashboardView.processedShare}
               remainingApplications={dashboardView.remainingApplications}
-              totalApplications={data.totalApplications}
+              totalApplications={dashboardView.totalStudents}
             />
             {statusCards.map((card, index) => (
               <MetricCard
@@ -926,7 +847,7 @@ const DashboardPage = () => {
                             </p>
                           </div>
                           <p className="mt-1 text-xs font-medium text-slate-500">
-                            {level.count} demande{level.count > 1 ? "s" : ""}
+                            {level.count} élève{level.count > 1 ? "s" : ""}
                           </p>
                         </div>
                       );
@@ -984,10 +905,10 @@ const DashboardPage = () => {
                   {dashboardView.levelBreakdown.map((level) => (
                     <Link
                       key={`${level.code}-summary`}
-                      to={`/students?level=${encodeURIComponent(level.code)}`}
+                      to={`/students?levelId=${encodeURIComponent(level.id ?? "")}`}
                       title="Voir les élèves ayant demandé ce niveau"
                       aria-label={`Voir les élèves ayant demandé ce niveau: ${level.label}`}
-                      className="group grid gap-3 rounded-[22px] border border-slate-200/80 bg-slate-50/70 px-4 py-3 text-left transition hover:border-primary/20 hover:bg-white hover:shadow-[0_16px_30px_-28px_rgba(15,23,42,0.35)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/25 sm:grid-cols-[150px_minmax(0,1fr)_112px] sm:items-center"
+                      className="group grid gap-3 rounded-[22px] border border-slate-200/80 bg-slate-50/70 px-4 py-3 text-left transition hover:border-primary/20 hover:bg-white hover:shadow-[0_16px_30px_-28px_rgba(15,23,42,0.35)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/25 sm:grid-cols-[150px_minmax(0,1fr)_150px] sm:items-center"
                     >
                       <div className="flex min-w-0 items-center gap-3">
                         <span
@@ -1019,13 +940,15 @@ const DashboardPage = () => {
 
                       <div className="flex items-center justify-between gap-3 sm:justify-end">
                         <div className="flex items-baseline gap-3">
-                          <p className="text-lg font-semibold text-slate-900">
-                            {level.count}
-                          </p>
+                          <p className="text-lg font-semibold text-slate-900">{level.count}</p>
                           <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
                             {level.share}%
                           </p>
                         </div>
+                        <p className="text-xs font-medium text-slate-500">
+                          {level.availablePlaces ?? 0} place
+                          {(level.availablePlaces ?? 0) > 1 ? "s" : ""}
+                        </p>
                         <span
                           aria-hidden="true"
                           className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-400 transition group-hover:border-primary/20 group-hover:text-primary"
@@ -1049,148 +972,123 @@ const DashboardPage = () => {
           <div className="flex flex-wrap items-center justify-between gap-4">
             <div>
               <p className="text-sm font-semibold uppercase tracking-[0.2em] text-primaryLight">
-                Demandes prioritaires
+                Élèves prioritaires
               </p>
               <h2 className="mt-2 text-2xl font-semibold text-slate-900">
-                Dossiers à traiter en priorité
+                Élèves à traiter en priorité
               </h2>
               <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
-                Conservez les dossiers sensibles en haut de pile avec une lecture
-                rapide de la famille, des enfants concernés, du niveau demandé et
-                du statut actuel.
+                Conservez les situations sensibles en haut de pile avec une lecture
+                rapide de la famille, des élèves concernés, du niveau demandé et
+                du statut élève.
               </p>
             </div>
             <div className="rounded-full bg-primary/10 px-4 py-2 text-sm font-medium text-primaryDark">
-              {data.priorityApplications.length} priorité
-              {data.priorityApplications.length > 1 ? "s" : ""}
+              {dashboardView.priorityStudentsCount} priorité
+              {dashboardView.priorityStudentsCount > 1 ? "s" : ""}
             </div>
           </div>
 
           <div className="mt-6 space-y-4">
-            {data.priorityApplications.length === 0 ? (
+            {dashboardView.priorityStudentsCount === 0 ? (
               <p className="rounded-2xl border border-dashed border-border bg-background/70 px-4 py-6 text-sm text-slate-500">
-                Aucune demande prioritaire pour le moment.
+                Aucun élève prioritaire pour le moment.
               </p>
             ) : (
-              dashboardView.visiblePriorityApplications.map((application, index) => {
-                const priorityLevels = getPriorityLevels(application);
+              dashboardView.visiblePriorityStudents.map((student, index) => {
+                const familyName = getPriorityStudentFamilyDisplayName(
+                  student.application.family
+                );
 
                 return (
                   <article
-                    key={application.id}
-                    role="link"
-                    tabIndex={0}
-                    aria-label={`Ouvrir la demande de la famille ${getFamilyDisplayName(application)}`}
-                    onClick={() => openApplicationDetail(application.id)}
-                    onKeyDown={(event) => handlePriorityCardKeyDown(event, application.id)}
-                    className="ui-animate-in ui-surface-hover ui-surface-hover--soft cursor-pointer rounded-[28px] border border-slate-200/90 bg-slate-50/80 p-5 shadow-[0_14px_28px_-24px_rgba(15,23,42,0.18)] outline-none transition focus-visible:ring-4 focus-visible:ring-primary/20"
+                    key={student.id ?? `${student.firstName}-${student.lastName}-${index}`}
+                    className="ui-animate-in ui-surface-hover ui-surface-hover--soft rounded-[28px] border border-slate-200/90 bg-slate-50/80 p-5 shadow-[0_14px_28px_-24px_rgba(15,23,42,0.18)] outline-none transition focus-within:ring-4 focus-within:ring-primary/20"
                     style={getEnterStyle(760 + index * 80)}
                   >
                     <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                       <div className="min-w-0">
                         <div className="flex flex-wrap items-center gap-2.5">
                           <h3 className="text-lg font-semibold text-slate-900">
-                            Famille {getFamilyDisplayName(application)}
+                            {student.firstName} {student.lastName}
                           </h3>
-                          <PriorityBadge isPriority={application.isPriority} />
+                          <PriorityBadge isPriority={Boolean(student.isPriority)} />
                         </div>
                         <p className="mt-2 text-sm text-slate-500">
-                          {application.schoolYear.label}
-                          {application.schoolYear.isActive ? " · année active" : ""}
+                          {student.application.schoolYear.label}
+                          {student.application.schoolYear.isActive ? " · année active" : ""}
                         </p>
                       </div>
-                      <div className="flex flex-wrap items-center gap-2">
-                        <StatusBadge status={application.status} />
-                        <Link
-                          to={`/applications/${application.id}`}
-                          onClick={(event) => event.stopPropagation()}
-                          className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary/30 hover:text-primary"
-                        >
-                          Voir la demande
-                        </Link>
-                      </div>
+                      <Link
+                        to={student.id ? `/students/${student.id}` : "/students?isPriority=true"}
+                        className="inline-flex w-fit items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary/30 hover:text-primary"
+                      >
+                        Fiche élève
+                      </Link>
                     </div>
 
                     <div className="mt-5 grid gap-3 md:grid-cols-2">
                       <div className="rounded-2xl border border-white bg-white/80 px-4 py-3">
                         <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                          Enfants
+                          Élève
                         </p>
-                        <p className="mt-2 text-sm leading-6 text-slate-700">
-                          {getPriorityChildrenLabel(application)}
-                        </p>
+                        <div className="mt-2 flex flex-wrap items-center gap-2">
+                          <span className="text-sm font-semibold leading-6 text-slate-800">
+                            {student.firstName} {student.lastName}
+                          </span>
+                          <StudentStatusBadge status={student.admissionStatus ?? "PENDING"} />
+                        </div>
                       </div>
                       <div className="rounded-2xl border border-white bg-white/80 px-4 py-3">
                         <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
                           Niveau
                         </p>
-                        <div className="mt-2 flex flex-wrap gap-2">
-                          {priorityLevels.length === 0 ? (
-                            <span className="text-sm leading-6 text-slate-500">
-                              Niveau non renseigné
-                            </span>
-                          ) : (
-                            priorityLevels.map((level) => (
-                              <LevelBadge
-                                key={`${application.id}-${level.code}-${level.label}`}
-                                code={level.code}
-                                label={level.label}
-                                size="sm"
-                              />
-                            ))
-                          )}
+                        <div className="mt-2">
+                          <LevelBadge
+                            code={student.level.code}
+                            label={student.level.label}
+                            size="sm"
+                          />
                         </div>
+                      </div>
+                      <div className="rounded-2xl border border-white bg-white/80 px-4 py-3">
+                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                          Famille
+                        </p>
+                        <p className="mt-2 text-sm leading-6 text-slate-700">
+                          Famille {familyName}
+                        </p>
                       </div>
                       <div className="rounded-2xl border border-white bg-white/80 px-4 py-3">
                         <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
                           Contact
                         </p>
                         <p className="mt-2 text-sm leading-6 text-slate-700">
-                          {application.family.contactEmail ? (
+                          {student.application.family.contactEmail ? (
                             <a
-                              href={`mailto:${application.family.contactEmail}`}
-                              onClick={(event) => event.stopPropagation()}
+                              href={`mailto:${student.application.family.contactEmail}`}
                               className="break-all text-primary hover:text-primaryDark"
                             >
-                              {application.family.contactEmail}
+                              {student.application.family.contactEmail}
                             </a>
                           ) : (
                             "Non renseigné"
                           )}
                         </p>
                       </div>
-                      <div className="rounded-2xl border border-white bg-white/80 px-4 py-3">
-                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                          Date
-                        </p>
-                        <p className="mt-2 text-sm leading-6 text-slate-700">
-                          {priorityDateFormatter.format(new Date(application.createdAt))}
-                        </p>
-                      </div>
                     </div>
 
-                    <div className="mt-4 flex flex-wrap gap-2">
-                      {application.students.length === 0 ? (
-                        <span className="rounded-full bg-white px-3 py-1.5 text-xs font-medium text-slate-500 ring-1 ring-slate-200">
-                          Aucun élève rattaché
-                        </span>
-                      ) : (
-                        application.students.map((student) => (
-                          <span
-                            key={`${application.id}-${student.firstName}-${student.lastName}-${student.level.code}`}
-                            className="ui-surface-hover__chip inline-flex items-center gap-2 rounded-full bg-white px-2.5 py-1.5 text-xs font-medium text-slate-700 ring-1 ring-slate-200"
-                          >
-                            <span>
-                              {student.firstName} {student.lastName}
-                            </span>
-                            <LevelBadge
-                              code={student.level.code}
-                              label={student.level.label}
-                              size="xs"
-                            />
-                          </span>
-                        ))
-                      )}
+                    <div className="mt-4 flex flex-wrap items-center gap-2">
+                      <span className="rounded-full bg-white px-3 py-1.5 text-xs font-medium text-slate-500 ring-1 ring-slate-200">
+                        Signalé le{" "}
+                        {priorityDateFormatter.format(new Date(student.application.createdAt))}
+                      </span>
+                      <Link
+                        to={`/applications/${student.application.id}`}
+                        className="rounded-full bg-white px-3 py-1.5 text-xs font-medium text-primary ring-1 ring-slate-200 transition hover:text-primaryDark"
+                      >
+                        Voir la famille
+                      </Link>
                     </div>
                   </article>
                 );
@@ -1198,7 +1096,7 @@ const DashboardPage = () => {
             )}
           </div>
 
-          {data.priorityApplications.length > 0 ? (
+          {dashboardView.priorityStudentsCount > 0 ? (
             <div className="mt-6 flex justify-center border-t border-slate-200 pt-5">
               <div className="flex flex-wrap items-center justify-center gap-2">
                 <button
@@ -1224,13 +1122,13 @@ const DashboardPage = () => {
             </div>
           ) : null}
 
-          {data.priorityApplications.length > 0 ? (
+          {dashboardView.priorityStudentsCount > 0 ? (
             <div className="mt-4 flex justify-center">
               <Link
-                to="/applications?isPriority=true"
+                to="/students?isPriority=true"
                 className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-5 py-2.5 text-sm font-semibold text-primary transition hover:border-primary/25 hover:text-primaryDark"
               >
-                <span>Ouvrir toutes les demandes prioritaires</span>
+                <span>Ouvrir tous les élèves prioritaires</span>
                 <ChevronRightIcon />
               </Link>
             </div>

--- a/apps/web/src/pages/StudentsPage.tsx
+++ b/apps/web/src/pages/StudentsPage.tsx
@@ -1,6 +1,6 @@
 import {
-  memo,
   useCallback,
+  useDeferredValue,
   useEffect,
   useMemo,
   useState,
@@ -18,27 +18,23 @@ import PersonAvatar, {
   type PersonAvatarVariant
 } from "../components/ui/PersonAvatar";
 import PriorityBadge from "../components/ui/PriorityBadge";
-import StatusBadge from "../components/ui/StatusBadge";
-import { getActiveSchoolYear, getApplications, getLevels } from "../lib/api";
+import StudentStatusBadge from "../components/ui/StudentStatusBadge";
+import {
+  getActiveSchoolYear,
+  getLevels,
+  getSchoolYears,
+  getStudents
+} from "../lib/api";
 import type {
   ApplicationGender,
-  ApplicationListItem,
-  ApplicationStudent,
   LevelSummary,
-  SchoolYearSummary
+  SchoolYearSummary,
+  StudentFilterParams,
+  StudentListItem,
+  VisibleStudentAdmissionStatus
 } from "../types/application";
 
-type StudentListItem = {
-  application: ApplicationListItem;
-  student: ApplicationStudent;
-};
-
-type PageSize = 4 | 6 | 8 | 10 | 12;
-
-type IconProps = {
-  className?: string;
-};
-
+type PageSize = 4 | 6 | 8 | 10 | 12 | 15 | 18 | 20;
 type PaginationItem = number | "ellipsis-left" | "ellipsis-right";
 
 type PaginationControlsProps = {
@@ -47,34 +43,48 @@ type PaginationControlsProps = {
   onPageChange: (page: number) => void;
 };
 
-const pageSizeOptions: PageSize[] = [4, 6, 8, 10, 12];
+const pageSizeOptions: PageSize[] = [4, 6, 8, 10, 12, 15, 18, 20];
+const sortableFields: Array<NonNullable<StudentFilterParams["sortBy"]>> = [
+  "lastName",
+  "firstName",
+  "level",
+  "birthDate",
+  "submittedAt",
+  "status"
+];
+
+const formatDate = new Intl.DateTimeFormat("fr-FR", {
+  day: "2-digit",
+  month: "short",
+  year: "numeric"
+});
 
 const getEnterStyle = (delay: number): CSSProperties => {
-  return {
-    "--ui-enter-delay": `${delay}ms`
-  } as CSSProperties;
+  return { "--ui-enter-delay": `${delay}ms` } as CSSProperties;
 };
 
 const formatSchoolYearLabel = (label: string): string => {
   return label.replace(/^(\d{4})-(\d{4})$/u, "$1 - $2");
 };
 
-const normalizeLevelCode = (value: string): string => {
-  return value.trim().toUpperCase();
+const isAbortError = (error: unknown): boolean => {
+  return error instanceof DOMException && error.name === "AbortError";
 };
 
-const getStudentAvatarVariant = (
-  gender: ApplicationGender
-): PersonAvatarVariant => {
-  if (gender === "BOY") {
-    return "boy";
+const getFamilyDisplayName = (student: StudentListItem): string => {
+  const family = student.application.family;
+  const familyNames = [family.fatherLastName, family.motherLastName]
+    .filter((value): value is string => Boolean(value?.trim()));
+
+  if (familyNames.length > 0) {
+    return Array.from(new Set(familyNames)).join(" / ");
   }
 
-  if (gender === "GIRL") {
-    return "girl";
-  }
+  return student.lastName || family.contactEmail || "Famille non renseignée";
+};
 
-  return "neutral";
+const getStudentCountLabel = (count: number): string => {
+  return `${count} élève${count > 1 ? "s" : ""}`;
 };
 
 const getPaginationItems = (
@@ -101,8 +111,8 @@ const getPaginationItems = (
     items.push("ellipsis-left");
   }
 
-  for (let page = startPage; page <= endPage; page += 1) {
-    items.push(page);
+  for (let pageNumber = startPage; pageNumber <= endPage; pageNumber += 1) {
+    items.push(pageNumber);
   }
 
   if (endPage < totalPages - 1) {
@@ -114,77 +124,21 @@ const getPaginationItems = (
   return items;
 };
 
-const getFamilyDisplayName = (application: ApplicationListItem): string => {
-  const familyNames = [
-    application.family.fatherLastName,
-    application.family.motherLastName
-  ].filter((value): value is string => typeof value === "string" && value.trim().length > 0);
-
-  if (familyNames.length > 0) {
-    return Array.from(new Set(familyNames)).join(" / ");
+const getStudentAvatarVariant = (
+  gender: ApplicationGender
+): PersonAvatarVariant => {
+  if (gender === "BOY") {
+    return "boy";
   }
 
-  const studentLastNames = application.students
-    .map((student) => student.lastName.trim())
-    .filter((value) => value.length > 0);
-
-  if (studentLastNames.length > 0) {
-    return Array.from(new Set(studentLastNames)).join(" / ");
+  if (gender === "GIRL") {
+    return "girl";
   }
 
-  return application.family.contactEmail ?? "Famille non renseignée";
+  return "neutral";
 };
 
-const getStudentSearchValue = ({ application, student }: StudentListItem): string => {
-  return [
-    student.firstName,
-    student.lastName,
-    student.level.code,
-    student.level.label,
-    getFamilyDisplayName(application),
-    application.family.contactEmail
-  ]
-    .filter((value): value is string => typeof value === "string")
-    .join(" ")
-    .toLowerCase();
-};
-
-const SearchIcon = ({ className = "h-4 w-4" }: IconProps) => {
-  return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.6"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <circle cx="7" cy="7" r="4.6" />
-      <path d="m10.3 10.3 3.2 3.2" />
-    </svg>
-  );
-};
-
-const ChevronRightIcon = ({ className = "h-4 w-4" }: IconProps) => {
-  return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.8"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-    >
-      <path d="m6.25 3.25 4.5 4.75-4.5 4.75" />
-    </svg>
-  );
-};
-
-const ChevronLeftIcon = ({ className = "h-4 w-4" }: IconProps) => {
+const ChevronLeftIcon = ({ className = "h-4 w-4" }: { className?: string }) => {
   return (
     <svg
       aria-hidden="true"
@@ -201,35 +155,28 @@ const ChevronLeftIcon = ({ className = "h-4 w-4" }: IconProps) => {
   );
 };
 
-const StudentPanelIcon = ({ className = "h-5 w-5" }: IconProps) => {
+const ChevronRightIcon = ({ className = "h-4 w-4" }: { className?: string }) => {
   return (
     <svg
       aria-hidden="true"
-      viewBox="0 0 20 20"
+      viewBox="0 0 16 16"
       fill="none"
       stroke="currentColor"
-      strokeWidth="1.7"
+      strokeWidth="1.8"
       strokeLinecap="round"
       strokeLinejoin="round"
       className={className}
     >
-      <path d="M7.7 9.2a2.7 2.7 0 1 0 0-5.4 2.7 2.7 0 0 0 0 5.4Z" />
-      <path d="M13.7 8.5a2.1 2.1 0 1 0 0-4.2" />
-      <path d="M3.5 16.4a4.3 4.3 0 0 1 8.4 0" />
-      <path d="M12.7 15.6a3.4 3.4 0 0 1 3.8.8" />
+      <path d="m6.25 3.25 4.5 4.75-4.5 4.75" />
     </svg>
   );
 };
 
-const isAbortError = (error: unknown): boolean => {
-  return error instanceof DOMException && error.name === "AbortError";
-};
-
-const PaginationControls = memo(function PaginationControls({
+const PaginationControls = ({
   currentPage,
   totalPages,
   onPageChange
-}: PaginationControlsProps) {
+}: PaginationControlsProps) => {
   if (totalPages <= 1) {
     return null;
   }
@@ -239,7 +186,7 @@ const PaginationControls = memo(function PaginationControls({
     "inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary/25 hover:text-primary disabled:cursor-not-allowed disabled:opacity-50";
 
   return (
-    <div className="mt-6 flex justify-center border-t border-slate-200/80 pt-5">
+    <div className="mt-6 flex justify-center border-t border-slate-200/80 pb-6 pt-5">
       <div className="flex flex-wrap items-center justify-center gap-2">
         <button
           type="button"
@@ -272,7 +219,7 @@ const PaginationControls = memo(function PaginationControls({
                 key={item}
                 className="inline-flex h-10 min-w-[2.5rem] items-center justify-center text-sm font-semibold text-slate-400"
               >
-                ...
+                …
               </span>
             )
           )}
@@ -294,167 +241,199 @@ const PaginationControls = memo(function PaginationControls({
       </div>
     </div>
   );
-});
+};
+
+const getParam = (params: URLSearchParams, key: string): string => {
+  return params.get(key)?.trim() ?? "";
+};
+
+const getStatusParam = (params: URLSearchParams): "" | VisibleStudentAdmissionStatus => {
+  const status = getParam(params, "status");
+
+  return status === "ACCEPTED" || status === "WAITLISTED" ? status : "";
+};
+
+const getSortByParam = (
+  params: URLSearchParams
+): NonNullable<StudentFilterParams["sortBy"]> => {
+  const sortBy = getParam(params, "sortBy");
+
+  return sortableFields.includes(sortBy as NonNullable<StudentFilterParams["sortBy"]>)
+    ? (sortBy as NonNullable<StudentFilterParams["sortBy"]>)
+    : "submittedAt";
+};
+
+const getInitialPage = (params: URLSearchParams): number => {
+  return Math.max(1, Number(getParam(params, "page")) || 1);
+};
+
+const getInitialPageSize = (params: URLSearchParams): PageSize => {
+  const requestedLimit = Number(getParam(params, "limit")) as PageSize;
+
+  return pageSizeOptions.includes(requestedLimit) ? requestedLimit : 4;
+};
 
 const StudentsPage = () => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const requestedLevel = normalizeLevelCode(searchParams.get("level") ?? "");
   const [levels, setLevels] = useState<LevelSummary[]>([]);
-  const [applications, setApplications] = useState<ApplicationListItem[]>([]);
+  const [schoolYears, setSchoolYears] = useState<SchoolYearSummary[]>([]);
+  const [students, setStudents] = useState<StudentListItem[]>([]);
+  const [totalStudents, setTotalStudents] = useState(0);
   const [activeSchoolYear, setActiveSchoolYear] = useState<SchoolYearSummary | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [pageSize, setPageSize] = useState<PageSize>(4);
-  const [search, setSearch] = useState("");
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
+  const [search, setSearch] = useState(() => getParam(searchParams, "search"));
+  const [page, setPage] = useState(() => getInitialPage(searchParams));
+  const [limit, setLimit] = useState<PageSize>(() => getInitialPageSize(searchParams));
+  const deferredSearch = useDeferredValue(search);
 
-  const selectedLevel = useMemo(() => {
-    return levels.find((level) => normalizeLevelCode(level.code) === requestedLevel) ?? null;
-  }, [levels, requestedLevel]);
+  const filters = useMemo<StudentFilterParams>(() => {
+    const isPriority = getParam(searchParams, "isPriority");
+    const sortOrder = getParam(searchParams, "sortOrder");
 
-  const levelStudentRows = useMemo<StudentListItem[]>(() => {
-    if (!requestedLevel) {
-      return [];
-    }
+    return {
+      search: deferredSearch.trim() || undefined,
+      status: getStatusParam(searchParams) || undefined,
+      levelId: getParam(searchParams, "levelId") || undefined,
+      schoolYearId: getParam(searchParams, "schoolYearId") || activeSchoolYear?.id,
+      isPriority: isPriority === "true" ? "true" : undefined,
+      familyId: getParam(searchParams, "familyId") || undefined,
+      page: "1",
+      limit: "5000",
+      sortBy: getSortByParam(searchParams),
+      sortOrder: sortOrder === "asc" ? "asc" : "desc"
+    };
+  }, [activeSchoolYear?.id, deferredSearch, searchParams]);
 
-    return applications.flatMap((application) =>
-      application.students
-        .filter((student) => normalizeLevelCode(student.level.code) === requestedLevel)
-        .map((student) => ({ application, student }))
-    );
-  }, [applications, requestedLevel]);
-  const studentRows = useMemo<StudentListItem[]>(() => {
-    const normalizedSearch = search.trim().toLowerCase();
-
-    if (!normalizedSearch) {
-      return levelStudentRows;
-    }
-
-    return levelStudentRows.filter((row) =>
-      getStudentSearchValue(row).includes(normalizedSearch)
-    );
-  }, [levelStudentRows, search]);
-
-  const studentsCountLabel = `${studentRows.length} élève${studentRows.length > 1 ? "s" : ""}`;
   const totalPages = useMemo(() => {
-    return Math.max(1, Math.ceil(studentRows.length / pageSize));
-  }, [pageSize, studentRows.length]);
-  const resolvedCurrentPage = Math.min(currentPage, totalPages);
-  const currentPageStudentRows = useMemo(() => {
-    const startIndex = (resolvedCurrentPage - 1) * pageSize;
+    return Math.max(1, Math.ceil(students.length / limit));
+  }, [limit, students.length]);
+  const currentPageStudents = useMemo(() => {
+    const startIndex = (page - 1) * limit;
 
-    return studentRows.slice(startIndex, startIndex + pageSize);
-  }, [pageSize, resolvedCurrentPage, studentRows]);
-  const visibleStart = studentRows.length === 0
-    ? 0
-    : (resolvedCurrentPage - 1) * pageSize + 1;
-  const visibleEnd = Math.min(resolvedCurrentPage * pageSize, studentRows.length);
-  const selectedLevelLabel = selectedLevel?.label ?? requestedLevel;
-  const activeSchoolYearLabel = activeSchoolYear
-    ? formatSchoolYearLabel(activeSchoolYear.label)
-    : "Toutes les années";
+    return students.slice(startIndex, startIndex + limit);
+  }, [limit, page, students]);
+
+  const selectedLevel = levels.find((level) => level.id === filters.levelId) ?? null;
+  const selectedSchoolYear =
+    schoolYears.find((schoolYear) => schoolYear.id === filters.schoolYearId) ?? null;
+  const activeSchoolYearLabel = selectedSchoolYear
+    ? formatSchoolYearLabel(selectedSchoolYear.label)
+    : activeSchoolYear
+      ? formatSchoolYearLabel(activeSchoolYear.label)
+      : "Toutes les années";
+  const studentListAnimationKey = [
+    page,
+    limit,
+    filters.search ?? "",
+    filters.status ?? "",
+    filters.levelId ?? "",
+    filters.schoolYearId ?? "",
+    filters.isPriority ?? "",
+    filters.familyId ?? "",
+    filters.sortBy ?? "",
+    filters.sortOrder ?? ""
+  ].join("|");
+
   const inputClassName =
     "w-full rounded-2xl border border-primary/15 bg-white/95 px-4 py-3 text-sm font-medium text-slate-900 shadow-[0_12px_26px_-24px_rgba(31,77,58,0.22)] outline-none transition hover:border-primary/30 focus:border-secondary focus:ring-2 focus:ring-secondary/20";
 
-  const handleLevelChange = useCallback(
-    (event: React.ChangeEvent<HTMLSelectElement>): void => {
-      const nextLevel = normalizeLevelCode(event.target.value);
+  const updateParams = useCallback(
+    (updates: Record<string, string | undefined>): void => {
       const nextParams = new URLSearchParams(searchParams);
 
-      if (nextLevel) {
-        nextParams.set("level", nextLevel);
-      } else {
-        nextParams.delete("level");
-      }
+      Object.entries(updates).forEach(([key, value]) => {
+        if (value) {
+          nextParams.set(key, value);
+        } else {
+          nextParams.delete(key);
+        }
+      });
 
+      nextParams.delete("page");
+      nextParams.delete("limit");
+      setPage(1);
       setSearchParams(nextParams);
     },
     [searchParams, setSearchParams]
   );
 
-  const handleSearchChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>): void => {
-      setSearch(event.target.value);
-    },
-    []
-  );
+  useEffect(() => {
+    const requestedSearch = getParam(searchParams, "search");
 
-  const handlePageSizeChange = useCallback(
-    (event: React.ChangeEvent<HTMLSelectElement>): void => {
-      setPageSize(Number(event.target.value) as PageSize);
-    },
-    []
-  );
+    setSearch((currentSearch) =>
+      currentSearch === requestedSearch ? currentSearch : requestedSearch
+    );
+  }, [searchParams]);
 
-  const handlePageChange = useCallback(
-    (page: number): void => {
-      setCurrentPage(Math.min(totalPages, Math.max(1, page)));
-    },
-    [totalPages]
-  );
+  useEffect(() => {
+    setPage(1);
+  }, [deferredSearch]);
 
-  const loadStudentsContext = useCallback(async (signal?: AbortSignal): Promise<void> => {
-    setIsLoading(true);
-    setError(null);
+  useEffect(() => {
+    setPage((currentPage) => Math.min(currentPage, totalPages));
+  }, [totalPages]);
 
-    try {
-      const [loadedLevels, currentSchoolYear] = await Promise.all([
-        getLevels({ signal }),
-        getActiveSchoolYear({ signal }).catch(() => null)
-      ]);
+  const loadReferenceData = useCallback(async (signal: AbortSignal): Promise<void> => {
+    const [loadedLevels, loadedSchoolYears, loadedActiveSchoolYear] = await Promise.all([
+      getLevels({ signal }),
+      getSchoolYears({ signal }),
+      getActiveSchoolYear({ signal }).catch(() => null)
+    ]);
 
-      if (signal?.aborted) {
-        return;
-      }
-
-      const loadedApplications = await getApplications(
-        currentSchoolYear ? { schoolYearId: currentSchoolYear.id } : {},
-        { signal }
-      );
-
-      if (signal?.aborted) {
-        return;
-      }
-
-      setLevels(loadedLevels);
-      setActiveSchoolYear(currentSchoolYear);
-      setApplications(loadedApplications);
-    } catch (loadError) {
-      if (isAbortError(loadError) || signal?.aborted) {
-        return;
-      }
-
-      setError(
-        loadError instanceof Error
-          ? loadError.message
-          : "Impossible de charger la liste des élèves."
-      );
-    } finally {
-      if (!signal?.aborted) {
-        setIsLoading(false);
-        setHasLoadedOnce(true);
-      }
+    if (signal.aborted) {
+      return;
     }
+
+    setLevels(loadedLevels);
+    setSchoolYears(loadedSchoolYears);
+    setActiveSchoolYear(loadedActiveSchoolYear);
   }, []);
 
   useEffect(() => {
     const controller = new AbortController();
 
-    void loadStudentsContext(controller.signal);
+    void loadReferenceData(controller.signal);
 
-    return () => {
-      controller.abort();
-    };
-  }, [loadStudentsContext]);
+    return () => controller.abort();
+  }, [loadReferenceData]);
 
   useEffect(() => {
-    setCurrentPage(1);
-  }, [requestedLevel, pageSize, search]);
+    const controller = new AbortController();
 
-  useEffect(() => {
-    setCurrentPage((page) => Math.min(page, totalPages));
-  }, [totalPages]);
+    setIsLoading(true);
+    setError(null);
+
+    void getStudents(filters, { signal: controller.signal })
+      .then((response) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        setStudents(response.data);
+        setTotalStudents(response.meta.total);
+      })
+      .catch((loadError) => {
+        if (isAbortError(loadError) || controller.signal.aborted) {
+          return;
+        }
+
+        setError(
+          loadError instanceof Error
+            ? loadError.message
+            : "Impossible de charger les élèves."
+        );
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+          setHasLoadedOnce(true);
+        }
+      });
+
+    return () => controller.abort();
+  }, [filters]);
 
   const pageTopBar = (
     <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
@@ -462,26 +441,17 @@ const StudentsPage = () => {
         className="ui-animate-in ui-animate-in--subtle w-fit rounded-2xl border border-primary/10 bg-white/80 px-4 py-3 text-sm text-primaryDark shadow-[0_10px_22px_-22px_rgba(15,23,42,0.18)]"
         style={getEnterStyle(20)}
       >
-        <Breadcrumb
-          items={[
-            { label: "Tableau de bord", href: "/" },
-            { label: "Élèves par niveau" }
-          ]}
-        />
+        <Breadcrumb items={[{ label: "Tableau de bord", href: "/" }, { label: "Élèves" }]} />
       </div>
 
-      <div className="flex lg:justify-end">
-        <div
-          className="ui-animate-in ui-animate-in--subtle rounded-2xl border border-primary/10 bg-white/80 px-4 py-3 text-center text-sm text-primaryDark shadow-[0_10px_22px_-22px_rgba(15,23,42,0.18)]"
-          style={getEnterStyle(90)}
-        >
-          <p className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-primaryLight">
-            Année active
-          </p>
-          <p className="mt-1 font-semibold">
-            {activeSchoolYearLabel}
-          </p>
-        </div>
+      <div
+        className="ui-animate-in ui-animate-in--subtle rounded-2xl border border-primary/10 bg-white/80 px-4 py-3 text-center text-sm text-primaryDark shadow-[0_10px_22px_-22px_rgba(15,23,42,0.18)]"
+        style={getEnterStyle(90)}
+      >
+        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-primaryLight">
+          Année affichée
+        </p>
+        <p className="mt-1 font-semibold">{activeSchoolYearLabel}</p>
       </div>
     </div>
   );
@@ -491,8 +461,8 @@ const StudentsPage = () => {
       <PageSectionHeader
         topBar={pageTopBar}
         eyebrow="Élèves"
-        title="Élèves par niveau demandé"
-        description="Retrouvez rapidement les élèves associés au niveau sélectionné depuis le tableau de bord."
+        title="Traitement des élèves"
+        description="Pilotez les décisions élève par élève avec les filtres utiles au suivi quotidien des inscriptions."
       />
     </div>
   );
@@ -506,15 +476,11 @@ const StudentsPage = () => {
     );
   }
 
-  if (error && applications.length === 0) {
+  if (error && students.length === 0) {
     return (
       <>
         {pageHeader}
-        <ErrorState
-          message={error}
-          actionLabel="Réessayer"
-          onAction={() => void loadStudentsContext()}
-        />
+        <ErrorState message={error} actionLabel="Réessayer" onAction={() => updateParams({})} />
       </>
     );
   }
@@ -528,150 +494,172 @@ const StudentsPage = () => {
         style={getEnterStyle(190)}
       >
         <div className="border-b border-secondary/30 bg-primary px-6 py-5 text-white sm:px-7">
-          <div className="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
-            <div className="flex min-w-0 items-start gap-4">
-              <span className="mt-1 inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl border border-white/20 bg-white/10 text-secondary shadow-[0_16px_30px_-22px_rgba(0,0,0,0.55)]">
-                <StudentPanelIcon />
-              </span>
-              <div className="min-w-0">
-                <p className="text-sm font-semibold uppercase tracking-[0.2em] text-secondary">
-                  Poste élèves
-                </p>
-                <h2 className="mt-2 text-2xl font-semibold text-white">
-                  {requestedLevel ? selectedLevelLabel : "Sélectionner un niveau"}
-                </h2>
-                <p className="mt-2 max-w-3xl text-sm leading-6 text-white/80">
-                  Consultez la cohorte d&apos;un niveau, recherchez un élève et
-                  accédez directement au dossier de chaque famille.
-                </p>
-              </div>
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-secondary">
+                Poste principal
+              </p>
+              <h2 className="mt-2 text-2xl font-semibold text-white">
+                {getStudentCountLabel(totalStudents)}
+              </h2>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-white/80">
+                Recherche, tri et décisions restent centrés sur les statuts élèves.
+              </p>
             </div>
-
-            <div className="flex flex-wrap items-center gap-2.5">
-              <span className="inline-flex items-center rounded-full border border-secondary/40 bg-secondary/20 px-4 py-2 text-sm font-semibold text-white">
-                {isLoading ? "Actualisation..." : studentsCountLabel}
-              </span>
-              <span className="inline-flex items-center rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-medium text-white">
-                {activeSchoolYearLabel}
-              </span>
-              {requestedLevel ? (
-                <span className="inline-flex items-center rounded-full border border-secondary/40 bg-secondary/20 px-4 py-2 text-sm font-semibold text-white">
-                  {requestedLevel}
-                </span>
+            <div className="flex flex-wrap gap-2">
+              {filters.status ? <StudentStatusBadge status={filters.status} /> : null}
+              {selectedLevel ? (
+                <LevelBadge code={selectedLevel.code} label={selectedLevel.label} size="md" />
               ) : null}
+              {filters.isPriority === "true" ? <PriorityBadge isPriority /> : null}
             </div>
           </div>
         </div>
 
         <div className="bg-[#fffaf2] px-6 py-5 sm:px-7">
-          <div className="grid gap-4 xl:grid-cols-[minmax(260px,1.1fr)_minmax(260px,1fr)_auto] xl:items-end">
-            <label className="block">
+          <div className="grid gap-4 lg:grid-cols-4">
+            <label className="block lg:col-span-2">
               <span className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-primaryLight">
-                Recherche rapide
+                Recherche
               </span>
-              <div className="relative mt-2">
-                <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-4 text-primary">
-                  <SearchIcon className="h-5 w-5" />
-                </span>
-                <input
-                  type="search"
-                  value={search}
-                  onChange={handleSearchChange}
-                  placeholder="Élève, famille ou email..."
-                  className={`${inputClassName} h-14 pl-12 text-base`}
-                />
-              </div>
+              <input
+                type="search"
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Nom élève, parent, email ou téléphone..."
+                className={`${inputClassName} mt-2`}
+              />
             </label>
 
             <label className="block">
               <span className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-primaryLight">
-                Niveau
+                Statut élève
               </span>
               <select
-                value={requestedLevel}
-                onChange={handleLevelChange}
+                value={filters.status ?? ""}
+                onChange={(event) => updateParams({ status: event.target.value || undefined })}
                 className={`${inputClassName} mt-2`}
               >
-                <option value="">Choisir un niveau</option>
+                <option value="">Tous les statuts</option>
+                <option value="WAITLISTED">En attente</option>
+                <option value="ACCEPTED">Accepté</option>
+              </select>
+            </label>
+
+            <label className="block">
+              <span className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-primaryLight">
+                Priorité
+              </span>
+              <select
+                value={filters.isPriority ?? ""}
+                onChange={(event) => updateParams({ isPriority: event.target.value || undefined })}
+                className={`${inputClassName} mt-2`}
+              >
+                <option value="">Toutes</option>
+                <option value="true">Prioritaires</option>
+              </select>
+            </label>
+
+            <label className="block">
+              <span className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-primaryLight">
+                Niveau demandé
+              </span>
+              <select
+                value={filters.levelId ?? ""}
+                onChange={(event) => updateParams({ levelId: event.target.value || undefined })}
+                className={`${inputClassName} mt-2`}
+              >
+                <option value="">Tous les niveaux</option>
                 {levels.map((level) => (
-                  <option key={level.id} value={level.code}>
+                  <option key={level.id} value={level.id}>
                     {level.label} · {level.code.toUpperCase()}
                   </option>
                 ))}
               </select>
             </label>
 
-            <div className="flex flex-wrap items-center gap-2 lg:justify-end">
-              {requestedLevel ? (
-                <LevelBadge
-                  code={selectedLevel?.code ?? requestedLevel}
-                  label={selectedLevelLabel}
-                  size="md"
-                />
-              ) : null}
-              <span className="inline-flex items-center justify-center rounded-full border border-primary/15 bg-white px-4 py-2.5 text-sm font-semibold text-primaryDark">
-                {isLoading ? "Actualisation..." : studentsCountLabel}
+            <label className="block">
+              <span className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-primaryLight">
+                Année scolaire
               </span>
-            </div>
-          </div>
+              <select
+                value={filters.schoolYearId ?? ""}
+                onChange={(event) => updateParams({ schoolYearId: event.target.value || undefined })}
+                className={`${inputClassName} mt-2`}
+              >
+                <option value="">Toutes les années</option>
+                {schoolYears.map((schoolYear) => (
+                  <option key={schoolYear.id} value={schoolYear.id}>
+                    {formatSchoolYearLabel(schoolYear.label)}
+                    {schoolYear.isActive ? " · active" : ""}
+                  </option>
+                ))}
+              </select>
+            </label>
 
-          <div className="mt-5 flex flex-wrap items-center gap-2 border-t border-secondary/25 pt-4">
-            <span className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-primaryLight">
-              Vue active
-            </span>
-            {requestedLevel ? (
-              <span className="inline-flex items-center rounded-full border border-secondary/30 bg-white px-3 py-1.5 text-xs font-semibold text-primaryDark">
-                {selectedLevelLabel} · {requestedLevel}
+            <label className="block">
+              <span className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-primaryLight">
+                Famille
               </span>
-            ) : (
-              <span className="inline-flex items-center rounded-full border border-primary/15 bg-white px-3 py-1.5 text-xs font-semibold text-primaryDark">
-                Aucun niveau sélectionné
+              <input
+                value={filters.familyId ?? ""}
+                onChange={(event) => updateParams({ familyId: event.target.value.trim() || undefined })}
+                placeholder="Identifiant famille"
+                className={`${inputClassName} mt-2`}
+              />
+            </label>
+
+            <label className="block">
+              <span className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-primaryLight">
+                Tri
               </span>
-            )}
-            <span className="inline-flex items-center rounded-full border border-secondary/30 bg-white px-3 py-1.5 text-xs font-semibold text-primaryDark">
-              {activeSchoolYearLabel}
-            </span>
-            {search.trim() ? (
-              <span className="inline-flex items-center rounded-full border border-secondary/30 bg-white px-3 py-1.5 text-xs font-semibold text-primaryDark">
-                Recherche: {search.trim()}
+              <select
+                value={filters.sortBy}
+                onChange={(event) => updateParams({ sortBy: event.target.value })}
+                className={`${inputClassName} mt-2`}
+              >
+                <option value="lastName">Nom</option>
+                <option value="firstName">Prénom</option>
+                <option value="level">Niveau</option>
+                <option value="birthDate">Date de naissance</option>
+                <option value="submittedAt">Date de soumission</option>
+                <option value="status">Statut</option>
+              </select>
+            </label>
+
+            <label className="block">
+              <span className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-primaryLight">
+                Ordre
               </span>
-            ) : null}
+              <select
+                value={filters.sortOrder}
+                onChange={(event) => updateParams({ sortOrder: event.target.value })}
+                className={`${inputClassName} mt-2`}
+              >
+                <option value="desc">Décroissant</option>
+                <option value="asc">Croissant</option>
+              </select>
+            </label>
           </div>
         </div>
       </section>
 
       <section className="mt-6 space-y-4">
         {isLoading && hasLoadedOnce ? <LoadingState variant="card" /> : null}
-
-        {error && applications.length > 0 ? (
-          <ErrorState
-            message={`${error} Les derniers résultats chargés restent affichés.`}
-            actionLabel="Réessayer"
-            onAction={() => void loadStudentsContext()}
-          />
+        {error && students.length > 0 ? (
+          <ErrorState message={`${error} Les derniers résultats restent affichés.`} />
         ) : null}
 
-        {!requestedLevel ? (
-          <EmptyState
-            title="Aucun niveau sélectionné"
-            description="Choisissez un niveau pour afficher les élèves correspondants."
-          />
-        ) : null}
-
-        {requestedLevel && !isLoading && studentRows.length === 0 ? (
+        {!isLoading && students.length === 0 ? (
           <EmptyState
             title="Aucun élève trouvé"
-            description={
-              search.trim()
-                ? `Aucun élève en ${selectedLevelLabel} ne correspond à cette recherche.`
-                : `Aucun élève ne correspond au niveau ${selectedLevelLabel}.`
-            }
+            description="Aucun élève ne correspond aux filtres sélectionnés."
           />
         ) : null}
 
-        {studentRows.length > 0 ? (
+        {students.length > 0 ? (
           <section
-            className="ui-animate-in ui-surface-hover ui-surface-hover--soft ui-surface-hover--no-accent overflow-hidden rounded-[32px] border border-white/80 bg-white/92 shadow-[0_24px_48px_-34px_rgba(15,23,42,0.3)]"
+            className="ui-animate-in overflow-hidden rounded-[32px] border border-white/80 bg-white/92 shadow-[0_24px_48px_-34px_rgba(15,23,42,0.3)]"
             style={getEnterStyle(250)}
           >
             <div className="border-b border-slate-200/80 px-6 py-5 sm:px-7">
@@ -681,18 +669,22 @@ const StudentsPage = () => {
                     Résultats
                   </p>
                   <h2 className="mt-2 text-2xl font-semibold text-slate-900">
-                    {studentsCountLabel} en {selectedLevelLabel}
+                    {getStudentCountLabel(students.length)}
                   </h2>
                 </div>
                 <div className="flex flex-nowrap items-center gap-2">
                   <span className="inline-flex shrink-0 items-center rounded-full border border-primary/15 bg-primary/5 px-3.5 py-2 text-sm font-medium text-primaryDark">
-                    {visibleStart}-{visibleEnd} sur {studentRows.length}
+                    {currentPageStudents.length === 0 ? 0 : (page - 1) * limit + 1}-
+                    {Math.min(page * limit, students.length)} sur {students.length}
                   </span>
                   <label className="inline-flex min-w-0 shrink-0 items-center gap-2 rounded-full border border-slate-200 bg-slate-50 py-1.5 pl-3.5 pr-1.5 text-sm font-medium text-slate-700">
                     <span className="whitespace-nowrap">Élèves par page</span>
                     <select
-                      value={pageSize}
-                      onChange={handlePageSizeChange}
+                      value={limit}
+                      onChange={(event) => {
+                        setLimit(Number(event.target.value) as PageSize);
+                        setPage(1);
+                      }}
                       className="w-[4.25rem] rounded-full border border-slate-200 bg-white px-2.5 py-1 text-sm font-semibold text-slate-900 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
                     >
                       {pageSizeOptions.map((option) => (
@@ -702,100 +694,95 @@ const StudentsPage = () => {
                       ))}
                     </select>
                   </label>
-                  <LevelBadge
-                    code={selectedLevel?.code ?? requestedLevel}
-                    label={selectedLevelLabel}
-                    size="md"
-                  />
                 </div>
               </div>
             </div>
 
             <div className="px-4 py-4 sm:px-6">
               <div className="space-y-3">
-                {currentPageStudentRows.map(({ application, student }, index) => (
-                  <Link
-                    key={`${application.id}-${student.id}`}
-                    to={`/applications/${application.id}`}
-                    aria-label={`Ouvrir la demande associée à ${student.firstName} ${student.lastName}`}
-                    className="group ui-animate-in ui-surface-hover ui-surface-hover--soft block rounded-[28px] border border-slate-200/90 bg-slate-50/80 p-4 shadow-[0_14px_30px_-24px_rgba(15,23,42,0.16)] outline-none transition focus-visible:ring-4 focus-visible:ring-primary/20 sm:p-5"
-                    style={getEnterStyle(310 + index * 45)}
-                  >
-                    <div className="grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_76px_minmax(0,1.4fr)_170px_180px_108px] xl:items-center">
-                      <div className="min-w-0">
-                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                          Élève
-                        </p>
-                        <h3 className="mt-1 text-lg font-semibold text-slate-900">
-                          {student.firstName} {student.lastName}
-                        </h3>
-                        <div className="mt-2">
-                          <LevelBadge
-                            code={student.level.code}
-                            label={student.level.label}
-                            size="sm"
-                          />
-                        </div>
-                      </div>
-
-                      <div className="flex xl:justify-center">
-                        <PersonAvatar
-                          label={`${student.firstName} ${student.lastName}`}
-                          size="md"
-                          variant={getStudentAvatarVariant(student.gender)}
-                        />
-                      </div>
-
-                      <div className="min-w-0">
-                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                          Famille
-                        </p>
-                        <p className="mt-1 text-sm font-semibold text-slate-900">
-                          Famille {getFamilyDisplayName(application)}
-                        </p>
-                        <p className="mt-1 break-all text-sm text-slate-500">
-                          {application.family.contactEmail ?? "Contact non renseigné"}
-                        </p>
-                      </div>
-
-                      <div>
-                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                          Année
-                        </p>
-                        <p className="mt-1 text-sm font-semibold text-slate-900">
-                          {formatSchoolYearLabel(application.schoolYear.label)}
-                        </p>
-                      </div>
-
-                      <div>
-                        <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                          Demande
-                        </p>
-                        <div className="mt-1 flex flex-wrap items-center gap-2">
-                          <StatusBadge status={application.status} />
-                          <PriorityBadge isPriority={application.isPriority} />
-                        </div>
-                      </div>
-
-                      <div className="xl:justify-self-end">
-                        <span
-                          className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition group-hover:border-primary/25 group-hover:text-primary hover:border-primary/25 hover:text-primary"
-                        >
-                          <span>Voir</span>
-                          <ChevronRightIcon />
-                        </span>
-                      </div>
+              {currentPageStudents.map((student, index) => (
+                <article
+                  key={`${studentListAnimationKey}-${student.id}`}
+                  className="ui-animate-in ui-surface-hover ui-surface-hover--soft grid gap-4 rounded-[28px] border border-slate-200/90 bg-slate-50/80 p-4 shadow-[0_14px_30px_-24px_rgba(15,23,42,0.16)] transition hover:bg-white lg:grid-cols-[minmax(0,1.25fr)_160px_minmax(0,1fr)_170px_150px] lg:items-center sm:p-5"
+                  style={getEnterStyle(300 + index * 30)}
+                >
+                  <div className="flex min-w-0 items-center gap-4">
+                    <PersonAvatar
+                      label={`${student.firstName} ${student.lastName}`}
+                      size="md"
+                      variant={getStudentAvatarVariant(student.gender)}
+                    />
+                    <div className="min-w-0">
+                      <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                        Élève
+                      </p>
+                      <Link
+                        to={`/students/${student.id}`}
+                        className="mt-1 block text-lg font-semibold text-slate-900 transition hover:text-primary"
+                      >
+                        {student.firstName} {student.lastName}
+                      </Link>
+                      <p className="mt-1 text-sm text-slate-500">
+                        Né(e) le {formatDate.format(new Date(student.birthDate))}
+                      </p>
                     </div>
-                  </Link>
-                ))}
-              </div>
+                  </div>
 
-              <PaginationControls
-                currentPage={resolvedCurrentPage}
-                totalPages={totalPages}
-                onPageChange={handlePageChange}
-              />
+                  <div>
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                      Niveau
+                    </p>
+                    <div className="mt-2">
+                      <LevelBadge code={student.level.code} label={student.level.label} size="sm" />
+                    </div>
+                  </div>
+
+                  <div className="min-w-0">
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                      Famille
+                    </p>
+                    <p className="mt-1 text-sm font-semibold text-slate-900">
+                      Famille {getFamilyDisplayName(student)}
+                    </p>
+                    <p className="mt-1 break-all text-sm text-slate-500">
+                      {student.application.family.contactEmail || "Email non renseigné"}
+                    </p>
+                  </div>
+
+                  <div>
+                    <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                      Statut
+                    </p>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      <StudentStatusBadge status={student.admissionStatus} />
+                      <PriorityBadge isPriority={student.isPriority} />
+                    </div>
+                  </div>
+
+                  <div className="flex flex-wrap gap-2 lg:justify-end">
+                    <Link
+                      to={`/students/${student.id}`}
+                      className="inline-flex items-center rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-primaryDark"
+                    >
+                      Fiche élève
+                    </Link>
+                    <Link
+                      to={`/applications/${student.application.id}`}
+                      className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary/25 hover:text-primary"
+                    >
+                      Famille
+                    </Link>
+                  </div>
+                </article>
+              ))}
+              </div>
             </div>
+
+            <PaginationControls
+              currentPage={page}
+              totalPages={totalPages}
+              onPageChange={setPage}
+            />
           </section>
         ) : null}
       </section>


### PR DESCRIPTION
## 🎯 Objectif

Réorienter l’application autour du suivi des élèves, conformément au retour métier du directeur de l’ECE.

La logique des demandes reste conservée, mais l’interface, les filtres, les compteurs et les actions principales sont désormais davantage centrés sur les élèves.

## ✅ Changements principaux

### Page détail d’une demande / famille
- Suppression du cadre priorité au niveau de la demande.
- Suppression du badge priorité dans l’en-tête.
- Suppression du badge priorité dans la carte famille.
- Suppression du handler et de l’import liés à `updateApplicationPriority`.
- Ajout d’un bouton `Voir l’élève` sur chaque carte élève.

### Page Élèves
- Recherche rendue dynamique, sans validation par Entrée.
- Synchronisation de la recherche avec l’URL via `?search=...`.
- Ajout d’une pagination alignée sur la page Familles :
  - 4, 6, 8, 10, 12, 15, 18, 20 éléments par page.
- Pagination numérotée avec précédent, suivant et ellipses.
- Les cartes élèves sont maintenant arrondies et espacées comme les familles.
- Ajout de l’animation d’apparition/hover sur les élèves.
- L’animation se rejoue à chaque changement de page ou de taille de pagination.
- Le changement de pagination ne recharge plus toute la page.
- Le bloc résultats ne se recharge plus inutilement lors du changement du nombre d’élèves affichés.

### API Élèves
- Ajustement du contrôleur students pour permettre de charger le jeu filtré complet côté client.
- Meilleur comportement de pagination locale côté front.

### Page Familles / Demandes
- Ajout des options de pagination 15, 18 et 20 sur la page Familles.

### Dashboard
- Modification de l’icône du bloc traitement pour le différencier du bloc élèves acceptés.
- Curseur de progression du bloc traitement passé en doré `secondary`.
- Bloc `En attente` aligné sur la couleur du tag en attente pour garder une cohérence visuelle.

## 🧪 Vérifications effectuées

- `npm exec -w apps/web -- tsc -b`
- `npm run build -w apps/web`
- `npm run build -w apps/api`

## 📌 Notes

Cette PR prépare l’application à une logique métier davantage centrée sur les élèves, tout en conservant la structure robuste existante :

`Family -> Application -> Student`