### PR TITLE
fix: rendre les imports complémentaires non destructifs

### DIFF
--- a/apps/api/src/controllers/import.controller.ts
+++ b/apps/api/src/controllers/import.controller.ts
@@ -219,22 +219,6 @@ const getActiveImportSchoolYear = async (): Promise<{ id: string; label: string 
   return activeSchoolYear;
 };
 
-const ensureNoSuccessfulImportForSchoolYear = async (schoolYearId: string): Promise<void> => {
-  const existingSuccessfulImport = await prisma.csvImportLog.findFirst({
-    where: {
-      schoolYearId,
-      status: "SUCCESS"
-    },
-    select: {
-      id: true
-    }
-  });
-
-  if (existingSuccessfulImport) {
-    throw badRequest("CSV import already completed for active school year");
-  }
-};
-
 const getDuplicateRowWarnings = async (
   schoolYearId: string,
   rows: ReturnType<typeof parseCsvImportFile>["rows"]
@@ -315,68 +299,6 @@ const buildFamilyCreateData = (
   };
 };
 
-const buildFamilyUpdateData = (
-  family: {
-    fatherLastName: string | null;
-    fatherFirstName: string | null;
-    fatherCity: string | null;
-    motherLastName: string | null;
-    motherFirstName: string | null;
-    motherCity: string | null;
-    familyStatus: string | null;
-    contactEmail: string;
-    contactPhone: string | null;
-    postalAddress: string | null;
-    googleAccountEmail: string | null;
-  }
-): Prisma.FamilyUpdateInput => {
-  const updateData: Prisma.FamilyUpdateInput = {
-    contactEmail: family.contactEmail
-  };
-
-  if (family.fatherLastName !== null) {
-    updateData.fatherLastName = family.fatherLastName;
-  }
-
-  if (family.fatherFirstName !== null) {
-    updateData.fatherFirstName = family.fatherFirstName;
-  }
-
-  if (family.fatherCity !== null) {
-    updateData.fatherCity = family.fatherCity;
-  }
-
-  if (family.motherLastName !== null) {
-    updateData.motherLastName = family.motherLastName;
-  }
-
-  if (family.motherFirstName !== null) {
-    updateData.motherFirstName = family.motherFirstName;
-  }
-
-  if (family.motherCity !== null) {
-    updateData.motherCity = family.motherCity;
-  }
-
-  if (family.familyStatus !== null) {
-    updateData.familyStatus = family.familyStatus;
-  }
-
-  if (family.contactPhone !== null) {
-    updateData.contactPhone = family.contactPhone;
-  }
-
-  if (family.postalAddress !== null) {
-    updateData.postalAddress = family.postalAddress;
-  }
-
-  if (family.googleAccountEmail !== null) {
-    updateData.googleAccountEmail = family.googleAccountEmail;
-  }
-
-  return updateData;
-};
-
 const mapCsvImportLog = (log: CsvImportLogResponse) => {
   return {
     id: log.id,
@@ -415,8 +337,6 @@ export const previewCsvImport = async (req: Request, res: Response): Promise<voi
   const parsedImport = parseCsvImportFile(file.buffer);
   const activeSchoolYear = await getActiveImportSchoolYear();
 
-  await ensureNoSuccessfulImportForSchoolYear(activeSchoolYear.id);
-
   const duplicateRows = await getDuplicateRowWarnings(activeSchoolYear.id, parsedImport.rows);
 
   res.status(200).json({
@@ -438,42 +358,6 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
   const mergeDuplicateFamilies = parseMergeDuplicateFamiliesFlag(req.body?.mergeDuplicateFamilies);
   const activeSchoolYear = await getActiveImportSchoolYear();
 
-  await ensureNoSuccessfulImportForSchoolYear(activeSchoolYear.id);
-
-  const levels = await prisma.level.findMany({
-    select: {
-      id: true,
-      code: true,
-      label: true,
-      sortOrder: true
-    }
-  });
-  const missingLevels = buildMissingLevelDefinitions(parsedImport.rows, levels);
-
-  if (missingLevels.length > 0) {
-    await prisma.level.createMany({
-      data: missingLevels,
-      skipDuplicates: true
-    });
-  }
-
-  const allLevels = missingLevels.length > 0
-    ? await prisma.level.findMany({
-      select: {
-        id: true,
-        code: true,
-        label: true,
-        sortOrder: true
-      }
-    })
-    : levels;
-  const levelLookup = buildLevelLookupMap(allLevels);
-
-  const importedFamilyIds = new Set<string>();
-  let importedFamilies = 0;
-  let importedApplications = 0;
-  let importedStudents = 0;
-  let duplicateRows = 0;
   const duplicateFamilies = parsedImport.duplicateFamilies;
   const duplicateFamiliesCount = parsedImport.duplicateFamiliesCount;
   const duplicateFamilyRows = new Set(duplicateFamilies.flatMap((family) => family.rows));
@@ -482,34 +366,68 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
       ? duplicateFamilies.flatMap((family) => family.rows.slice(1))
       : []
   );
-  let mergedDuplicateFamilyRows = 0;
-  let invalidRows = parsedImport.invalidRows.length;
 
-  for (const row of parsedImport.rows) {
-    if (duplicateFamilyRowsToMerge.has(row.rowNumber)) {
-      mergedDuplicateFamilyRows += 1;
-      continue;
-    }
-
-    const resolvedStudents = row.students.map((student) => {
-      const levelId = levelLookup.get(student.requestedLevelKey);
-
-      return {
-        ...student,
-        levelId: levelId ?? null
-      };
+  const importSummary = await prisma.$transaction(async (tx) => {
+    const levels = await tx.level.findMany({
+      select: {
+        id: true,
+        code: true,
+        label: true,
+        sortOrder: true
+      }
     });
+    const missingLevels = buildMissingLevelDefinitions(parsedImport.rows, levels);
 
-    const missingLevelStudent = resolvedStudents.find((student) => student.levelId === null);
-
-    if (missingLevelStudent) {
-      invalidRows += 1;
-      continue;
+    if (missingLevels.length > 0) {
+      await tx.level.createMany({
+        data: missingLevels,
+        skipDuplicates: true
+      });
     }
 
-    const applicationHash = buildApplicationImportHash(activeSchoolYear.id, row);
+    const allLevels = missingLevels.length > 0
+      ? await tx.level.findMany({
+        select: {
+          id: true,
+          code: true,
+          label: true,
+          sortOrder: true
+        }
+      })
+      : levels;
+    const levelLookup = buildLevelLookupMap(allLevels);
+    const createdFamilyIds = new Set<string>();
+    const reusedFamilyIds = new Set<string>();
+    let importedApplications = 0;
+    let importedStudents = 0;
+    let duplicateRows = 0;
+    let mergedDuplicateFamilyRows = 0;
+    let invalidRows = parsedImport.invalidRows.length;
 
-    const importResult = await prisma.$transaction(async (tx) => {
+    for (const row of parsedImport.rows) {
+      if (duplicateFamilyRowsToMerge.has(row.rowNumber)) {
+        mergedDuplicateFamilyRows += 1;
+        continue;
+      }
+
+      const resolvedStudents = row.students.map((student) => {
+        const levelId = levelLookup.get(student.requestedLevelKey);
+
+        return {
+          ...student,
+          levelId: levelId ?? null
+        };
+      });
+
+      const missingLevelStudent = resolvedStudents.find((student) => student.levelId === null);
+
+      if (missingLevelStudent) {
+        invalidRows += 1;
+        continue;
+      }
+
+      const applicationHash = buildApplicationImportHash(activeSchoolYear.id, row);
+
       // Existing "duplicateRows" semantics:
       // this counter only covers exact imported applications whose rawCsvRowHash
       // already exists for the school year. Potential duplicate families are
@@ -530,12 +448,8 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
       });
 
       if (existingApplication) {
-        return {
-          createdApplication: false,
-          familyId: null,
-          createdStudents: 0,
-          skippedAsDuplicate: true
-        };
+        duplicateRows += 1;
+        continue;
       }
 
       const shouldMergeFamily = mergeDuplicateFamilies || !duplicateFamilyRows.has(row.rowNumber);
@@ -556,12 +470,7 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
       let familyId = existingFamily?.id;
 
       if (existingFamily) {
-        await tx.family.update({
-          where: {
-            id: existingFamily.id
-          },
-          data: buildFamilyUpdateData(row.family)
-        });
+        reusedFamilyIds.add(existingFamily.id);
       } else {
         const createdFamilyRecord = await tx.family.create({
           data: buildFamilyCreateData(row.family),
@@ -571,6 +480,7 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
         });
 
         familyId = createdFamilyRecord.id;
+        createdFamilyIds.add(createdFamilyRecord.id);
       }
 
       if (!familyId) {
@@ -604,63 +514,62 @@ export const importCsv = async (req: Request, res: Response): Promise<void> => {
         }))
       });
 
-      return {
-        createdApplication: true,
-        familyId,
-        createdStudents: resolvedStudents.length,
-        skippedAsDuplicate: false
-      };
+      importedApplications += 1;
+      importedStudents += resolvedStudents.length;
+    }
+
+    const createdFamilies = createdFamilyIds.size;
+    const reusedFamilies = reusedFamilyIds.size;
+    const importedFamilies = createdFamilies + reusedFamilies;
+    const skippedRows = invalidRows + duplicateRows + mergedDuplicateFamilyRows;
+
+    const createdImportLog = await tx.csvImportLog.create({
+      data: {
+        schoolYearId: activeSchoolYear.id,
+        fileName: normalizedFileName.length > 0 ? normalizedFileName : null,
+        importedFamilies,
+        importedApplications,
+        importedStudents,
+        skippedRows,
+        duplicateRows,
+        duplicateFamilies: duplicateFamiliesCount,
+        invalidRows,
+        totalRows: parsedImport.totalRows
+      },
+      select: csvImportLogSelect
     });
 
-    if (importResult.skippedAsDuplicate) {
-      duplicateRows += 1;
-      continue;
-    }
-
-    if (importResult.createdApplication) {
-      if (importResult.familyId) {
-        importedFamilyIds.add(importResult.familyId);
-      }
-
-      importedApplications += 1;
-      importedStudents += importResult.createdStudents;
-    }
-  }
-
-  importedFamilies = importedFamilyIds.size;
-  const skippedRows = invalidRows + duplicateRows + mergedDuplicateFamilyRows;
-
-  const createdImportLog = await prisma.csvImportLog.create({
-    data: {
-      schoolYearId: activeSchoolYear.id,
-      fileName: normalizedFileName.length > 0 ? normalizedFileName : null,
+    return {
       importedFamilies,
+      createdFamilies,
+      reusedFamilies,
       importedApplications,
       importedStudents,
       skippedRows,
       duplicateRows,
-      duplicateFamilies: duplicateFamiliesCount,
+      mergedDuplicateFamilyRows,
       invalidRows,
-      totalRows: parsedImport.totalRows
-    },
-    select: csvImportLogSelect
+      historyEntry: mapCsvImportLog(createdImportLog)
+    };
   });
 
   res.status(200).json({
-    importedFamilies,
-    importedApplications,
-    importedStudents,
-    skippedRows,
-    duplicateRows,
-    duplicateRowsCount: duplicateRows,
+    importedFamilies: importSummary.importedFamilies,
+    createdFamilies: importSummary.createdFamilies,
+    reusedFamilies: importSummary.reusedFamilies,
+    importedApplications: importSummary.importedApplications,
+    importedStudents: importSummary.importedStudents,
+    skippedRows: importSummary.skippedRows,
+    duplicateRows: importSummary.duplicateRows,
+    duplicateRowsCount: importSummary.duplicateRows,
     duplicateFamilies,
     duplicateFamiliesCount,
-    mergedDuplicateFamilyRows,
+    mergedDuplicateFamilyRows: importSummary.mergedDuplicateFamilyRows,
     mergeDuplicateFamilies,
-    invalidRows,
+    invalidRows: importSummary.invalidRows,
     totalRows: parsedImport.totalRows,
     activeSchoolYear: activeSchoolYear.label,
     delimiter: parsedImport.detectedDelimiter,
-    historyEntry: mapCsvImportLog(createdImportLog)
+    historyEntry: importSummary.historyEntry
   });
 };

--- a/apps/web/src/pages/ImportCsvPage.tsx
+++ b/apps/web/src/pages/ImportCsvPage.tsx
@@ -7,10 +7,8 @@ import type {
   MouseEvent
 } from "react";
 
-import { CsvImportSuccessAnimation } from "../components/animations";
 import AppLoader from "../components/feedback/AppLoader";
 import FeedbackEmptyState from "../components/feedback/EmptyState";
-import SuccessFeedback from "../components/feedback/SuccessFeedback";
 import PageSectionHeader from "../components/layout/PageSectionHeader";
 import Breadcrumb from "../components/ui/Breadcrumb";
 import { useToast } from "../context/ToastContext";
@@ -104,8 +102,14 @@ const getImportHistoryResult = (item: CsvImportHistoryItem): string => {
   ].join(" · ");
 };
 
-const getImportSuccessMessage = (summary: CsvImportSummary): string => {
-  return `Import terminé : ${pluralize(summary.importedApplications, "demande", "demandes")} et ${pluralize(summary.importedStudents, "élève", "élèves")} traités.`;
+const getImportSuccessMessage = (summary: CsvImportSummary, isComplementaryImport: boolean): string => {
+  const result = `${pluralize(summary.importedApplications, "demande", "demandes")} et ${pluralize(summary.importedStudents, "élève", "élèves")}`;
+
+  if (isComplementaryImport) {
+    return `Ajout terminé : ${result} ajoutés à la campagne en cours.`;
+  }
+
+  return `Import terminé : ${result} traités.`;
 };
 
 const getDuplicatePreviewCount = (preview: CsvImportPreview): number => {
@@ -169,7 +173,7 @@ const getImportErrorMessage = (error: unknown): string => {
     case "Active school year not found":
       return "Aucune année scolaire active n'est configurée pour recevoir l'import.";
     case "CSV import already completed for active school year":
-      return "Cette campagne d'inscription possède déjà un import CSV réussi. Créez une nouvelle année scolaire avant de lancer un nouvel import.";
+      return "Cette campagne d'inscription possède déjà un import CSV réussi. Rechargez la page puis utilisez l'action d'ajout à la campagne en cours.";
     default:
       if (error.message.startsWith("CSV missing ")) {
         return "Le fichier CSV ne correspond pas au format attendu du formulaire.";
@@ -300,11 +304,15 @@ const SummaryMetric = ({
 
 const DuplicateImportModal = ({
   preview,
+  isComplementaryImport,
+  activeSchoolYearLabel,
   isSubmitting,
   onCancel,
   onConfirm
 }: {
   preview: CsvImportPreview;
+  isComplementaryImport: boolean;
+  activeSchoolYearLabel: string;
   isSubmitting: boolean;
   onCancel: () => void;
   onConfirm: (mergeDuplicateFamilies: boolean) => void;
@@ -330,7 +338,9 @@ const DuplicateImportModal = ({
             <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
               {pluralize(duplicateCount, "doublon a été détecté", "doublons ont été détectés")}
               . Choisissez si les familles signalées doivent être fusionnées avant
-              l&apos;import définitif du fichier CSV.
+              {isComplementaryImport
+                ? ` l'ajout à la campagne ${activeSchoolYearLabel}.`
+                : " l'import définitif du fichier CSV."}
             </p>
           </div>
           <div className="grid grid-cols-2 gap-2 text-center sm:min-w-72">
@@ -411,6 +421,9 @@ const DuplicateImportModal = ({
           ignore les autres lignes du groupe. Importer sans fusion crée des
           fiches familles séparées pour ces demandes. Les doublons exacts restent
           ignorés dans les deux cas.
+          {isComplementaryImport
+            ? " Les données déjà présentes dans la campagne seront conservées."
+            : ""}
         </p>
 
         <div className="mt-5 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
@@ -428,7 +441,7 @@ const DuplicateImportModal = ({
             disabled={isSubmitting}
             className="inline-flex items-center justify-center rounded-2xl border border-secondary/50 px-5 py-3 text-sm font-semibold text-secondaryDark transition hover:bg-secondary/10 disabled:cursor-wait disabled:opacity-60"
           >
-            Importer sans fusion
+            {isComplementaryImport ? "Ajouter sans fusion" : "Importer sans fusion"}
           </button>
           <button
             type="button"
@@ -436,7 +449,67 @@ const DuplicateImportModal = ({
             disabled={isSubmitting}
             className="inline-flex items-center justify-center rounded-2xl bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:bg-primaryDark disabled:cursor-wait disabled:bg-slate-300"
           >
-            {isSubmitting ? "Import en cours..." : "Fusionner et importer"}
+            {isSubmitting
+              ? "Import en cours..."
+              : isComplementaryImport
+                ? "Fusionner et ajouter"
+                : "Fusionner et importer"}
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+const ComplementaryImportConfirmModal = ({
+  activeSchoolYearLabel,
+  isSubmitting,
+  onCancel,
+  onConfirm
+}: {
+  activeSchoolYearLabel: string;
+  isSubmitting: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) => {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="append-import-title"
+    >
+      <section className="w-full max-w-xl rounded-[28px] border border-[#e8dccf] bg-white p-5 shadow-[0_30px_80px_-35px_rgba(15,23,42,0.55)] sm:p-6">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-secondaryDark">
+          Campagne en cours
+        </p>
+        <h2 id="append-import-title" className="mt-2 font-serif text-[2rem] text-slate-900">
+          Ajouter ces demandes à la campagne en cours ?
+        </h2>
+        <p className="mt-3 text-sm leading-6 text-slate-600">
+          Les demandes déjà présentes seront conservées. Les nouvelles demandes
+          valides seront ajoutées à l&apos;année scolaire active {activeSchoolYearLabel}.
+        </p>
+        <p className="mt-4 rounded-2xl border border-primary/15 bg-primary/5 px-4 py-3 text-sm leading-6 text-slate-700">
+          Les données existantes seront conservées. Seules les nouvelles demandes
+          non déjà importées seront ajoutées.
+        </p>
+        <div className="mt-5 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isSubmitting}
+            className="inline-flex items-center justify-center rounded-2xl border border-slate-300 px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Annuler
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isSubmitting}
+            className="inline-flex items-center justify-center rounded-2xl bg-primary px-5 py-3 text-sm font-semibold text-white transition hover:bg-primaryDark disabled:cursor-wait disabled:bg-slate-300"
+          >
+            {isSubmitting ? "Ajout en cours..." : "Confirmer l'ajout"}
           </button>
         </div>
       </section>
@@ -462,6 +535,7 @@ const ImportCsvPage = () => {
   const [isDragging, setIsDragging] = useState(false);
   const [lastImportSummary, setLastImportSummary] = useState<CsvImportSummary | null>(null);
   const [pendingImportPreview, setPendingImportPreview] = useState<CsvImportPreview | null>(null);
+  const [isComplementaryConfirmationOpen, setIsComplementaryConfirmationOpen] = useState(false);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -566,8 +640,7 @@ const ImportCsvPage = () => {
     isLoadingHistory ||
     isCreatingSchoolYear ||
     isSubmitting ||
-    activeSchoolYear === null ||
-    hasCompletedImportForActiveSchoolYear;
+    activeSchoolYear === null;
 
   const openFilePicker = useCallback((): void => {
     if (isUploadLocked) {
@@ -583,6 +656,7 @@ const ImportCsvPage = () => {
   const clearSelectedFile = useCallback((): void => {
     setSelectedFile(null);
     setPendingImportPreview(null);
+    setIsComplementaryConfirmationOpen(false);
 
     if (fileInputRef.current) {
       fileInputRef.current.value = "";
@@ -609,6 +683,7 @@ const ImportCsvPage = () => {
     setSelectedFile(nextFile);
     setInlineMessage(null);
     setPendingImportPreview(null);
+    setIsComplementaryConfirmationOpen(false);
   }, [isUploadLocked, showError]);
 
   const handleFileInputChange = useCallback((event: ChangeEvent<HTMLInputElement>): void => {
@@ -643,9 +718,11 @@ const ImportCsvPage = () => {
 
     try {
       const summary = await uploadCsvImport(selectedFile, { mergeDuplicateFamilies });
+      const isComplementaryImport = hasCompletedImportForActiveSchoolYear;
 
       setLastImportSummary(summary);
       setPendingImportPreview(null);
+      setIsComplementaryConfirmationOpen(false);
 
       if (summary.historyEntry) {
         setHistory((currentHistory) => [
@@ -655,7 +732,7 @@ const ImportCsvPage = () => {
       }
 
       clearSelectedFile();
-      showSuccess(getImportSuccessMessage(summary));
+      showSuccess(getImportSuccessMessage(summary, isComplementaryImport));
     } catch (submitError) {
       const message = getImportErrorMessage(submitError);
 
@@ -788,15 +865,6 @@ const ImportCsvPage = () => {
       return;
     }
 
-    if (hasCompletedImportForActiveSchoolYear) {
-      const message =
-        "Cette campagne d'inscription possède déjà un import CSV réussi. Créez une nouvelle année scolaire avant de lancer un nouvel import.";
-
-      setInlineMessage(message);
-      showError(message);
-      return;
-    }
-
     if (!selectedFile) {
       const message = "Sélectionnez un fichier CSV avant de lancer l'import.";
 
@@ -814,6 +882,11 @@ const ImportCsvPage = () => {
 
       if (getDuplicatePreviewCount(preview) > 0) {
         setPendingImportPreview(preview);
+        return;
+      }
+
+      if (hasCompletedImportForActiveSchoolYear) {
+        setIsComplementaryConfirmationOpen(true);
         return;
       }
 
@@ -853,12 +926,27 @@ const ImportCsvPage = () => {
       {pendingImportPreview ? (
         <DuplicateImportModal
           preview={pendingImportPreview}
+          isComplementaryImport={hasCompletedImportForActiveSchoolYear}
+          activeSchoolYearLabel={activeSchoolYearLabel}
           isSubmitting={isSubmitting}
           onCancel={() => {
             setPendingImportPreview(null);
           }}
           onConfirm={(mergeDuplicateFamilies) => {
             void finalizeCsvImport(mergeDuplicateFamilies);
+          }}
+        />
+      ) : null}
+
+      {isComplementaryConfirmationOpen ? (
+        <ComplementaryImportConfirmModal
+          activeSchoolYearLabel={activeSchoolYearLabel}
+          isSubmitting={isSubmitting}
+          onCancel={() => {
+            setIsComplementaryConfirmationOpen(false);
+          }}
+          onConfirm={() => {
+            void finalizeCsvImport(true);
           }}
         />
       ) : null}
@@ -980,21 +1068,36 @@ const ImportCsvPage = () => {
           </p>
         ) : null}
 
-        {hasCompletedImportForActiveSchoolYear ? (
-          <div className="mt-5 grid gap-4 lg:grid-cols-[150px_minmax(0,1fr)] lg:items-center">
-            <div className="mx-auto w-full max-w-[150px] lg:mx-0">
-              <CsvImportSuccessAnimation className="h-auto" />
+        <section className="mt-5 rounded-[24px] border border-primary/15 bg-primary/5 px-4 py-4 sm:px-5">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-primaryLight">
+                Campagne en cours
+              </p>
+              <h2 className="mt-2 font-serif text-[1.7rem] text-slate-900">
+                Année scolaire {activeSchoolYearLabel}
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-slate-700">
+                {hasCompletedImportForActiveSchoolYear
+                  ? "Un import a déjà été réalisé pour cette campagne. Vous pouvez ajouter un nouveau fichier CSV contenant uniquement les demandes reçues ultérieurement. Les doublons seront détectés automatiquement."
+                  : "Aucun import réussi n'est encore enregistré pour cette année active. Le prochain fichier lancera l'import initial de la campagne."}
+              </p>
             </div>
-            <SuccessFeedback
-              title="Import terminé"
-              description={
-                activeSchoolYearImport
-                  ? `Un import CSV réussi est déjà enregistré pour l'année scolaire ${activeSchoolYearLabel}. Dernier import : ${dateTimeFormatter.format(new Date(activeSchoolYearImport.createdAt))}.`
-                  : `Un import CSV réussi est déjà enregistré pour l'année scolaire ${activeSchoolYearLabel}.`
-              }
-            />
+            {activeSchoolYearImport ? (
+              <div className="shrink-0 rounded-2xl border border-primary/15 bg-white/80 px-4 py-3 text-sm text-slate-700">
+                <span className="block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                  Dernier import
+                </span>
+                <span className="mt-1 block font-medium text-slate-900">
+                  {dateTimeFormatter.format(new Date(activeSchoolYearImport.createdAt))}
+                </span>
+                <span className="mt-1 block truncate text-slate-500">
+                  {activeSchoolYearImport.fileName ?? "Fichier non renseigné"}
+                </span>
+              </div>
+            ) : null}
           </div>
-        ) : null}
+        </section>
 
         <form
           className="ui-animate-in mt-6"
@@ -1043,7 +1146,7 @@ const ImportCsvPage = () => {
                   >
                     <UploadIcon className="h-5 w-5" />
                     {hasCompletedImportForActiveSchoolYear
-                      ? "Import déjà effectué"
+                      ? "Importer de nouvelles demandes"
                       : "Choisir un fichier"}
                   </button>
                   <p className="text-base text-slate-500">Format accepté : .csv</p>
@@ -1064,7 +1167,9 @@ const ImportCsvPage = () => {
                 <p className="mt-1 text-sm text-slate-500">
                   {selectedFile
                     ? `${formatFileSize(selectedFile.size)} · prêt pour l'import`
-                    : "Ajoutez un CSV exporté depuis le formulaire pour démarrer."}
+                    : hasCompletedImportForActiveSchoolYear
+                      ? "Ajoutez un CSV contenant uniquement les demandes reçues après le premier import."
+                      : "Ajoutez un CSV exporté depuis le formulaire pour démarrer."}
                 </p>
               </div>
 
@@ -1094,7 +1199,7 @@ const ImportCsvPage = () => {
                   {isSubmitting
                     ? "Import en cours..."
                     : hasCompletedImportForActiveSchoolYear
-                      ? "Import déjà terminé"
+                      ? "Ajouter à la campagne"
                       : "Lancer l'import"}
                 </button>
               </div>
@@ -1206,15 +1311,15 @@ const ImportCsvPage = () => {
 
             <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-6">
               <SummaryMetric
-                label="Familles"
+                label="Familles traitées"
                 value={getImportedFamiliesCount(latestImport)}
               />
               <SummaryMetric
-                label="Demandes"
+                label="Demandes ajoutées"
                 value={latestImport.importedApplications}
               />
-              <SummaryMetric label="Élèves" value={latestImport.importedStudents} />
-              <SummaryMetric label="Ignorées" value={latestImport.skippedRows} />
+              <SummaryMetric label="Élèves ajoutés" value={latestImport.importedStudents} />
+              <SummaryMetric label="Lignes ignorées" value={latestImport.skippedRows} />
               <SummaryMetric
                 label="Doublons exacts"
                 value={getDuplicateRowsCount(latestImport)}

--- a/apps/web/src/types/import.ts
+++ b/apps/web/src/types/import.ts
@@ -33,6 +33,8 @@ export type CsvImportHistoryItem = {
 
 export type CsvImportSummary = {
   importedFamilies: number;
+  createdFamilies?: number;
+  reusedFamilies?: number;
   importedApplications: number;
   importedStudents: number;
   skippedRows: number;

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -357,26 +357,30 @@ const ensureLevels = async () => {
 
 const ensureActiveSchoolYear = async () =>
   prisma.$transaction(async (tx) => {
-    await tx.schoolYear.updateMany({
-      where: {
-        isActive: true,
-        NOT: {
-          label: ACTIVE_SCHOOL_YEAR.label
-        }
-      },
-      data: {
-        isActive: false
-      }
+    const existingSchoolYear = await tx.schoolYear.findUnique({
+      where: { label: ACTIVE_SCHOOL_YEAR.label }
     });
 
-    return tx.schoolYear.upsert({
-      where: { label: ACTIVE_SCHOOL_YEAR.label },
-      update: {
-        startYear: ACTIVE_SCHOOL_YEAR.startYear,
-        endYear: ACTIVE_SCHOOL_YEAR.endYear,
-        isActive: ACTIVE_SCHOOL_YEAR.isActive
-      },
-      create: ACTIVE_SCHOOL_YEAR
+    if (existingSchoolYear) {
+      return tx.schoolYear.update({
+        where: { id: existingSchoolYear.id },
+        data: {
+          startYear: ACTIVE_SCHOOL_YEAR.startYear,
+          endYear: ACTIVE_SCHOOL_YEAR.endYear
+        }
+      });
+    }
+
+    const existingActiveSchoolYear = await tx.schoolYear.findFirst({
+      where: { isActive: true },
+      select: { id: true }
+    });
+
+    return tx.schoolYear.create({
+      data: {
+        ...ACTIVE_SCHOOL_YEAR,
+        isActive: existingActiveSchoolYear ? false : ACTIVE_SCHOOL_YEAR.isActive
+      }
     });
   });
 
@@ -386,10 +390,7 @@ const ensureFamily = async (tx, familyData) => {
   });
 
   if (existingFamily) {
-    return tx.family.update({
-      where: { id: existingFamily.id },
-      data: familyData
-    });
+    return existingFamily;
   }
 
   return tx.family.create({
@@ -401,20 +402,17 @@ const ensureApplicationBundle = async (levelIdsByCode, schoolYearId, seedRecord)
   await prisma.$transaction(async (tx) => {
     const family = await ensureFamily(tx, seedRecord.family);
 
-    const application = await tx.application.upsert({
+    const existingApplication = await tx.application.findUnique({
       where: { rawCsvRowHash: seedRecord.application.rawCsvRowHash },
-      update: {
-        familyId: family.id,
-        schoolYearId,
-        submittedAt: seedRecord.application.submittedAt,
-        declaredChildrenCount: seedRecord.application.declaredChildrenCount,
-        discoverySource: seedRecord.application.discoverySource,
-        status: seedRecord.application.status,
-        isPriority: seedRecord.application.isPriority,
-        decisionAt: seedRecord.application.decisionAt,
-        decisionNote: seedRecord.application.decisionNote
-      },
-      create: {
+      select: { id: true }
+    });
+
+    if (existingApplication) {
+      return;
+    }
+
+    const application = await tx.application.create({
+      data: {
         familyId: family.id,
         schoolYearId,
         submittedAt: seedRecord.application.submittedAt,
@@ -426,14 +424,6 @@ const ensureApplicationBundle = async (levelIdsByCode, schoolYearId, seedRecord)
         decisionNote: seedRecord.application.decisionNote,
         rawCsvRowHash: seedRecord.application.rawCsvRowHash
       }
-    });
-
-    await tx.applicationEmailLog.deleteMany({
-      where: { applicationId: application.id }
-    });
-
-    await tx.student.deleteMany({
-      where: { applicationId: application.id }
     });
 
     await tx.student.createMany({


### PR DESCRIPTION
## 🎯 Objectif

Permettre l’ajout de nouvelles demandes CSV sur une campagne d’inscription déjà active, sans écraser les données existantes.

Cette PR corrige le flux d’import complémentaire et sécurise également le seed Prisma, qui pouvait recréer ou remplacer des données au redémarrage Docker.

## ✅ Changements principaux

### Import CSV complémentaire

- Suppression du blocage global lorsqu’un import existe déjà pour l’année active.
- L’import utilise toujours l’année scolaire active.
- Les imports successifs deviennent cumulatifs.
- Les lignes déjà importées sont détectées via `rawCsvRowHash`.
- Les doublons exacts sont comptés sans recréation.
- Les familles existantes sont réutilisées par email.
- Les familles existantes ne sont plus mises à jour pendant l’import pour éviter d’écraser téléphone, adresse ou statut familial.
- Les nouvelles demandes et les nouveaux élèves sont uniquement créés si la ligne CSV est nouvelle.
- L’historique `CsvImportLog` est créé dans la même transaction Prisma que les insertions.
- La réponse API expose maintenant `createdFamilies` et `reusedFamilies`.

### Page Import CSV

- Distinction claire entre import initial et import complémentaire.
- Ajout d’un bloc `Campagne en cours`.
- Affichage de l’année active et du dernier import.
- Remplacement de `Import déjà effectué` par une action claire :
  - `Importer de nouvelles demandes`
  - `Ajouter à la campagne`
- Ajout d’une confirmation dédiée pour l’import complémentaire.
- Résumé d’import clarifié :
  - `Demandes ajoutées`
  - `Élèves ajoutés`
  - `Lignes ignorées`
  - `Doublons exacts`
  - `Familles en double`

### Seed Prisma

- Correction du seed pour le rendre non destructif.
- Le seed ne force plus une autre année active si une campagne active existe déjà.
- Le seed ne met plus à jour les familles existantes.
- Le seed ne met plus à jour les demandes existantes.
- Le seed ne supprime plus les élèves.
- Le seed ne supprime plus les historiques email.
- Le seed crée uniquement les données manquantes.

## 🧪 Tests effectués

### Vérifications techniques

- `npm run build -w apps/api`
- `npm exec -w apps/web -- tsc -b`
- `npm run build -w apps/web`

### Tests API Docker locale

Scénario A :
- Avant : 115 demandes / 219 élèves.
- Import A1 : +2 demandes.
- Import A2 : +1 demande.
- Après : 118 demandes / 222 élèves.

Scénario B :
- Réimport du même CSV.
- 0 ajout.
- 1 doublon exact.
- Compteurs inchangés.

Scénario C :
- Même famille avec nouvelle demande.
- `reusedFamilies=1`.
- +1 demande / +1 élève.
- Les champs de la famille existante restent inchangés.

Validation seed :
- Le seed relancé deux fois ne modifie plus les compteurs.
- Les imports existants ne sont plus écrasés au redémarrage Docker.

## 📌 Notes

Le problème d’écrasement venait de deux sources :
1. la logique d’import complémentaire ;
2. le seed Prisma exécuté automatiquement au démarrage Docker.

Les deux points sont corrigés dans cette PR.