### PR TITLE
feat: ajouter la page des e-mails de décision prêts à envoyer

### DIFF
--- a/apps/api/src/controllers/application.controller.ts
+++ b/apps/api/src/controllers/application.controller.ts
@@ -2,6 +2,7 @@ import {
   ApplicationStatus,
   EmailSendStatus,
   EmailType,
+  StudentAdmissionStatus,
   type Prisma
 } from "@prisma/client";
 import type { Request, Response } from "express";
@@ -40,16 +41,14 @@ const isApplicationStatus = (value: string): value is ApplicationStatus => {
   return Object.values(ApplicationStatus).includes(value as ApplicationStatus);
 };
 
-type StudentAdmissionStatus = "PENDING" | "ACCEPTED" | "REFUSED" | "WAITLISTED";
-const studentAdmissionStatuses: StudentAdmissionStatus[] = [
-  "PENDING",
-  "ACCEPTED",
-  "REFUSED",
-  "WAITLISTED"
+const visibleStudentAdmissionStatuses: StudentAdmissionStatus[] = [
+  StudentAdmissionStatus.PENDING,
+  StudentAdmissionStatus.ACCEPTED,
+  StudentAdmissionStatus.WAITLISTED
 ];
 
 const isStudentAdmissionStatus = (value: string): value is StudentAdmissionStatus => {
-  return studentAdmissionStatuses.includes(value as StudentAdmissionStatus);
+  return visibleStudentAdmissionStatuses.includes(value as StudentAdmissionStatus);
 };
 
 type ApplicationDecisionStatus = "ACCEPTED" | "WAITLISTED";
@@ -58,6 +57,7 @@ type ApplicationEmailType =
   | "WAITLIST"
   | "PARTIAL_DECISION"
   | "CUSTOM";
+type ReadyApplicationEmailType = Exclude<ApplicationEmailType, "CUSTOM">;
 
 const isApplicationDecisionStatus = (
   value: string
@@ -125,6 +125,44 @@ const getDecisionStatusFromEmailType = (
   return null;
 };
 
+const getRecommendedEmailTypeFromStudents = (
+  students: Array<{ admissionStatus: StudentAdmissionStatus }>
+): ReadyApplicationEmailType | null => {
+  if (students.length === 0) {
+    return null;
+  }
+
+  const allAccepted = students.every(
+    (student) => student.admissionStatus === StudentAdmissionStatus.ACCEPTED
+  );
+
+  if (allAccepted) {
+    return EmailType.ACCEPTANCE;
+  }
+
+  const allWaitlisted = students.every(
+    (student) => student.admissionStatus === StudentAdmissionStatus.WAITLISTED
+  );
+
+  if (allWaitlisted) {
+    return EmailType.WAITLIST;
+  }
+
+  const allReady = students.every(
+    (student) =>
+      student.admissionStatus === StudentAdmissionStatus.ACCEPTED ||
+      student.admissionStatus === StudentAdmissionStatus.WAITLISTED
+  );
+
+  return allReady ? EmailType.PARTIAL_DECISION : null;
+};
+
+const decisionEmailTypes = [
+  EmailType.ACCEPTANCE,
+  EmailType.WAITLIST,
+  EmailType.PARTIAL_DECISION
+] as const;
+
 const getRecalculatedApplicationStatus = (
   currentStatus: ApplicationStatus,
   students: Array<{ admissionStatus: StudentAdmissionStatus }>
@@ -133,18 +171,8 @@ const getRecalculatedApplicationStatus = (
     return currentStatus;
   }
 
-  const allPending = students.every(
-    (student) => student.admissionStatus === "PENDING"
-  );
-
-  if (allPending) {
-    return currentStatus === ApplicationStatus.IN_REVIEW
-      ? currentStatus
-      : ApplicationStatus.IN_REVIEW;
-  }
-
   const allAccepted = students.every(
-    (student) => student.admissionStatus === "ACCEPTED"
+    (student) => student.admissionStatus === StudentAdmissionStatus.ACCEPTED
   );
 
   if (allAccepted) {
@@ -153,8 +181,8 @@ const getRecalculatedApplicationStatus = (
 
   const allWaitlisted = students.every(
     (student) =>
-      student.admissionStatus === "WAITLISTED" ||
-      student.admissionStatus === "REFUSED"
+      student.admissionStatus === StudentAdmissionStatus.WAITLISTED ||
+      student.admissionStatus === StudentAdmissionStatus.REFUSED
   );
 
   if (allWaitlisted) {
@@ -162,15 +190,15 @@ const getRecalculatedApplicationStatus = (
   }
 
   const hasAccepted = students.some(
-    (student) => student.admissionStatus === "ACCEPTED"
+    (student) => student.admissionStatus === StudentAdmissionStatus.ACCEPTED
   );
   const hasWaitlisted = students.some(
     (student) =>
-      student.admissionStatus === "WAITLISTED" ||
-      student.admissionStatus === "REFUSED"
+      student.admissionStatus === StudentAdmissionStatus.WAITLISTED ||
+      student.admissionStatus === StudentAdmissionStatus.REFUSED
   );
   const hasPending = students.some(
-    (student) => student.admissionStatus === "PENDING"
+    (student) => student.admissionStatus === StudentAdmissionStatus.PENDING
   );
 
   if (hasAccepted && hasWaitlisted) {
@@ -291,6 +319,104 @@ export const getApplications = async (req: Request, res: Response): Promise<void
   });
 
   res.status(200).json(applications);
+};
+
+export const getApplicationsReadyForEmail = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  const requestedSchoolYearId = getQueryParam(req.query.schoolYearId);
+  const activeSchoolYear = requestedSchoolYearId
+    ? null
+    : await prisma.schoolYear.findFirst({
+        where: { isActive: true },
+        select: { id: true },
+        orderBy: { startYear: "desc" }
+      });
+  const schoolYearId = requestedSchoolYearId ?? activeSchoolYear?.id;
+
+  if (!schoolYearId) {
+    res.status(200).json([]);
+    return;
+  }
+
+  const applications = await prisma.application.findMany({
+    where: {
+      schoolYearId,
+      students: {
+        some: {},
+        every: {
+          admissionStatus: {
+            in: [StudentAdmissionStatus.ACCEPTED, StudentAdmissionStatus.WAITLISTED]
+          }
+        }
+      }
+    },
+    orderBy: { updatedAt: "desc" },
+    include: {
+      family: true,
+      students: {
+        orderBy: [{ rankInForm: "asc" }, { createdAt: "asc" }],
+        include: {
+          level: true
+        }
+      },
+      emailLogs: {
+        where: {
+          sendStatus: EmailSendStatus.SENT,
+          emailType: {
+            in: [...decisionEmailTypes]
+          }
+        },
+        orderBy: [{ sentAt: "desc" }, { createdAt: "desc" }]
+      }
+    }
+  });
+
+  res.status(200).json(
+    applications
+      .map((application) => {
+        const recommendedEmailType = getRecommendedEmailTypeFromStudents(
+          application.students
+        );
+
+        if (!recommendedEmailType) {
+          return null;
+        }
+
+        const lastSentEmailLog = application.emailLogs[0] ?? null;
+
+        return {
+          id: application.id,
+          status: application.status,
+          decisionAt: application.decisionAt,
+          family: {
+            fatherLastName: application.family.fatherLastName,
+            fatherFirstName: application.family.fatherFirstName,
+            motherLastName: application.family.motherLastName,
+            motherFirstName: application.family.motherFirstName,
+            contactEmail: application.family.contactEmail,
+            contactPhone: application.family.contactPhone
+          },
+          students: application.students.map((student) => ({
+            id: student.id,
+            firstName: student.firstName,
+            lastName: student.lastName,
+            admissionStatus: student.admissionStatus,
+            level: {
+              code: student.level.code,
+              label: student.level.label
+            }
+          })),
+          recommendedEmailType,
+          hasSentEmail: Boolean(lastSentEmailLog),
+          lastEmailSentAt: lastSentEmailLog?.sentAt ?? lastSentEmailLog?.createdAt ?? null
+        };
+      })
+      .filter((application): application is NonNullable<typeof application> =>
+        application !== null
+      )
+  );
 };
 
 export const getApplicationById = async (req: Request, res: Response): Promise<void> => {

--- a/apps/api/src/routes/application.routes.ts
+++ b/apps/api/src/routes/application.routes.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 
 import {
   getApplicationEmailLogs,
+  getApplicationsReadyForEmail,
   updateApplicationDecision,
   getApplicationById,
   getApplications,
@@ -10,16 +11,25 @@ import {
   updateApplicationPriority,
   updateApplicationStatus
 } from "../controllers/application.controller";
+import {
+  getStudentById,
+  getStudents,
+  updateStudentPriority
+} from "../controllers/student.controller";
 
 const router = Router();
 
 router.get("/applications", getApplications);
+router.get("/applications/ready-for-email", getApplicationsReadyForEmail);
 router.get("/applications/:id", getApplicationById);
 router.get("/applications/:id/email-logs", getApplicationEmailLogs);
 router.patch("/applications/:id/status", updateApplicationStatus);
 router.patch("/applications/:id/priority", updateApplicationPriority);
 router.patch("/applications/:id/decision", updateApplicationDecision);
 router.post("/applications/:id/send-email", sendApplicationEmail);
+router.get("/students", getStudents);
+router.get("/students/:id", getStudentById);
+router.patch("/students/:id/priority", updateStudentPriority);
 router.patch("/students/:id/admission-status", updateStudentAdmissionStatus);
 
 export default router;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,11 +10,13 @@ import ApplicationDetailPage from "./pages/ApplicationDetailPage";
 import ApplicationEmailPage from "./pages/ApplicationEmailPage";
 import ApplicationsPage from "./pages/ApplicationsPage";
 import DashboardPage from "./pages/DashboardPage";
+import EmailsPage from "./pages/EmailsPage";
 import ForgotPasswordPage from "./pages/ForgotPasswordPage";
 import ImportCsvPage from "./pages/ImportCsvPage";
 import LoginPage from "./pages/LoginPage";
 import ResetPasswordPage from "./pages/ResetPasswordPage";
 import SchoolYearsPage from "./pages/SchoolYearsPage";
+import StudentDetailPage from "./pages/StudentDetailPage";
 import StudentsPage from "./pages/StudentsPage";
 
 const NotFoundPage = () => {
@@ -43,7 +45,7 @@ const NotFoundPage = () => {
               to="/applications"
               className="inline-flex items-center rounded-full border border-slate-300 px-5 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
             >
-              Ouvrir les demandes
+              Ouvrir les familles
             </Link>
           </div>
         </div>
@@ -68,7 +70,9 @@ function App() {
             <Route path="applications" element={<ApplicationsPage />} />
             <Route path="applications/:id/email" element={<ApplicationEmailPage />} />
             <Route path="applications/:id" element={<ApplicationDetailPage />} />
+            <Route path="emails" element={<EmailsPage />} />
             <Route path="students" element={<StudentsPage />} />
+            <Route path="students/:id" element={<StudentDetailPage />} />
             <Route path="imports">
               <Route index element={<Navigate to="new" replace />} />
               <Route path="new" element={<ImportCsvPage />} />

--- a/apps/web/src/components/layout/AppLayout.tsx
+++ b/apps/web/src/components/layout/AppLayout.tsx
@@ -1,8 +1,9 @@
-import type { CSSProperties } from "react";
+import { useEffect, useState, type CSSProperties } from "react";
 
-import { NavLink, Outlet, useNavigate } from "react-router-dom";
+import { NavLink, Outlet, useLocation, useNavigate } from "react-router-dom";
 
 import { useAuth } from "../../hooks/useAuth";
+import { getReadyEmailApplications } from "../../lib/api";
 import FirstRunOnboarding from "./FirstRunOnboarding";
 import SiteFooter from "./SiteFooter";
 
@@ -11,7 +12,13 @@ type IconProps = {
 };
 
 type NavigationItem = {
-  key: "dashboard" | "applications" | "students" | "imports" | "schoolYears";
+  key:
+    | "dashboard"
+    | "applications"
+    | "emails"
+    | "students"
+    | "imports"
+    | "schoolYears";
   label: string;
   to?: string;
   end?: boolean;
@@ -56,6 +63,15 @@ const FolderIcon = ({ className = "h-5 w-5" }: IconProps) => {
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className={className}>
       <path d="M4 7.5A2.5 2.5 0 0 1 6.5 5h3l1.6 1.8h6.4A2.5 2.5 0 0 1 20 9.3v7.2A2.5 2.5 0 0 1 17.5 19h-11A2.5 2.5 0 0 1 4 16.5v-9Z" />
       <path d="M7.5 12h9" strokeLinecap="round" />
+    </svg>
+  );
+};
+
+const MailIcon = ({ className = "h-5 w-5" }: IconProps) => {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className={className}>
+      <rect x="4" y="6" width="16" height="12" rx="2.5" />
+      <path d="m5.5 8 6.5 5 6.5-5" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   );
 };
@@ -108,16 +124,22 @@ const navigationItems: NavigationItem[] = [
     icon: DashboardIcon
   },
   {
-    key: "applications",
-    label: "Demandes",
-    to: "/applications",
-    icon: FolderIcon
-  },
-  {
     key: "students",
     label: "Élèves",
     to: "/students",
     icon: StudentsIcon
+  },
+  {
+    key: "applications",
+    label: "Familles",
+    to: "/applications",
+    icon: FolderIcon
+  },
+  {
+    key: "emails",
+    label: "E-mail",
+    to: "/emails",
+    icon: MailIcon
   },
   {
     key: "imports",
@@ -133,11 +155,26 @@ const navigationItems: NavigationItem[] = [
   }
 ];
 
-const SidebarLink = ({ item }: { item: NavigationItem }) => {
+const SidebarLink = ({
+  item,
+  pendingEmailCount
+}: {
+  item: NavigationItem;
+  pendingEmailCount: number;
+}) => {
+  const shouldShowPendingEmailBadge = item.key === "emails" && pendingEmailCount > 0;
   const content = (
     <>
       <item.icon className="h-5 w-5 shrink-0" />
-      <span>{item.label}</span>
+      <span className="min-w-0 flex-1">{item.label}</span>
+      {shouldShowPendingEmailBadge ? (
+        <span
+          aria-label={`${pendingEmailCount} email${pendingEmailCount > 1 ? "s" : ""} en attente d'envoi`}
+          className="ml-auto inline-flex min-h-6 min-w-6 shrink-0 items-center justify-center rounded-full border border-white/30 bg-secondary px-2 text-xs font-bold tabular-nums text-white shadow-[0_10px_22px_-14px_rgba(212,162,76,0.95)]"
+        >
+          {pendingEmailCount > 99 ? "99+" : pendingEmailCount}
+        </span>
+      ) : null}
     </>
   );
 
@@ -171,7 +208,39 @@ const SidebarLink = ({ item }: { item: NavigationItem }) => {
 
 const AppLayout = () => {
   const { logout } = useAuth();
+  const location = useLocation();
   const navigate = useNavigate();
+  const [pendingEmailCount, setPendingEmailCount] = useState(0);
+  const isStudentDetailPage = /^\/students\/[^/]+$/u.test(location.pathname);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const loadPendingEmailCount = async (): Promise<void> => {
+      try {
+        const readyApplications = await getReadyEmailApplications(
+          {},
+          { signal: controller.signal }
+        );
+
+        setPendingEmailCount(
+          readyApplications.filter((application) => !application.hasSentEmail).length
+        );
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+
+        setPendingEmailCount(0);
+      }
+    };
+
+    void loadPendingEmailCount();
+
+    return () => {
+      controller.abort();
+    };
+  }, [location.pathname]);
 
   const handleLogout = (): void => {
     logout();
@@ -234,7 +303,11 @@ const AppLayout = () => {
             <div className="p-4">
               <nav className="mb-[100px] space-y-3" aria-label="Navigation principale">
                 {navigationItems.map((item) => (
-                  <SidebarLink key={item.key} item={item} />
+                  <SidebarLink
+                    key={item.key}
+                    item={item}
+                    pendingEmailCount={pendingEmailCount}
+                  />
                 ))}
               </nav>
 
@@ -251,13 +324,17 @@ const AppLayout = () => {
 
           <div className="flex min-h-[calc(100vh-164px)] flex-col gap-6">
             <main
-              className="overflow-hidden rounded-[34px] border border-[#e8ddd1] px-5 py-5 shadow-[0_26px_58px_-42px_rgba(15,23,42,0.28)] sm:px-6 lg:flex-1 lg:px-10 lg:py-8"
+              className={`overflow-hidden rounded-[34px] border border-[#e8ddd1] px-5 py-5 shadow-[0_26px_58px_-42px_rgba(15,23,42,0.28)] sm:px-6 lg:px-10 lg:py-8 ${
+                isStudentDetailPage ? "" : "lg:flex-1"
+              }`}
               style={paperTextureStyle}
             >
               <Outlet />
             </main>
 
-            <SiteFooter />
+            <div className="mt-auto">
+              <SiteFooter />
+            </div>
           </div>
         </div>
       </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -6,14 +6,21 @@ import type {
   ApplicationFilterParams,
   ApplicationEmailLog,
   ApplicationListItem,
+  LevelCapacitySummary,
   LevelSummary,
   ApplicationPriorityUpdateResult,
   ApplicationStatus,
   ApplicationStatusUpdateResult,
   CreateSchoolYearPayload,
   SchoolYearSummary,
+  StudentFilterParams,
   StudentAdmissionStatus,
-  StudentAdmissionStatusUpdateResult
+  StudentListItem,
+  StudentListResponse,
+  StudentAdmissionStatusUpdateResult,
+  UpdateLevelCapacitiesPayload,
+  ReadyEmailApplication,
+  ReadyEmailApplicationFilterParams
 } from "../types/application";
 import type { DashboardStats } from "../types/dashboard";
 import type { CsvImportHistoryItem, CsvImportPreview, CsvImportSummary } from "../types/import";
@@ -166,6 +173,33 @@ export const getApplications = async (
   return fetchJson<ApplicationListItem[]>(`/api/applications${queryString}`, init);
 };
 
+export const getStudents = async (
+  params: StudentFilterParams = {},
+  init?: RequestInit
+): Promise<StudentListResponse> => {
+  const queryString = buildQueryString({
+    search: params.search,
+    status: params.status,
+    levelId: params.levelId,
+    schoolYearId: params.schoolYearId,
+    isPriority: params.isPriority,
+    familyId: params.familyId,
+    page: params.page,
+    limit: params.limit,
+    sortBy: params.sortBy,
+    sortOrder: params.sortOrder
+  });
+
+  return fetchJson<StudentListResponse>(`/api/students${queryString}`, init);
+};
+
+export const getStudentById = async (
+  studentId: string,
+  init?: RequestInit
+): Promise<StudentListItem> => {
+  return fetchJson<StudentListItem>(`/api/students/${encodeURIComponent(studentId)}`, init);
+};
+
 export const getLevels = async (init?: RequestInit): Promise<LevelSummary[]> => {
   return fetchJson<LevelSummary[]>("/api/levels", init);
 };
@@ -186,6 +220,20 @@ export const getApplicationEmailLogs = async (
 ): Promise<ApplicationEmailLog[]> => {
   return fetchJson<ApplicationEmailLog[]>(
     `/api/applications/${encodeURIComponent(applicationId)}/email-logs`,
+    init
+  );
+};
+
+export const getReadyEmailApplications = async (
+  params: ReadyEmailApplicationFilterParams = {},
+  init?: RequestInit
+): Promise<ReadyEmailApplication[]> => {
+  const queryString = buildQueryString({
+    schoolYearId: params.schoolYearId
+  });
+
+  return fetchJson<ReadyEmailApplication[]>(
+    `/api/applications/ready-for-email${queryString}`,
     init
   );
 };
@@ -285,6 +333,25 @@ export const updateStudentAdmissionStatus = async (
   );
 };
 
+export const updateStudentPriority = async (
+  studentId: string,
+  isPriority: boolean,
+  init?: RequestInit
+): Promise<StudentListItem> => {
+  return fetchJson<StudentListItem>(
+    `/api/students/${encodeURIComponent(studentId)}/priority`,
+    {
+      ...init,
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        ...init?.headers
+      },
+      body: JSON.stringify({ isPriority })
+    }
+  );
+};
+
 export const getSchoolYears = async (
   init?: RequestInit
 ): Promise<SchoolYearSummary[]> => {
@@ -295,6 +362,35 @@ export const getActiveSchoolYear = async (
   init?: RequestInit
 ): Promise<SchoolYearSummary> => {
   return fetchJson<SchoolYearSummary>("/api/school-years/active", init);
+};
+
+export const getSchoolYearLevelCapacities = async (
+  schoolYearId: string,
+  init?: RequestInit
+): Promise<LevelCapacitySummary[]> => {
+  return fetchJson<LevelCapacitySummary[]>(
+    `/api/school-years/${encodeURIComponent(schoolYearId)}/level-capacities`,
+    init
+  );
+};
+
+export const updateSchoolYearLevelCapacities = async (
+  schoolYearId: string,
+  payload: UpdateLevelCapacitiesPayload,
+  init?: RequestInit
+): Promise<LevelCapacitySummary[]> => {
+  return fetchJson<LevelCapacitySummary[]>(
+    `/api/school-years/${encodeURIComponent(schoolYearId)}/level-capacities`,
+    {
+      ...init,
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        ...init?.headers
+      },
+      body: JSON.stringify(payload)
+    }
+  );
 };
 
 export const createSchoolYear = async (

--- a/apps/web/src/pages/EmailsPage.tsx
+++ b/apps/web/src/pages/EmailsPage.tsx
@@ -1,0 +1,411 @@
+import { useEffect, useMemo, useState, type ChangeEvent } from "react";
+import { Link } from "react-router-dom";
+
+import PageSectionHeader from "../components/layout/PageSectionHeader";
+import EmptyState from "../components/ui/EmptyState";
+import ErrorState from "../components/ui/ErrorState";
+import LoadingState from "../components/ui/LoadingState";
+import StatusBadge from "../components/ui/StatusBadge";
+import { getReadyEmailApplications } from "../lib/api";
+import { applicationEmailTypeLabels } from "../lib/applicationEmail";
+import type {
+  ReadyEmailApplication,
+  ReadyEmailApplicationStudent,
+  ReadyEmailType
+} from "../types/application";
+
+type EmailFilter = "ALL" | ReadyEmailType | "UNSENT" | "SENT";
+
+type FilterOption = {
+  label: string;
+  value: EmailFilter;
+};
+
+const filterOptions: FilterOption[] = [
+  { value: "ALL", label: "Toutes" },
+  { value: "ACCEPTANCE", label: "Acceptation" },
+  { value: "WAITLIST", label: "Liste d'attente" },
+  { value: "PARTIAL_DECISION", label: "Décision partielle" },
+  { value: "UNSENT", label: "Non envoyées" },
+  { value: "SENT", label: "Déjà envoyées" }
+];
+
+const emailTypeBadgeStyles: Record<ReadyEmailType, string> = {
+  ACCEPTANCE: "bg-success/15 text-success ring-success/20",
+  WAITLIST: "bg-info/15 text-info ring-info/20",
+  PARTIAL_DECISION: "bg-secondary/15 text-secondaryDark ring-secondary/25"
+};
+
+const studentStatusLabels: Record<ReadyEmailApplicationStudent["admissionStatus"], string> = {
+  ACCEPTED: "Accepté",
+  WAITLISTED: "Liste d'attente"
+};
+
+const studentStatusStyles: Record<ReadyEmailApplicationStudent["admissionStatus"], string> = {
+  ACCEPTED: "bg-success/15 text-success ring-success/20",
+  WAITLISTED: "bg-info/15 text-info ring-info/20"
+};
+
+const dateTimeFormatter = new Intl.DateTimeFormat("fr-FR", {
+  dateStyle: "medium",
+  timeStyle: "short"
+});
+
+const normalizeSearchText = (value: string): string => {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/gu, "")
+    .toLowerCase();
+};
+
+const formatOptionalDateTime = (value: string | null): string => {
+  return value ? dateTimeFormatter.format(new Date(value)) : "Non envoyé";
+};
+
+const formatParentName = (
+  firstName: string | null | undefined,
+  lastName: string | null | undefined
+): string | null => {
+  const parts = [firstName, lastName].filter(
+    (value): value is string =>
+      typeof value === "string" && value.trim().length > 0
+  );
+
+  return parts.length > 0 ? parts.join(" ") : null;
+};
+
+const getFamilyTitle = (application: ReadyEmailApplication): string => {
+  const parents = [
+    formatParentName(
+      application.family.fatherFirstName,
+      application.family.fatherLastName
+    ),
+    formatParentName(
+      application.family.motherFirstName,
+      application.family.motherLastName
+    )
+  ].filter((value): value is string => value !== null);
+
+  if (parents.length > 0) {
+    return parents.join(" / ");
+  }
+
+  const firstStudent = application.students[0];
+
+  return firstStudent
+    ? `Famille ${firstStudent.lastName}`
+    : "Famille non renseignée";
+};
+
+const getApplicationSearchText = (application: ReadyEmailApplication): string => {
+  return normalizeSearchText(
+    [
+      getFamilyTitle(application),
+      application.family.contactEmail,
+      application.family.contactPhone,
+      ...application.students.flatMap((student) => [
+        student.firstName,
+        student.lastName,
+        student.level.code,
+        student.level.label
+      ])
+    ]
+      .filter(Boolean)
+      .join(" ")
+  );
+};
+
+const SummaryCard = ({
+  label,
+  value,
+  tone = "default"
+}: {
+  label: string;
+  value: number;
+  tone?: "default" | "success" | "info" | "gold";
+}) => {
+  const toneClassNames = {
+    default: "border-primary/10 bg-white text-primaryDark",
+    success: "border-success/20 bg-success/10 text-success",
+    info: "border-info/20 bg-info/10 text-info",
+    gold: "border-secondary/30 bg-secondary/15 text-secondaryDark"
+  };
+
+  return (
+    <article className={`rounded-[26px] border p-5 shadow-[0_18px_36px_-32px_rgba(15,23,42,0.35)] ${toneClassNames[tone]}`}>
+      <p className="text-3xl font-semibold">{value}</p>
+      <p className="mt-2 text-xs font-semibold uppercase tracking-[0.2em]">
+        {label}
+      </p>
+    </article>
+  );
+};
+
+const EmailsPage = () => {
+  const [applications, setApplications] = useState<ReadyEmailApplication[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [filter, setFilter] = useState<EmailFilter>("ALL");
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const loadApplications = async (): Promise<void> => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const readyApplications = await getReadyEmailApplications(
+          {},
+          { signal: controller.signal }
+        );
+
+        setApplications(readyApplications);
+      } catch (loadError) {
+        if (loadError instanceof DOMException && loadError.name === "AbortError") {
+          return;
+        }
+
+        setError(
+          loadError instanceof Error
+            ? loadError.message
+            : "Impossible de charger les demandes prêtes pour email."
+        );
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadApplications();
+
+    return () => {
+      controller.abort();
+    };
+  }, []);
+
+  const summary = useMemo(() => {
+    return {
+      total: applications.length,
+      accepted: applications.filter(
+        (application) => application.recommendedEmailType === "ACCEPTANCE"
+      ).length,
+      waitlisted: applications.filter(
+        (application) => application.recommendedEmailType === "WAITLIST"
+      ).length,
+      partial: applications.filter(
+        (application) => application.recommendedEmailType === "PARTIAL_DECISION"
+      ).length,
+      sent: applications.filter((application) => application.hasSentEmail).length
+    };
+  }, [applications]);
+
+  const displayedApplications = useMemo(() => {
+    const normalizedSearch = normalizeSearchText(search.trim());
+
+    return applications.filter((application) => {
+      const matchesFilter =
+        filter === "ALL" ||
+        (filter === "UNSENT" && !application.hasSentEmail) ||
+        (filter === "SENT" && application.hasSentEmail) ||
+        application.recommendedEmailType === filter;
+
+      if (!matchesFilter) {
+        return false;
+      }
+
+      return (
+        normalizedSearch.length === 0 ||
+        getApplicationSearchText(application).includes(normalizedSearch)
+      );
+    });
+  }, [applications, filter, search]);
+
+  const handleSearchChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    setSearch(event.target.value);
+  };
+
+  if (isLoading) {
+    return (
+      <>
+        <PageSectionHeader
+          eyebrow="E-mail"
+          title="E-mails de décision"
+          description="Demandes prêtes pour l'envoi aux familles."
+        />
+        <LoadingState />
+      </>
+    );
+  }
+
+  if (error && applications.length === 0) {
+    return (
+      <>
+        <PageSectionHeader
+          eyebrow="E-mail"
+          title="E-mails de décision"
+          description="Demandes prêtes pour l'envoi aux familles."
+        />
+        <ErrorState
+          message={error}
+          actionLabel="Réessayer"
+          onAction={() => window.location.reload()}
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <PageSectionHeader
+        eyebrow="E-mail"
+        title="E-mails de décision"
+        description="Demandes prêtes pour l'envoi aux familles."
+        aside={
+          <span className="rounded-full border border-primary/15 bg-white px-4 py-2 text-sm font-semibold text-primaryDark">
+            {displayedApplications.length} dossier{displayedApplications.length > 1 ? "s" : ""}
+          </span>
+        }
+      />
+
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+        <SummaryCard label="Prêtes" value={summary.total} />
+        <SummaryCard label="Acceptées" value={summary.accepted} tone="success" />
+        <SummaryCard label="En attente" value={summary.waitlisted} tone="info" />
+        <SummaryCard label="Partielles" value={summary.partial} tone="gold" />
+        <SummaryCard label="Déjà envoyées" value={summary.sent} tone="default" />
+      </section>
+
+      <section className="mt-6 overflow-hidden rounded-[30px] border border-primary/15 bg-white/90 shadow-[0_24px_48px_-36px_rgba(15,23,42,0.32)]">
+        <div className="border-b border-secondary/25 bg-[#fffaf2] px-5 py-5 sm:px-6">
+          <div className="grid gap-4 xl:grid-cols-[minmax(260px,0.8fr)_minmax(0,1.2fr)] xl:items-center">
+            <label className="block">
+              <span className="text-xs font-semibold uppercase tracking-[0.2em] text-primaryLight">
+                Recherche
+              </span>
+              <input
+                type="search"
+                value={search}
+                onChange={handleSearchChange}
+                placeholder="Famille, enfant ou email..."
+                className="mt-2 h-12 w-full rounded-2xl border border-primary/15 bg-white px-4 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-primary focus:ring-4 focus:ring-primary/10"
+              />
+            </label>
+
+            <div className="flex flex-wrap gap-2 xl:justify-end">
+              {filterOptions.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setFilter(option.value)}
+                  className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+                    filter === option.value
+                      ? "bg-secondary text-white shadow-[0_12px_24px_-18px_rgba(212,162,76,0.95)]"
+                      : "border border-primary/15 bg-white text-primaryDark hover:border-secondary/40 hover:bg-secondary/10"
+                  }`}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {error ? (
+          <p className="mx-5 mt-5 rounded-2xl border border-warning/20 bg-warning/10 px-4 py-3 text-sm text-slate-700 sm:mx-6">
+            {error} Les derniers résultats chargés restent affichés.
+          </p>
+        ) : null}
+
+        <div className="p-5 sm:p-6">
+          {applications.length === 0 ? (
+            <EmptyState
+              title="Aucune demande prête pour l'envoi"
+              description="Les demandes apparaîtront ici lorsque tous les enfants auront une décision."
+            />
+          ) : displayedApplications.length === 0 ? (
+            <EmptyState
+              title="Aucun résultat"
+              description="Aucune demande prête ne correspond à cette recherche ou à ce filtre."
+            />
+          ) : (
+            <div className="space-y-4">
+              {displayedApplications.map((application) => (
+                <article
+                  key={application.id}
+                  className="rounded-[26px] border border-slate-200/90 bg-white p-5 shadow-[0_18px_36px_-32px_rgba(15,23,42,0.35)]"
+                >
+                  <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h2 className="text-xl font-semibold text-slate-900">
+                          {getFamilyTitle(application)}
+                        </h2>
+                        <StatusBadge status={application.status} />
+                      </div>
+                      <p className="mt-2 break-all text-sm font-medium text-slate-600">
+                        {application.family.contactEmail || "Email non renseigné"}
+                      </p>
+                      <p className="mt-1 text-sm text-slate-500">
+                        {application.students.length} enfant{application.students.length > 1 ? "s" : ""} concerné{application.students.length > 1 ? "s" : ""}
+                      </p>
+                    </div>
+
+                    <div className="flex flex-wrap items-center gap-2 xl:justify-end">
+                      <span className={`inline-flex items-center rounded-full px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] ring-1 ${emailTypeBadgeStyles[application.recommendedEmailType]}`}>
+                        {applicationEmailTypeLabels[application.recommendedEmailType]}
+                      </span>
+                      <span className={`inline-flex items-center rounded-full px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.18em] ring-1 ${
+                        application.hasSentEmail
+                          ? "bg-success/10 text-success ring-success/20"
+                          : "bg-slate-100 text-slate-600 ring-slate-200"
+                      }`}>
+                        {application.hasSentEmail
+                          ? `Email déjà envoyé · ${formatOptionalDateTime(application.lastEmailSentAt)}`
+                          : "Email non envoyé"}
+                      </span>
+                    </div>
+                  </div>
+
+                  <div className="mt-5 grid gap-3 lg:grid-cols-2">
+                    {application.students.map((student) => (
+                      <div
+                        key={student.id}
+                        className="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3"
+                      >
+                        <div className="flex flex-wrap items-center justify-between gap-2">
+                          <p className="font-semibold text-slate-900">
+                            {student.firstName} {student.lastName}
+                          </p>
+                          <span className={`inline-flex items-center rounded-full px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.16em] ring-1 ${studentStatusStyles[student.admissionStatus]}`}>
+                            {studentStatusLabels[student.admissionStatus]}
+                          </span>
+                        </div>
+                        <p className="mt-1 text-sm text-slate-600">
+                          {student.level.label} · {student.level.code}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+
+                  <div className="mt-5 flex justify-end">
+                    <Link
+                      to={`/applications/${application.id}/email`}
+                      className="inline-flex items-center rounded-full bg-secondary px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-secondaryDark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary"
+                    >
+                      Préparer l'e-mail
+                    </Link>
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+    </>
+  );
+};
+
+export default EmailsPage;

--- a/apps/web/src/types/application.ts
+++ b/apps/web/src/types/application.ts
@@ -13,7 +13,10 @@ export type StudentAdmissionStatus =
   | "REFUSED"
   | "WAITLISTED";
 
+export type VisibleStudentAdmissionStatus = "ACCEPTED" | "WAITLISTED";
+
 export type ApplicationLevel = {
+  id?: string;
   code: string;
   label: string;
 };
@@ -22,6 +25,23 @@ export type LevelSummary = ApplicationLevel & {
   id: string;
   sortOrder: number;
   availablePlaces: number;
+};
+
+export type LevelCapacitySummary = {
+  id: string | null;
+  schoolYearId: string;
+  levelId: string;
+  availablePlaces: number;
+  createdAt: string | null;
+  updatedAt: string | null;
+  level: LevelSummary;
+};
+
+export type UpdateLevelCapacitiesPayload = {
+  capacities: Array<{
+    levelId: string;
+    availablePlaces: number;
+  }>;
 };
 
 export type ApplicationGender = "BOY" | "GIRL" | "UNKNOWN";
@@ -39,6 +59,7 @@ export type ApplicationStudent = {
   lastName: string;
   gender: ApplicationGender;
   admissionStatus: StudentAdmissionStatus;
+  isPriority: boolean;
   level: ApplicationLevel;
 };
 
@@ -48,9 +69,13 @@ export type ApplicationDetailStudent = ApplicationStudent & {
 };
 
 export type ApplicationFamily = {
+  id?: string;
   contactEmail: string | null;
+  contactPhone?: string | null;
   fatherLastName: string | null;
+  fatherFirstName?: string | null;
   motherLastName: string | null;
+  motherFirstName?: string | null;
 };
 
 export type ApplicationDetailFamily = ApplicationFamily & {
@@ -108,6 +133,31 @@ export type ApplicationEmailSendPayload = {
   syncDecisionAt?: boolean;
 };
 
+export type ReadyEmailType = "ACCEPTANCE" | "WAITLIST" | "PARTIAL_DECISION";
+
+export type ReadyEmailApplicationStudent = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  admissionStatus: Extract<StudentAdmissionStatus, "ACCEPTED" | "WAITLISTED">;
+  level: ApplicationLevel;
+};
+
+export type ReadyEmailApplication = {
+  id: string;
+  status: ApplicationStatus;
+  decisionAt: string | null;
+  family: ApplicationFamily;
+  students: ReadyEmailApplicationStudent[];
+  recommendedEmailType: ReadyEmailType;
+  hasSentEmail: boolean;
+  lastEmailSentAt: string | null;
+};
+
+export type ReadyEmailApplicationFilterParams = {
+  schoolYearId?: string;
+};
+
 export type ApplicationStatusUpdateResult = {
   id: string;
   status: ApplicationStatus;
@@ -133,6 +183,54 @@ export type ApplicationDecisionUpdateResult = {
 export type StudentAdmissionStatusUpdateResult = {
   student: ApplicationDetailStudent;
   applicationStatus: ApplicationStatus;
+};
+
+export type StudentListItem = {
+  id: string;
+  applicationId: string;
+  levelId: string;
+  firstName: string;
+  lastName: string;
+  gender: ApplicationGender;
+  birthDate: string;
+  rankInForm: number | null;
+  admissionStatus: StudentAdmissionStatus;
+  isPriority: boolean;
+  createdAt: string;
+  updatedAt: string;
+  level: LevelSummary;
+  application: {
+    id: string;
+    status: ApplicationStatus;
+    isPriority: boolean;
+    createdAt: string;
+    submittedAt: string;
+    schoolYear: ApplicationSchoolYear;
+    family: ApplicationDetailFamily & { id: string };
+  };
+};
+
+export type StudentListResponse = {
+  data: StudentListItem[];
+  meta: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+};
+
+export type StudentFilterParams = {
+  search?: string;
+  status?: VisibleStudentAdmissionStatus;
+  levelId?: string;
+  schoolYearId?: string;
+  isPriority?: "true" | "false";
+  familyId?: string;
+  page?: string;
+  limit?: string;
+  sortBy?: "lastName" | "firstName" | "level" | "birthDate" | "submittedAt" | "status";
+  sortOrder?: "asc" | "desc";
 };
 
 export type ApplicationFilterParams = {


### PR DESCRIPTION
## Objectif

Ajouter une page centralisée permettant au directeur de retrouver toutes les demandes dont les décisions enfants sont entièrement traitées, afin de préparer l’envoi des e-mails de décision en fin de campagne.

## Changements réalisés

### API

- Ajout de la route `GET /api/applications/ready-for-email`
- Filtrage sur l’année scolaire active par défaut
- Support du paramètre `schoolYearId`
- Exclusion des demandes sans élève
- Exclusion des demandes contenant au moins un enfant `PENDING`
- Conservation uniquement des demandes dont tous les enfants sont `ACCEPTED` ou `WAITLISTED`
- Calcul du type d’e-mail recommandé :
  - `ACCEPTANCE`
  - `WAITLIST`
  - `PARTIAL_DECISION`
- Ajout des indicateurs :
  - `hasSentEmail`
  - `lastEmailSentAt`

### Frontend

- Ajout de la page `EmailsPage`
- Ajout de la route `/emails`
- Ajout d’un lien “E-mail” dans la sidebar sous “Familles”
- Ajout d’une bulle dorée indiquant le nombre d’e-mails en attente d’envoi
- Ajout d’un résumé global en haut de page
- Ajout d’une recherche famille / enfant / email
- Ajout de filtres rapides
- Ajout d’une liste des demandes prêtes pour e-mail
- Ajout du bouton “Préparer l’e-mail” redirigeant vers `/applications/:id/email`

## Règles métier respectées

- Aucun e-mail n’est envoyé directement depuis la nouvelle page
- La page sert uniquement de file d’attente centralisée
- Les demandes avec un enfant encore `PENDING` ne sont pas affichées
- La logique existante de `/applications/:id/email` n’a pas été modifiée
- Le flux `REFUSAL` n’a pas été réintroduit

## Vérifications

- `npm exec -w apps/web -- tsc -b`
- `npm run build -w apps/web`
- `npm run build -w apps/api`