### PR TITLE
feat: polish admin list views and dashboard actions

### DIFF
--- a/apps/web/src/pages/ApplicationsPage.tsx
+++ b/apps/web/src/pages/ApplicationsPage.tsx
@@ -4,6 +4,7 @@ import {
   useDeferredValue,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type CSSProperties,
   type KeyboardEvent,
@@ -38,6 +39,13 @@ type SortOption = "createdAtDesc" | "createdAtAsc" | "priorityDesc";
 
 type PageSize = 4 | 6 | 8 | 10 | 12 | 15 | 18 | 20;
 
+type ApplicationsListViewState = {
+  filters: FilterState;
+  sort: SortOption;
+  currentPage: number;
+  pageSize: PageSize;
+};
+
 type StatusOption = {
   value: "" | ApplicationStatus;
   label: string;
@@ -67,6 +75,7 @@ type PaginationControlsProps = {
 };
 
 const pageSizeOptions: PageSize[] = [4, 6, 8, 10, 12, 15, 18, 20];
+const applicationsListViewStorageKey = "ece-admin.applications.listViewState.v1";
 
 const statusOptions: StatusOption[] = [
   { value: "", label: "Tous les statuts" },
@@ -78,6 +87,42 @@ const statusOptions: StatusOption[] = [
 
 const isApplicationStatus = (value: string): value is ApplicationStatus => {
   return statusOptions.some((option) => option.value === value && option.value !== "");
+};
+
+const sortOptionValues: SortOption[] = ["createdAtDesc", "createdAtAsc", "priorityDesc"];
+
+const isSortOption = (value: string): value is SortOption => {
+  return sortOptionValues.includes(value as SortOption);
+};
+
+const isValidPageSize = (value: number): value is PageSize => {
+  return pageSizeOptions.includes(value as PageSize);
+};
+
+const readStoredApplicationsListViewState = (): Partial<ApplicationsListViewState> => {
+  try {
+    const rawValue = window.localStorage.getItem(applicationsListViewStorageKey);
+
+    if (!rawValue) {
+      return {};
+    }
+
+    const value = JSON.parse(rawValue) as Partial<ApplicationsListViewState>;
+
+    return value && typeof value === "object" ? value : {};
+  } catch {
+    return {};
+  }
+};
+
+const writeStoredApplicationsListViewState = (
+  state: ApplicationsListViewState
+): void => {
+  try {
+    window.localStorage.setItem(applicationsListViewStorageKey, JSON.stringify(state));
+  } catch {
+    // Ignore private browsing or storage quota failures.
+  }
 };
 
 const getRequestedStatusFilter = (
@@ -387,19 +432,26 @@ const PaginationControls = memo(function PaginationControls({
 const ApplicationsPage = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const [storedListViewState] = useState(() => readStoredApplicationsListViewState());
   const requestedSchoolYearId = searchParams.get("schoolYearId")?.trim() ?? "";
   const requestedStatus = getRequestedStatusFilter(searchParams);
   const requestedPriority = getRequestedPriorityFilter(searchParams);
+  const storedFilters = storedListViewState.filters;
+  const storedSort = storedListViewState.sort;
+  const storedPageSize = Number(storedListViewState.pageSize);
+  const hasStoredListViewState = Object.keys(storedListViewState).length > 0;
   const [hasInitializedSchoolYearFilter, setHasInitializedSchoolYearFilter] = useState(
-    requestedSchoolYearId.length > 0
+    requestedSchoolYearId.length > 0 || hasStoredListViewState
   );
   const [filters, setFilters] = useState<FilterState>(() => ({
-    status: requestedStatus,
-    schoolYearId: requestedSchoolYearId,
-    isPriority: requestedPriority,
-    search: ""
+    status: requestedStatus || (storedFilters?.status ?? ""),
+    schoolYearId: requestedSchoolYearId || storedFilters?.schoolYearId || "",
+    isPriority: requestedPriority || (storedFilters?.isPriority ?? ""),
+    search: storedFilters?.search ?? ""
   }));
-  const [sort, setSort] = useState<SortOption>("createdAtDesc");
+  const [sort, setSort] = useState<SortOption>(
+    isSortOption(storedSort ?? "") ? (storedSort as SortOption) : "createdAtDesc"
+  );
   const [applications, setApplications] = useState<ApplicationListItem[]>([]);
   const [schoolYears, setSchoolYears] = useState<SchoolYearSummary[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -407,8 +459,13 @@ const ApplicationsPage = () => {
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [isSchoolYearsLoading, setIsSchoolYearsLoading] = useState(true);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [pageSize, setPageSize] = useState<PageSize>(4);
+  const [currentPage, setCurrentPage] = useState(() =>
+    Math.max(1, Number(storedListViewState.currentPage) || 1)
+  );
+  const [pageSize, setPageSize] = useState<PageSize>(
+    isValidPageSize(storedPageSize) ? storedPageSize : 4
+  );
+  const hasMountedPageReset = useRef(false);
   const deferredSearch = useDeferredValue(filters.search);
   const applicationQueryParams = useMemo<ApplicationFilterParams>(() => {
     const params: ApplicationFilterParams = {};
@@ -762,12 +819,30 @@ const ApplicationsPage = () => {
   ]);
 
   useEffect(() => {
+    if (!hasMountedPageReset.current) {
+      hasMountedPageReset.current = true;
+      return;
+    }
+
     setCurrentPage(1);
   }, [filters.status, filters.schoolYearId, filters.isPriority, filters.search, pageSize, sort]);
 
   useEffect(() => {
     setCurrentPage((page) => Math.min(page, totalPages));
   }, [totalPages]);
+
+  useEffect(() => {
+    if (isWaitingForDefaultSchoolYear) {
+      return;
+    }
+
+    writeStoredApplicationsListViewState({
+      filters,
+      sort,
+      currentPage: resolvedCurrentPage,
+      pageSize
+    });
+  }, [filters, isWaitingForDefaultSchoolYear, pageSize, resolvedCurrentPage, sort]);
 
   const pageTopBar = (
     <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1022,16 +1022,51 @@ const DashboardPage = () => {
                             { label: "Acceptés", value: acceptedStudentsCount },
                             { label: "Places", value: availablePlaces },
                             { label: "Restantes", value: remainingPlaces }
-                          ].map((metric) => (
-                            <div key={metric.label} className="min-w-0 rounded-2xl border border-slate-200 bg-white/80 px-2.5 py-2">
-                              <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-500">
+                          ].map((metric) => {
+                            const isRemainingMetric = metric.label === "Restantes";
+
+                            return (
+                            <div
+                              key={metric.label}
+                              className={`min-w-0 rounded-2xl border px-2.5 py-2 transition ${
+                                isRemainingMetric
+                                  ? "shadow-[0_12px_24px_-22px_rgba(15,23,42,0.35)]"
+                                  : "border-slate-200 bg-white/80"
+                              }`}
+                              style={
+                                isRemainingMetric
+                                  ? {
+                                      backgroundColor: level.visual.codeBackground,
+                                      borderColor: level.visual.borderColor
+                                    }
+                                  : undefined
+                              }
+                            >
+                              <p
+                                className="text-[10px] font-semibold uppercase tracking-[0.14em]"
+                                style={
+                                  isRemainingMetric
+                                    ? { color: level.visual.codeTextColor }
+                                    : undefined
+                                }
+                              >
                                 {metric.label}
                               </p>
-                              <p className="mt-1 text-lg font-semibold text-slate-900">
+                              <p
+                                className={`mt-1 text-lg font-semibold ${
+                                  isRemainingMetric ? "" : "text-slate-900"
+                                }`}
+                                style={
+                                  isRemainingMetric
+                                    ? { color: level.visual.barColor }
+                                    : undefined
+                                }
+                              >
                                 {numberFormatter.format(metric.value)}
                               </p>
                             </div>
-                          ))}
+                            );
+                          })}
                           <div className="flex items-center justify-end sm:col-span-2 lg:col-span-1">
                             <span
                               aria-hidden="true"
@@ -1107,7 +1142,7 @@ const DashboardPage = () => {
                       </div>
                       <Link
                         to={student.id ? `/students/${student.id}` : "/students?isPriority=true"}
-                        className="inline-flex w-fit items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary/30 hover:text-primary"
+                        className="inline-flex w-fit items-center rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white shadow-[0_12px_24px_-18px_rgba(31,77,58,0.55)] transition hover:bg-primaryDark hover:shadow-[0_16px_28px_-18px_rgba(31,77,58,0.65)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
                       >
                         Fiche élève
                       </Link>
@@ -1171,7 +1206,7 @@ const DashboardPage = () => {
                       </span>
                       <Link
                         to={`/applications/${student.application.id}`}
-                        className="rounded-full bg-white px-3 py-1.5 text-xs font-medium text-primary ring-1 ring-slate-200 transition hover:text-primaryDark"
+                        className="rounded-full border border-secondary/35 bg-secondary/15 px-3 py-1.5 text-xs font-semibold text-secondaryDark shadow-[0_10px_20px_-18px_rgba(212,162,76,0.55)] transition hover:border-secondary hover:bg-secondary hover:text-white hover:shadow-[0_14px_24px_-18px_rgba(212,162,76,0.75)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary"
                       >
                         Voir la famille
                       </Link>

--- a/apps/web/src/pages/EmailsPage.tsx
+++ b/apps/web/src/pages/EmailsPage.tsx
@@ -146,7 +146,7 @@ const EmailsPage = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
-  const [filter, setFilter] = useState<EmailFilter>("ALL");
+  const [filter, setFilter] = useState<EmailFilter>("UNSENT");
 
   useEffect(() => {
     const controller = new AbortController();

--- a/apps/web/src/pages/StudentDetailPage.tsx
+++ b/apps/web/src/pages/StudentDetailPage.tsx
@@ -1,0 +1,408 @@
+import { useCallback, useEffect, useState, type CSSProperties } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import PageSectionHeader from "../components/layout/PageSectionHeader";
+import Breadcrumb from "../components/ui/Breadcrumb";
+import ErrorState from "../components/ui/ErrorState";
+import LevelBadge from "../components/ui/LevelBadge";
+import LoadingState from "../components/ui/LoadingState";
+import PersonAvatar, {
+  type PersonAvatarVariant
+} from "../components/ui/PersonAvatar";
+import PriorityBadge from "../components/ui/PriorityBadge";
+import StudentStatusBadge, { getVisibleStudentStatus } from "../components/ui/StudentStatusBadge";
+import {
+  getStudentById,
+  updateStudentAdmissionStatus,
+  updateStudentPriority
+} from "../lib/api";
+import type {
+  ApplicationGender,
+  StudentListItem,
+  VisibleStudentAdmissionStatus
+} from "../types/application";
+
+const formatDate = new Intl.DateTimeFormat("fr-FR", {
+  day: "2-digit",
+  month: "long",
+  year: "numeric"
+});
+
+const getEnterStyle = (delay: number): CSSProperties => {
+  return { "--ui-enter-delay": `${delay}ms` } as CSSProperties;
+};
+
+const isAbortError = (error: unknown): boolean => {
+  return error instanceof DOMException && error.name === "AbortError";
+};
+
+const getFamilyDisplayName = (student: StudentListItem): string => {
+  const family = student.application.family;
+  const familyNames = [family.fatherLastName, family.motherLastName]
+    .filter((value): value is string => Boolean(value?.trim()));
+
+  return familyNames.length > 0
+    ? Array.from(new Set(familyNames)).join(" / ")
+    : student.lastName;
+};
+
+const getStudentAvatarVariant = (
+  gender: ApplicationGender
+): PersonAvatarVariant => {
+  if (gender === "BOY") {
+    return "boy";
+  }
+
+  if (gender === "GIRL") {
+    return "girl";
+  }
+
+  return "neutral";
+};
+
+const BackIcon = ({ className = "h-4 w-4" }: { className?: string }) => {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M10.75 3.25 6.25 8l4.5 4.75" />
+      <path d="M6.5 8h7" />
+    </svg>
+  );
+};
+
+const StudentDetailPage = () => {
+  const { id } = useParams<{ id: string }>();
+  const [student, setStudent] = useState<StudentListItem | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isUpdatingStatus, setIsUpdatingStatus] = useState(false);
+  const [isUpdatingPriority, setIsUpdatingPriority] = useState(false);
+
+  const loadStudent = useCallback(
+    async (signal?: AbortSignal): Promise<void> => {
+      if (!id) {
+        setError("Identifiant élève manquant.");
+        setIsLoading(false);
+        return;
+      }
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const loadedStudent = await getStudentById(id, { signal });
+
+        if (signal?.aborted) {
+          return;
+        }
+
+        setStudent(loadedStudent);
+      } catch (loadError) {
+        if (isAbortError(loadError) || signal?.aborted) {
+          return;
+        }
+
+        setError(
+          loadError instanceof Error
+            ? loadError.message
+            : "Impossible de charger la fiche élève."
+        );
+      } finally {
+        if (!signal?.aborted) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [id]
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    void loadStudent(controller.signal);
+
+    return () => controller.abort();
+  }, [loadStudent]);
+
+  const handleStatusChange = useCallback(
+    async (nextStatus: VisibleStudentAdmissionStatus): Promise<void> => {
+      if (!student) {
+        return;
+      }
+
+      setIsUpdatingStatus(true);
+      setError(null);
+
+      try {
+        const result = await updateStudentAdmissionStatus(student.id, nextStatus);
+
+        setStudent((currentStudent) =>
+          currentStudent
+            ? {
+                ...currentStudent,
+                admissionStatus: result.student.admissionStatus,
+                application: {
+                  ...currentStudent.application,
+                  status: result.applicationStatus
+                }
+              }
+            : currentStudent
+        );
+      } catch (updateError) {
+        setError(
+          updateError instanceof Error
+            ? updateError.message
+            : "Impossible de modifier le statut de l'élève."
+        );
+      } finally {
+        setIsUpdatingStatus(false);
+      }
+    },
+    [student]
+  );
+
+  const handlePriorityToggle = useCallback(async (): Promise<void> => {
+    if (!student) {
+      return;
+    }
+
+    setIsUpdatingPriority(true);
+    setError(null);
+
+    try {
+      const updatedStudent = await updateStudentPriority(
+        student.id,
+        !student.isPriority
+      );
+
+      setStudent(updatedStudent);
+    } catch (updateError) {
+      setError(
+        updateError instanceof Error
+          ? updateError.message
+          : "Impossible de modifier la priorité de l'élève."
+      );
+    } finally {
+      setIsUpdatingPriority(false);
+    }
+  }, [student]);
+
+  const pageTopBar = (
+    <div
+      className="ui-animate-in ui-animate-in--subtle w-fit rounded-2xl border border-primary/10 bg-white/80 px-4 py-3 text-sm text-primaryDark shadow-[0_10px_22px_-22px_rgba(15,23,42,0.18)]"
+      style={getEnterStyle(20)}
+    >
+      <Breadcrumb
+        items={[
+          { label: "Tableau de bord", href: "/" },
+          { label: "Élèves", href: "/students" },
+          { label: student ? `${student.firstName} ${student.lastName}` : "Fiche élève" }
+        ]}
+      />
+    </div>
+  );
+
+  const pageHeader = (
+    <div className="ui-animate-in ui-animate-in--subtle" style={getEnterStyle(130)}>
+      <PageSectionHeader
+        topBar={pageTopBar}
+        eyebrow="Fiche élève"
+        title={student ? `${student.firstName} ${student.lastName}` : "Fiche élève"}
+        description="Vue de traitement individuelle avec la famille, le niveau demandé et les décisions élève."
+      />
+    </div>
+  );
+
+  if (isLoading && !student) {
+    return (
+      <>
+        {pageHeader}
+        <LoadingState variant="page" />
+      </>
+    );
+  }
+
+  if (error && !student) {
+    return (
+      <>
+        {pageHeader}
+        <ErrorState message={error} backLink="/students" />
+      </>
+    );
+  }
+
+  if (!student) {
+    return null;
+  }
+
+  const family = student.application.family;
+  const visibleStatus = getVisibleStudentStatus(student.admissionStatus);
+  const isAccepted = visibleStatus === "ACCEPTED";
+  const isWaitlisted = visibleStatus === "WAITLISTED";
+
+  return (
+    <>
+      {pageHeader}
+
+      {error ? <ErrorState message={error} actionLabel="Réessayer" onAction={() => void loadStudent()} /> : null}
+
+      <section
+        className="ui-animate-in ui-surface-hover ui-surface-hover--soft ui-surface-hover--no-accent overflow-hidden rounded-[32px] border border-primary/20 bg-[#fffdf8] shadow-[0_30px_66px_-38px_rgba(31,77,58,0.42)]"
+        style={getEnterStyle(190)}
+      >
+        <div className="border-b border-secondary/30 bg-primary px-5 py-5 text-white sm:px-7">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex min-w-0 items-center gap-4">
+              <PersonAvatar
+                label={`${student.firstName} ${student.lastName}`}
+                size="lg"
+                variant={getStudentAvatarVariant(student.gender)}
+              />
+              <div className="min-w-0">
+                <p className="text-sm font-semibold uppercase tracking-[0.2em] text-secondary">
+                  Décision élève
+                </p>
+                <h2 className="mt-1.5 text-3xl font-semibold text-white">
+                  {student.firstName} {student.lastName}
+                </h2>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <StudentStatusBadge status={student.admissionStatus} />
+                  <LevelBadge code={student.level.code} label={student.level.label} size="md" />
+                  <PriorityBadge isPriority={student.isPriority} />
+                </div>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                disabled={isUpdatingPriority}
+                onClick={() => void handlePriorityToggle()}
+                className="rounded-full border border-secondary/35 bg-secondary/15 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-secondary/25 disabled:cursor-not-allowed disabled:opacity-55"
+              >
+                {student.isPriority ? "Retirer priorité" : "Marquer prioritaire"}
+              </button>
+              <button
+                type="button"
+                disabled={isUpdatingStatus || isAccepted}
+                onClick={() => void handleStatusChange("ACCEPTED")}
+                className="rounded-full bg-success px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-green-700 disabled:cursor-not-allowed disabled:opacity-55"
+              >
+                Accepter
+              </button>
+              <button
+                type="button"
+                disabled={isUpdatingStatus || isWaitlisted}
+                onClick={() => void handleStatusChange("WAITLISTED")}
+                className="rounded-full border border-white/25 bg-white/10 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-white/15 disabled:cursor-not-allowed disabled:opacity-55"
+              >
+                Mettre en attente
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid items-start gap-4 bg-[#fffaf2] p-5 sm:p-6 lg:grid-cols-3">
+          <article className="rounded-[24px] border border-white bg-white/85 p-4 sm:p-5">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-primaryLight">
+              Informations élève
+            </p>
+            <dl className="mt-3 space-y-2.5 text-sm">
+              <div>
+                <dt className="font-semibold text-slate-500">Nom complet</dt>
+                <dd className="mt-1 text-slate-900">{student.firstName} {student.lastName}</dd>
+              </div>
+              <div>
+                <dt className="font-semibold text-slate-500">Date de naissance</dt>
+                <dd className="mt-1 text-slate-900">{formatDate.format(new Date(student.birthDate))}</dd>
+              </div>
+              <div>
+                <dt className="font-semibold text-slate-500">Niveau demandé</dt>
+                <dd className="mt-2">
+                  <LevelBadge code={student.level.code} label={student.level.label} size="sm" />
+                </dd>
+              </div>
+            </dl>
+          </article>
+
+          <article className="rounded-[24px] border border-white bg-white/85 p-4 sm:p-5">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-primaryLight">
+              Famille
+            </p>
+            <dl className="mt-3 space-y-2.5 text-sm">
+              <div>
+                <dt className="font-semibold text-slate-500">Famille</dt>
+                <dd className="mt-1 text-slate-900">Famille {getFamilyDisplayName(student)}</dd>
+              </div>
+              <div>
+                <dt className="font-semibold text-slate-500">Parents</dt>
+                <dd className="mt-1 text-slate-900">
+                  {[family.fatherFirstName, family.fatherLastName].filter(Boolean).join(" ") || "Père non renseigné"}
+                  <br />
+                  {[family.motherFirstName, family.motherLastName].filter(Boolean).join(" ") || "Mère non renseignée"}
+                </dd>
+              </div>
+              <div>
+                <dt className="font-semibold text-slate-500">Contact</dt>
+                <dd className="mt-1 break-all text-slate-900">
+                  {family.contactEmail || "Email non renseigné"}
+                  <br />
+                  {family.contactPhone || "Téléphone non renseigné"}
+                </dd>
+              </div>
+            </dl>
+          </article>
+
+          <article className="rounded-[24px] border border-white bg-white/85 p-4 sm:p-5">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-primaryLight">
+              Contexte secondaire
+            </p>
+            <dl className="mt-3 space-y-2.5 text-sm">
+              <div>
+                <dt className="font-semibold text-slate-500">Année scolaire</dt>
+                <dd className="mt-1 text-slate-900">{student.application.schoolYear.label}</dd>
+              </div>
+              <div>
+                <dt className="font-semibold text-slate-500">Soumission</dt>
+                <dd className="mt-1 text-slate-900">
+                  {formatDate.format(new Date(student.application.submittedAt))}
+                </dd>
+              </div>
+              <div>
+                <dt className="font-semibold text-slate-500">Origine</dt>
+                <dd className="mt-2">
+                  <Link
+                    to={`/applications/${student.application.id}`}
+                    className="inline-flex rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-primary/25 hover:text-primary"
+                  >
+                    Voir la famille
+                  </Link>
+                </dd>
+              </div>
+            </dl>
+          </article>
+        </div>
+      </section>
+
+      <div className="ui-animate-in mt-5 flex justify-center" style={getEnterStyle(250)}>
+        <Link
+          to="/students"
+          className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-white px-5 py-2.5 text-sm font-semibold text-primaryDark shadow-[0_14px_30px_-24px_rgba(15,23,42,0.3)] transition hover:border-primary/35 hover:text-primary"
+        >
+          <BackIcon />
+          <span>Retour à la liste d&apos;élèves</span>
+        </Link>
+      </div>
+    </>
+  );
+};
+
+export default StudentDetailPage;

--- a/apps/web/src/pages/StudentsPage.tsx
+++ b/apps/web/src/pages/StudentsPage.tsx
@@ -3,6 +3,7 @@ import {
   useDeferredValue,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type CSSProperties
 } from "react";
@@ -37,6 +38,19 @@ import type {
 type PageSize = 4 | 6 | 8 | 10 | 12 | 15 | 18 | 20;
 type PaginationItem = number | "ellipsis-left" | "ellipsis-right";
 
+type StudentListViewState = {
+  search: string;
+  status: "" | VisibleStudentAdmissionStatus;
+  levelId: string;
+  schoolYearId: string;
+  isPriority: "" | "true";
+  familyId: string;
+  page: number;
+  limit: PageSize;
+  sortBy: NonNullable<StudentFilterParams["sortBy"]>;
+  sortOrder: "asc" | "desc";
+};
+
 type PaginationControlsProps = {
   currentPage: number;
   totalPages: number;
@@ -44,6 +58,7 @@ type PaginationControlsProps = {
 };
 
 const pageSizeOptions: PageSize[] = [4, 6, 8, 10, 12, 15, 18, 20];
+const studentListViewStorageKey = "ece-admin.students.listViewState.v1";
 const sortableFields: Array<NonNullable<StudentFilterParams["sortBy"]>> = [
   "lastName",
   "firstName",
@@ -263,18 +278,105 @@ const getSortByParam = (
     : "submittedAt";
 };
 
-const getInitialPage = (params: URLSearchParams): number => {
-  return Math.max(1, Number(getParam(params, "page")) || 1);
+const isValidPageSize = (value: number): value is PageSize => {
+  return pageSizeOptions.includes(value as PageSize);
 };
 
-const getInitialPageSize = (params: URLSearchParams): PageSize => {
-  const requestedLimit = Number(getParam(params, "limit")) as PageSize;
+const hasParam = (params: URLSearchParams, key: string): boolean => {
+  return params.has(key) && getParam(params, key).length > 0;
+};
 
-  return pageSizeOptions.includes(requestedLimit) ? requestedLimit : 4;
+const readStoredStudentListViewState = (): Partial<StudentListViewState> => {
+  try {
+    const rawValue = window.localStorage.getItem(studentListViewStorageKey);
+
+    if (!rawValue) {
+      return {};
+    }
+
+    const value = JSON.parse(rawValue) as Partial<StudentListViewState>;
+
+    return value && typeof value === "object" ? value : {};
+  } catch {
+    return {};
+  }
+};
+
+const getInitialPage = (
+  params: URLSearchParams,
+  storedState: Partial<StudentListViewState>
+): number => {
+  if (hasParam(params, "page")) {
+    return Math.max(1, Number(getParam(params, "page")) || 1);
+  }
+
+  return Math.max(1, Number(storedState.page) || 1);
+};
+
+const getInitialPageSize = (
+  params: URLSearchParams,
+  storedState: Partial<StudentListViewState>
+): PageSize => {
+  if (hasParam(params, "limit")) {
+    const requestedLimit = Number(getParam(params, "limit"));
+
+    return isValidPageSize(requestedLimit) ? requestedLimit : 4;
+  }
+
+  const storedLimit = Number(storedState.limit);
+
+  return isValidPageSize(storedLimit) ? storedLimit : 4;
+};
+
+const getInitialStudentSearchParams = (
+  params: URLSearchParams,
+  storedState: Partial<StudentListViewState>
+): URLSearchParams => {
+  const nextParams = new URLSearchParams(params);
+  const storedValues: Record<string, string | undefined> = {
+    status: storedState.status,
+    levelId: storedState.levelId,
+    schoolYearId: storedState.schoolYearId,
+    isPriority: storedState.isPriority,
+    familyId: storedState.familyId,
+    sortBy: storedState.sortBy,
+    sortOrder: storedState.sortOrder
+  };
+
+  Object.entries(storedValues).forEach(([key, value]) => {
+    if (!hasParam(nextParams, key) && value) {
+      nextParams.set(key, value);
+    }
+  });
+
+  return nextParams;
+};
+
+const getInitialSearch = (
+  params: URLSearchParams,
+  storedState: Partial<StudentListViewState>
+): string => {
+  if (hasParam(params, "search")) {
+    return getParam(params, "search");
+  }
+
+  return typeof storedState.search === "string" ? storedState.search : "";
+};
+
+const writeStoredStudentListViewState = (state: StudentListViewState): void => {
+  try {
+    window.localStorage.setItem(studentListViewStorageKey, JSON.stringify(state));
+  } catch {
+    // Ignore private browsing or storage quota failures.
+  }
 };
 
 const StudentsPage = () => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const [initialListViewState] = useState(() => readStoredStudentListViewState());
+  const [studentParams, setStudentParams] = useState(() =>
+    getInitialStudentSearchParams(searchParams, initialListViewState)
+  );
   const [levels, setLevels] = useState<LevelSummary[]>([]);
   const [schoolYears, setSchoolYears] = useState<SchoolYearSummary[]>([]);
   const [students, setStudents] = useState<StudentListItem[]>([]);
@@ -283,28 +385,33 @@ const StudentsPage = () => {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
-  const [search, setSearch] = useState(() => getParam(searchParams, "search"));
-  const [page, setPage] = useState(() => getInitialPage(searchParams));
-  const [limit, setLimit] = useState<PageSize>(() => getInitialPageSize(searchParams));
+  const [search, setSearch] = useState(() =>
+    getInitialSearch(searchParams, initialListViewState)
+  );
+  const [page, setPage] = useState(() => getInitialPage(searchParams, initialListViewState));
+  const [limit, setLimit] = useState<PageSize>(() =>
+    getInitialPageSize(searchParams, initialListViewState)
+  );
+  const hasMountedSearchReset = useRef(false);
   const deferredSearch = useDeferredValue(search);
 
   const filters = useMemo<StudentFilterParams>(() => {
-    const isPriority = getParam(searchParams, "isPriority");
-    const sortOrder = getParam(searchParams, "sortOrder");
+    const isPriority = getParam(studentParams, "isPriority");
+    const sortOrder = getParam(studentParams, "sortOrder");
 
     return {
       search: deferredSearch.trim() || undefined,
-      status: getStatusParam(searchParams) || undefined,
-      levelId: getParam(searchParams, "levelId") || undefined,
-      schoolYearId: getParam(searchParams, "schoolYearId") || activeSchoolYear?.id,
+      status: getStatusParam(studentParams) || undefined,
+      levelId: getParam(studentParams, "levelId") || undefined,
+      schoolYearId: getParam(studentParams, "schoolYearId") || activeSchoolYear?.id,
       isPriority: isPriority === "true" ? "true" : undefined,
-      familyId: getParam(searchParams, "familyId") || undefined,
+      familyId: getParam(studentParams, "familyId") || undefined,
       page: "1",
       limit: "5000",
-      sortBy: getSortByParam(searchParams),
+      sortBy: getSortByParam(studentParams),
       sortOrder: sortOrder === "asc" ? "asc" : "desc"
     };
-  }, [activeSchoolYear?.id, deferredSearch, searchParams]);
+  }, [activeSchoolYear?.id, deferredSearch, studentParams]);
 
   const totalPages = useMemo(() => {
     return Math.max(1, Math.ceil(students.length / limit));
@@ -341,7 +448,7 @@ const StudentsPage = () => {
 
   const updateParams = useCallback(
     (updates: Record<string, string | undefined>): void => {
-      const nextParams = new URLSearchParams(searchParams);
+      const nextParams = new URLSearchParams(studentParams);
 
       Object.entries(updates).forEach(([key, value]) => {
         if (value) {
@@ -354,26 +461,51 @@ const StudentsPage = () => {
       nextParams.delete("page");
       nextParams.delete("limit");
       setPage(1);
+      setStudentParams(nextParams);
       setSearchParams(nextParams);
     },
-    [searchParams, setSearchParams]
+    [setSearchParams, studentParams]
   );
 
   useEffect(() => {
-    const requestedSearch = getParam(searchParams, "search");
+    if (!studentParams.has("search")) {
+      return;
+    }
+
+    const requestedSearch = getParam(studentParams, "search");
 
     setSearch((currentSearch) =>
       currentSearch === requestedSearch ? currentSearch : requestedSearch
     );
-  }, [searchParams]);
+  }, [studentParams]);
 
   useEffect(() => {
+    if (!hasMountedSearchReset.current) {
+      hasMountedSearchReset.current = true;
+      return;
+    }
+
     setPage(1);
   }, [deferredSearch]);
 
   useEffect(() => {
     setPage((currentPage) => Math.min(currentPage, totalPages));
   }, [totalPages]);
+
+  useEffect(() => {
+    writeStoredStudentListViewState({
+      search,
+      status: getStatusParam(studentParams),
+      levelId: getParam(studentParams, "levelId"),
+      schoolYearId: getParam(studentParams, "schoolYearId"),
+      isPriority: getParam(studentParams, "isPriority") === "true" ? "true" : "",
+      familyId: getParam(studentParams, "familyId"),
+      page,
+      limit,
+      sortBy: getSortByParam(studentParams),
+      sortOrder: getParam(studentParams, "sortOrder") === "asc" ? "asc" : "desc"
+    });
+  }, [limit, page, search, studentParams]);
 
   const loadReferenceData = useCallback(async (signal: AbortSignal): Promise<void> => {
     const [loadedLevels, loadedSchoolYears, loadedActiveSchoolYear] = await Promise.all([


### PR DESCRIPTION
## Objectif

Améliorer l’expérience utilisateur sur plusieurs vues administratives : mémorisation des filtres, navigation, page e-mail et lisibilité des actions du dashboard.

## Changements réalisés

- Mémorisation en `localStorage` des paramètres de vue sur la page élèves :
  - recherche
  - filtres
  - tri
  - page active
  - nombre d’élèves par page

- Mémorisation en `localStorage` des paramètres de vue sur la page demandes :
  - recherche
  - filtres
  - tri
  - page active
  - nombre de demandes par page

- Priorité conservée aux paramètres présents dans l’URL lorsqu’on arrive via un lien filtré.

- Ajout d’un bouton “Retour à la liste d’élèves” sous la card élève.

- Page des e-mails prêts à envoyer :
  - filtre actif par défaut défini sur “Non envoyées”.

- Dashboard :
  - mise en valeur du bloc “Restantes” avec la couleur du niveau correspondant.
  - amélioration des boutons du bloc élèves prioritaires :
    - “Fiche élève” en bouton primaire vert.
    - “Voir la famille” en bouton secondaire doré.
    - ajout d’états hover plus explicites.

## Vérifications

- `npm run build -w apps/web` : OK

## Note

- `npm run lint -w apps/web` échoue encore sur des règles déjà présentes dans le projet, notamment `AuthContext`, `ToastContext`, `StudentStatusBadge`, ainsi que des alertes React hooks existantes dans `StudentsPage`.