### PR TITLE
feat: bloquer les acceptations lorsque les niveaux sont complets

### DIFF
--- a/apps/api/src/controllers/application.controller.ts
+++ b/apps/api/src/controllers/application.controller.ts
@@ -3,11 +3,11 @@ import {
   EmailSendStatus,
   EmailType,
   StudentAdmissionStatus,
-  type Prisma
+  Prisma
 } from "@prisma/client";
 import type { Request, Response } from "express";
 
-import { badRequest, notFound } from "../lib/errors";
+import { badRequest, conflict, notFound } from "../lib/errors";
 import { prisma } from "../prisma/client";
 import { sendApplicationMail } from "../services/mailer.service";
 
@@ -210,6 +210,105 @@ const getRecalculatedApplicationStatus = (
   }
 
   return ApplicationStatus.IN_REVIEW;
+};
+
+const missingCapacityMessage =
+  "Impossible d'accepter cet élève : les places disponibles ne sont pas renseignées pour ce niveau.";
+const fullCapacityMessage =
+  "Impossible d'accepter cet élève : il n'y a plus de place disponible pour ce niveau.";
+
+const lockLevelCapacityRows = async (
+  transaction: Prisma.TransactionClient,
+  schoolYearId: string,
+  levelIds: string[]
+): Promise<void> => {
+  if (levelIds.length === 0) {
+    return;
+  }
+
+  await transaction.$queryRaw`
+    SELECT id
+    FROM "LevelCapacity"
+    WHERE "schoolYearId" = ${schoolYearId}
+      AND "levelId" IN (${Prisma.join(levelIds)})
+    FOR UPDATE
+  `;
+};
+
+const assertAcceptanceCapacity = async (
+  transaction: Prisma.TransactionClient,
+  schoolYearId: string,
+  requestedAcceptancesByLevelId: Map<string, number>
+): Promise<void> => {
+  const levelIds = [...requestedAcceptancesByLevelId.keys()];
+
+  await lockLevelCapacityRows(transaction, schoolYearId, levelIds);
+
+  const [levels, capacities, acceptedStudentsByLevel] = await Promise.all([
+    transaction.level.findMany({
+      where: { id: { in: levelIds } },
+      select: { id: true, code: true }
+    }),
+    transaction.levelCapacity.findMany({
+      where: {
+        schoolYearId,
+        levelId: { in: levelIds }
+      },
+      select: {
+        levelId: true,
+        availablePlaces: true
+      }
+    }),
+    transaction.student.groupBy({
+      by: ["levelId"],
+      where: {
+        levelId: { in: levelIds },
+        admissionStatus: StudentAdmissionStatus.ACCEPTED,
+        application: {
+          schoolYearId
+        }
+      },
+      _count: {
+        _all: true
+      }
+    })
+  ]);
+
+  const levelById = new Map(levels.map((level) => [level.id, level]));
+  const capacityByLevelId = new Map(
+    capacities.map((capacity) => [capacity.levelId, capacity.availablePlaces])
+  );
+  const acceptedCountByLevelId = new Map(
+    acceptedStudentsByLevel.map((level) => [level.levelId, level._count._all])
+  );
+
+  for (const [levelId, requestedAcceptances] of requestedAcceptancesByLevelId) {
+    const level = levelById.get(levelId);
+    const availablePlaces = capacityByLevelId.get(levelId);
+    const acceptedStudentsCount = acceptedCountByLevelId.get(levelId) ?? 0;
+
+    if (availablePlaces === undefined) {
+      throw conflict(missingCapacityMessage, {
+        code: "LEVEL_CAPACITY_MISSING",
+        levelCode: level?.code ?? null,
+        availablePlaces: null,
+        acceptedStudentsCount,
+        remainingPlaces: null
+      });
+    }
+
+    const remainingPlaces = availablePlaces - acceptedStudentsCount;
+
+    if (remainingPlaces < requestedAcceptances) {
+      throw conflict(fullCapacityMessage, {
+        code: "LEVEL_CAPACITY_FULL",
+        levelCode: level?.code ?? null,
+        availablePlaces,
+        acceptedStudentsCount,
+        remainingPlaces
+      });
+    }
+  }
 };
 
 export const getApplications = async (req: Request, res: Response): Promise<void> => {
@@ -478,11 +577,7 @@ export const updateApplicationStatus = async (req: Request, res: Response): Prom
 
   const existingApplication = await prisma.application.findUnique({
     where: { id: applicationId },
-    select: {
-      id: true,
-      status: true,
-      decisionAt: true
-    }
+    select: { id: true }
   });
 
   if (!existingApplication) {
@@ -535,8 +630,15 @@ export const updateApplicationDecision = async (req: Request, res: Response): Pr
     where: { id: applicationId },
     select: {
       id: true,
+      schoolYearId: true,
       status: true,
-      decisionAt: true
+      decisionAt: true,
+      students: {
+        select: {
+          levelId: true,
+          admissionStatus: true
+        }
+      }
     }
   });
 
@@ -545,6 +647,27 @@ export const updateApplicationDecision = async (req: Request, res: Response): Pr
   }
 
   const updatedApplication = await prisma.$transaction(async (transaction) => {
+    if (status === StudentAdmissionStatus.ACCEPTED) {
+      const requestedAcceptancesByLevelId = new Map<string, number>();
+
+      for (const student of existingApplication.students) {
+        if (student.admissionStatus === StudentAdmissionStatus.ACCEPTED) {
+          continue;
+        }
+
+        requestedAcceptancesByLevelId.set(
+          student.levelId,
+          (requestedAcceptancesByLevelId.get(student.levelId) ?? 0) + 1
+        );
+      }
+
+      await assertAcceptanceCapacity(
+        transaction,
+        existingApplication.schoolYearId,
+        requestedAcceptancesByLevelId
+      );
+    }
+
     await transaction.student.updateMany({
       where: { applicationId },
       data: { admissionStatus: status }
@@ -581,8 +704,11 @@ export const updateStudentAdmissionStatus = async (
       select: {
         id: true,
         applicationId: true,
+        levelId: true,
+        admissionStatus: true,
         application: {
           select: {
+            schoolYearId: true,
             status: true
           }
         }
@@ -591,6 +717,17 @@ export const updateStudentAdmissionStatus = async (
 
     if (!existingStudent) {
       throw notFound("Student not found");
+    }
+
+    if (
+      admissionStatus === StudentAdmissionStatus.ACCEPTED &&
+      existingStudent.admissionStatus !== StudentAdmissionStatus.ACCEPTED
+    ) {
+      await assertAcceptanceCapacity(
+        transaction,
+        existingStudent.application.schoolYearId,
+        new Map([[existingStudent.levelId, 1]])
+      );
     }
 
     const updatedStudent = await transaction.student.update({

--- a/apps/api/src/controllers/dashboard.controller.ts
+++ b/apps/api/src/controllers/dashboard.controller.ts
@@ -43,21 +43,48 @@ export const getDashboardStats = async (_req: Request, res: Response): Promise<v
         [ApplicationStatus.PARTIALLY_ACCEPTED]: 0
       },
       byLevel: levels.map((level) => ({
+        id: undefined,
         code: level.code,
         label: level.label,
-        count: 0
+        count: 0,
+        requestedStudentsCount: 0,
+        acceptedStudentsCount: 0,
+        availablePlaces: 0,
+        isCapacityConfigured: false,
+        remainingPlaces: 0
       })),
-      priorityApplications: []
+      priorityApplications: [],
+      studentStats: {
+        totalStudents: 0,
+        acceptedStudents: 0,
+        waitlistedStudents: 0,
+        byLevel: levels.map((level) => ({
+          id: undefined,
+          code: level.code,
+          label: level.label,
+          count: 0,
+          requestedStudentsCount: 0,
+          acceptedStudentsCount: 0,
+          availablePlaces: 0,
+          isCapacityConfigured: false,
+          remainingPlaces: 0
+        })),
+        priorityStudents: []
+      }
     });
     return;
   }
 
   const [
     totalApplications,
+    totalStudents,
+    acceptedStudents,
     waitlistedStudents,
     statusCounts,
     levels,
     studentCountsByLevel,
+    acceptedStudentCountsByLevel,
+    levelCapacities,
     priorityApplications
   ] = await Promise.all([
     prisma.application.count({
@@ -67,8 +94,26 @@ export const getDashboardStats = async (_req: Request, res: Response): Promise<v
     }),
     prisma.student.count({
       where: {
+        application: {
+          schoolYearId: activeSchoolYear.id
+        }
+      }
+    }),
+    prisma.student.count({
+      where: {
+        admissionStatus: StudentAdmissionStatus.ACCEPTED,
+        application: {
+          schoolYearId: activeSchoolYear.id
+        }
+      }
+    }),
+    prisma.student.count({
+      where: {
         admissionStatus: {
-          in: [StudentAdmissionStatus.WAITLISTED, StudentAdmissionStatus.REFUSED]
+          in: [
+            StudentAdmissionStatus.WAITLISTED,
+            StudentAdmissionStatus.REFUSED
+          ]
         },
         application: {
           schoolYearId: activeSchoolYear.id
@@ -89,7 +134,8 @@ export const getDashboardStats = async (_req: Request, res: Response): Promise<v
         id: true,
         code: true,
         label: true,
-        sortOrder: true
+        sortOrder: true,
+        availablePlaces: true
       },
       orderBy: {
         sortOrder: "asc"
@@ -106,10 +152,35 @@ export const getDashboardStats = async (_req: Request, res: Response): Promise<v
         _all: true
       }
     }),
+    prisma.student.groupBy({
+      by: ["levelId"],
+      where: {
+        admissionStatus: StudentAdmissionStatus.ACCEPTED,
+        application: {
+          schoolYearId: activeSchoolYear.id
+        }
+      },
+      _count: {
+        _all: true
+      }
+    }),
+    prisma.levelCapacity.findMany({
+      where: {
+        schoolYearId: activeSchoolYear.id
+      },
+      select: {
+        levelId: true,
+        availablePlaces: true
+      }
+    }),
     prisma.application.findMany({
       where: {
-        isPriority: true,
-        schoolYearId: activeSchoolYear.id
+        schoolYearId: activeSchoolYear.id,
+        students: {
+          some: {
+            isPriority: true
+          }
+        }
       },
       orderBy: {
         createdAt: "desc"
@@ -133,11 +204,18 @@ export const getDashboardStats = async (_req: Request, res: Response): Promise<v
           }
         },
         students: {
+          where: {
+            isPriority: true
+          },
           select: {
+            id: true,
             firstName: true,
             lastName: true,
+            admissionStatus: true,
+            isPriority: true,
             level: {
               select: {
+                id: true,
                 code: true,
                 label: true
               }
@@ -171,18 +249,70 @@ export const getDashboardStats = async (_req: Request, res: Response): Promise<v
   const studentCountsByLevelId = new Map(
     studentCountsByLevel.map((level) => [level.levelId, level._count._all])
   );
+  const acceptedStudentCountsByLevelId = new Map(
+    acceptedStudentCountsByLevel.map((level) => [level.levelId, level._count._all])
+  );
+  const levelCapacityByLevelId = new Map(
+    levelCapacities.map((capacity) => [capacity.levelId, capacity.availablePlaces])
+  );
+  const configuredLevelCapacityIds = new Set(
+    levelCapacities.map((capacity) => capacity.levelId)
+  );
 
-  const byLevel = levels.map((level) => ({
-    code: level.code,
-    label: level.label,
-    count: studentCountsByLevelId.get(level.id) ?? 0
-  }));
+  const byLevel = levels.map((level) => {
+    const requestedStudentsCount = studentCountsByLevelId.get(level.id) ?? 0;
+    const acceptedStudentsCount = acceptedStudentCountsByLevelId.get(level.id) ?? 0;
+    const availablePlaces = levelCapacityByLevelId.get(level.id) ?? 0;
+    const isCapacityConfigured = configuredLevelCapacityIds.has(level.id);
+
+    return {
+      id: level.id,
+      code: level.code,
+      label: level.label,
+      count: requestedStudentsCount,
+      requestedStudentsCount,
+      acceptedStudentsCount,
+      availablePlaces,
+      isCapacityConfigured,
+      remainingPlaces: availablePlaces - acceptedStudentsCount
+    };
+  });
+
+  const priorityStudents = priorityApplications.flatMap((application) =>
+    application.students.map((student) => ({
+      id: student.id,
+      firstName: student.firstName,
+      lastName: student.lastName,
+      admissionStatus:
+        student.admissionStatus === StudentAdmissionStatus.ACCEPTED
+          ? StudentAdmissionStatus.ACCEPTED
+          : student.admissionStatus === StudentAdmissionStatus.WAITLISTED ||
+            student.admissionStatus === StudentAdmissionStatus.REFUSED
+          ? StudentAdmissionStatus.WAITLISTED
+          : StudentAdmissionStatus.PENDING,
+      level: student.level,
+      application: {
+        id: application.id,
+        isPriority: student.isPriority,
+        createdAt: application.createdAt,
+        schoolYear: application.schoolYear,
+        family: application.family
+      }
+    }))
+  );
 
   res.status(200).json({
     totalApplications,
     waitlistedStudents,
     byStatus,
     byLevel,
-    priorityApplications
+    priorityApplications,
+    studentStats: {
+      totalStudents,
+      acceptedStudents,
+      waitlistedStudents,
+      byLevel,
+      priorityStudents
+    }
   });
 };

--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -1,10 +1,16 @@
 export class AppError extends Error {
   readonly statusCode: number;
+  readonly details?: Record<string, unknown>;
 
-  constructor(message: string, statusCode: number) {
+  constructor(
+    message: string,
+    statusCode: number,
+    details?: Record<string, unknown>
+  ) {
     super(message);
     this.name = "AppError";
     this.statusCode = statusCode;
+    this.details = details;
 
     Object.setPrototypeOf(this, new.target.prototype);
   }
@@ -24,4 +30,11 @@ export const unauthorized = (message: string): AppError => {
 
 export const notFound = (message: string): AppError => {
   return new AppError(message, 404);
+};
+
+export const conflict = (
+  message: string,
+  details?: Record<string, unknown>
+): AppError => {
+  return new AppError(message, 409, details);
 };

--- a/apps/api/src/middlewares/error-handler.ts
+++ b/apps/api/src/middlewares/error-handler.ts
@@ -32,6 +32,7 @@ export const errorHandler: ErrorRequestHandler = (error, _req, res, _next) => {
   }
 
   res.status(appError.statusCode).json({
-    message: appError.message
+    message: appError.message,
+    ...appError.details
   });
 };

--- a/apps/web/src/pages/ApplicationDetailPage.tsx
+++ b/apps/web/src/pages/ApplicationDetailPage.tsx
@@ -20,8 +20,10 @@ import PersonAvatar, {
 import StatusBadge from "../components/ui/StatusBadge";
 import { useToast } from "../context/ToastContext";
 import {
+  fetchDashboardStats,
   getApplicationById,
   getApplicationEmailLogs,
+  getSchoolYearLevelCapacities,
   updateStudentAdmissionStatus
 } from "../lib/api";
 import {
@@ -38,6 +40,7 @@ import type {
   ApplicationStatus,
   StudentAdmissionStatus
 } from "../types/application";
+import type { DashboardLevelStat } from "../types/dashboard";
 
 type IconProps = {
   className?: string;
@@ -661,6 +664,12 @@ const ApplicationDetailPage = () => {
   const { showError, showSuccess } = useToast();
   const [application, setApplication] = useState<ApplicationDetail | null>(null);
   const [emailLogs, setEmailLogs] = useState<ApplicationEmailLog[]>([]);
+  const [levelCapacityByLevelId, setLevelCapacityByLevelId] = useState<
+    Record<string, { isConfigured: boolean; availablePlaces: number }>
+  >({});
+  const [activeLevelStatsByLevelId, setActiveLevelStatsByLevelId] = useState<
+    Record<string, DashboardLevelStat>
+  >({});
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [updatingStudentAdmissionId, setUpdatingStudentAdmissionId] =
@@ -693,6 +702,14 @@ const ApplicationDetailPage = () => {
           getApplicationById(applicationId, { signal: controller.signal }),
           getApplicationEmailLogs(applicationId, { signal: controller.signal })
         ]);
+        const [capacities, dashboardStats] = await Promise.all([
+          getSchoolYearLevelCapacities(applicationData.schoolYear.id, {
+            signal: controller.signal
+          }),
+          applicationData.schoolYear.isActive
+            ? fetchDashboardStats({ signal: controller.signal })
+            : Promise.resolve(null)
+        ]);
 
         if (controller.signal.aborted) {
           return;
@@ -700,6 +717,26 @@ const ApplicationDetailPage = () => {
 
         setApplication(applicationData);
         setEmailLogs(emailLogsData);
+        setLevelCapacityByLevelId(
+          Object.fromEntries(
+            capacities.map((capacity) => [
+              capacity.levelId,
+              {
+                isConfigured: capacity.id !== null,
+                availablePlaces: capacity.availablePlaces
+              }
+            ])
+          )
+        );
+        setActiveLevelStatsByLevelId(
+          Object.fromEntries(
+            (dashboardStats?.byLevel ?? [])
+              .filter((level): level is DashboardLevelStat & { id: string } =>
+                typeof level.id === "string"
+              )
+              .map((level) => [level.id, level])
+          )
+        );
       } catch (loadError) {
         if (isAbortError(loadError) || controller.signal.aborted) {
           return;
@@ -773,6 +810,19 @@ const ApplicationDetailPage = () => {
             )
           };
         });
+        if (application.schoolYear.isActive) {
+          const dashboardStats = await fetchDashboardStats();
+
+          setActiveLevelStatsByLevelId(
+            Object.fromEntries(
+              dashboardStats.byLevel
+                .filter((level): level is DashboardLevelStat & { id: string } =>
+                  typeof level.id === "string"
+                )
+                .map((level) => [level.id, level])
+            )
+          );
+        }
         showSuccess("La décision de l'élève a bien été mise à jour.");
       } catch (updateError) {
         showError(
@@ -1193,6 +1243,28 @@ const ApplicationDetailPage = () => {
                         const isCurrentStatus =
                           getStudentAdmissionStatus(student) === option.value;
                         const isSubmitting = updatingStudentAdmissionId === student.id;
+                        const levelId = student.level.id;
+                        const levelCapacity = levelId
+                          ? levelCapacityByLevelId[levelId]
+                          : undefined;
+                        const activeLevelStats = levelId
+                          ? activeLevelStatsByLevelId[levelId]
+                          : undefined;
+                        const isCapacityMissing =
+                          option.value === "ACCEPTED" &&
+                          getStudentAdmissionStatus(student) !== "ACCEPTED" &&
+                          levelCapacity?.isConfigured === false;
+                        const isLevelFull =
+                          option.value === "ACCEPTED" &&
+                          getStudentAdmissionStatus(student) !== "ACCEPTED" &&
+                          application.schoolYear.isActive &&
+                          typeof activeLevelStats?.remainingPlaces === "number" &&
+                          activeLevelStats.remainingPlaces <= 0;
+                        const acceptBlockMessage = isCapacityMissing
+                          ? "Places disponibles non renseignées pour ce niveau."
+                          : isLevelFull
+                          ? "Ce niveau est complet. Aucune place restante."
+                          : null;
                         const activeButtonClassName =
                           option.value === "ACCEPTED"
                             ? "border-success/20 bg-success/15 text-success"
@@ -1215,7 +1287,10 @@ const ApplicationDetailPage = () => {
                               )
                             }
                             disabled={
-                              isTreatmentReadOnly || isSubmitting || isCurrentStatus
+                              isTreatmentReadOnly ||
+                              isSubmitting ||
+                              isCurrentStatus ||
+                              Boolean(acceptBlockMessage)
                             }
                             className={`inline-flex min-h-10 items-center justify-center rounded-full border px-3 py-2 text-xs font-semibold transition disabled:cursor-not-allowed ${
                               isTreatmentReadOnly
@@ -1232,6 +1307,31 @@ const ApplicationDetailPage = () => {
                         );
                       })}
                     </div>
+                    {(() => {
+                      const levelId = student.level.id;
+                      const levelCapacity = levelId
+                        ? levelCapacityByLevelId[levelId]
+                        : undefined;
+                      const activeLevelStats = levelId
+                        ? activeLevelStatsByLevelId[levelId]
+                        : undefined;
+                      const isAccepted = getStudentAdmissionStatus(student) === "ACCEPTED";
+                      const message =
+                        !isAccepted && levelCapacity?.isConfigured === false
+                          ? "Places disponibles non renseignées pour ce niveau."
+                          : !isAccepted &&
+                            application.schoolYear.isActive &&
+                            typeof activeLevelStats?.remainingPlaces === "number" &&
+                            activeLevelStats.remainingPlaces <= 0
+                          ? "Ce niveau est complet. Aucune place restante."
+                          : null;
+
+                      return message ? (
+                        <p className="mt-3 rounded-2xl border border-warning/20 bg-warning/10 px-3 py-2 text-xs font-semibold text-slate-700">
+                          {message}
+                        </p>
+                      ) : null;
+                    })()}
                   </div>
                 </article>
               ))}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -925,7 +925,14 @@ const DashboardPage = () => {
                       const availablePlaces = level.availablePlaces ?? 0;
                       const remainingPlaces = level.remainingPlaces ?? availablePlaces - acceptedStudentsCount;
                       const remainingRatio = getRemainingPlacesRatio(remainingPlaces, availablePlaces);
-                      const isCapacityMissing = availablePlaces === 0;
+                      const isCapacityMissing = level.isCapacityConfigured === false;
+                      const remainingLabel = isCapacityMissing
+                        ? "Non renseigné"
+                        : remainingPlaces < 0
+                        ? "Surcapacité"
+                        : remainingPlaces === 0
+                        ? "Complet"
+                        : `${numberFormatter.format(remainingPlaces)} / ${numberFormatter.format(availablePlaces)}`;
 
                       return (
                         <div key={`${level.code}-remaining-slider`}>
@@ -940,9 +947,7 @@ const DashboardPage = () => {
                               </span>
                             </div>
                             <span className="shrink-0 text-xs font-semibold text-slate-600">
-                              {isCapacityMissing
-                                ? "Non renseigné"
-                                : `${numberFormatter.format(remainingPlaces)} / ${numberFormatter.format(availablePlaces)}`}
+                              {remainingLabel}
                             </span>
                           </div>
                           <div
@@ -992,6 +997,14 @@ const DashboardPage = () => {
                     const acceptedStudentsCount = level.acceptedStudentsCount ?? 0;
                     const availablePlaces = level.availablePlaces ?? 0;
                     const remainingPlaces = level.remainingPlaces ?? availablePlaces - acceptedStudentsCount;
+                    const isCapacityMissing = level.isCapacityConfigured === false;
+                    const remainingLabel = isCapacityMissing
+                      ? "Non renseigné"
+                      : remainingPlaces < 0
+                      ? "Surcapacité"
+                      : remainingPlaces === 0
+                      ? "Complet"
+                      : numberFormatter.format(remainingPlaces);
 
                     return (
                       <Link
@@ -1021,7 +1034,7 @@ const DashboardPage = () => {
                             { label: "Demandes", value: level.requestedStudentsCount ?? level.count },
                             { label: "Acceptés", value: acceptedStudentsCount },
                             { label: "Places", value: availablePlaces },
-                            { label: "Restantes", value: remainingPlaces }
+                            { label: "Restantes", value: remainingLabel }
                           ].map((metric) => {
                             const isRemainingMetric = metric.label === "Restantes";
 
@@ -1062,7 +1075,9 @@ const DashboardPage = () => {
                                     : undefined
                                 }
                               >
-                                {numberFormatter.format(metric.value)}
+                                {typeof metric.value === "number"
+                                  ? numberFormatter.format(metric.value)
+                                  : metric.value}
                               </p>
                             </div>
                             );

--- a/apps/web/src/pages/StudentDetailPage.tsx
+++ b/apps/web/src/pages/StudentDetailPage.tsx
@@ -12,6 +12,8 @@ import PersonAvatar, {
 import PriorityBadge from "../components/ui/PriorityBadge";
 import StudentStatusBadge, { getVisibleStudentStatus } from "../components/ui/StudentStatusBadge";
 import {
+  fetchDashboardStats,
+  getSchoolYearLevelCapacities,
   getStudentById,
   updateStudentAdmissionStatus,
   updateStudentPriority
@@ -21,6 +23,7 @@ import type {
   StudentListItem,
   VisibleStudentAdmissionStatus
 } from "../types/application";
+import type { DashboardLevelStat } from "../types/dashboard";
 
 const formatDate = new Intl.DateTimeFormat("fr-FR", {
   day: "2-digit",
@@ -81,6 +84,12 @@ const BackIcon = ({ className = "h-4 w-4" }: { className?: string }) => {
 const StudentDetailPage = () => {
   const { id } = useParams<{ id: string }>();
   const [student, setStudent] = useState<StudentListItem | null>(null);
+  const [levelCapacityByLevelId, setLevelCapacityByLevelId] = useState<
+    Record<string, { isConfigured: boolean; availablePlaces: number }>
+  >({});
+  const [activeLevelStatsByLevelId, setActiveLevelStatsByLevelId] = useState<
+    Record<string, DashboardLevelStat>
+  >({});
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isUpdatingStatus, setIsUpdatingStatus] = useState(false);
@@ -99,12 +108,38 @@ const StudentDetailPage = () => {
 
       try {
         const loadedStudent = await getStudentById(id, { signal });
+        const [capacities, dashboardStats] = await Promise.all([
+          getSchoolYearLevelCapacities(loadedStudent.application.schoolYear.id, { signal }),
+          loadedStudent.application.schoolYear.isActive
+            ? fetchDashboardStats({ signal })
+            : Promise.resolve(null)
+        ]);
 
         if (signal?.aborted) {
           return;
         }
 
         setStudent(loadedStudent);
+        setLevelCapacityByLevelId(
+          Object.fromEntries(
+            capacities.map((capacity) => [
+              capacity.levelId,
+              {
+                isConfigured: capacity.id !== null,
+                availablePlaces: capacity.availablePlaces
+              }
+            ])
+          )
+        );
+        setActiveLevelStatsByLevelId(
+          Object.fromEntries(
+            (dashboardStats?.byLevel ?? [])
+              .filter((level): level is DashboardLevelStat & { id: string } =>
+                typeof level.id === "string"
+              )
+              .map((level) => [level.id, level])
+          )
+        );
       } catch (loadError) {
         if (isAbortError(loadError) || signal?.aborted) {
           return;
@@ -156,6 +191,19 @@ const StudentDetailPage = () => {
               }
             : currentStudent
         );
+        if (student.application.schoolYear.isActive) {
+          const dashboardStats = await fetchDashboardStats();
+
+          setActiveLevelStatsByLevelId(
+            Object.fromEntries(
+              dashboardStats.byLevel
+                .filter((level): level is DashboardLevelStat & { id: string } =>
+                  typeof level.id === "string"
+                )
+                .map((level) => [level.id, level])
+            )
+          );
+        }
       } catch (updateError) {
         setError(
           updateError instanceof Error
@@ -247,6 +295,20 @@ const StudentDetailPage = () => {
   const visibleStatus = getVisibleStudentStatus(student.admissionStatus);
   const isAccepted = visibleStatus === "ACCEPTED";
   const isWaitlisted = visibleStatus === "WAITLISTED";
+  const levelCapacity = levelCapacityByLevelId[student.levelId];
+  const activeLevelStats = activeLevelStatsByLevelId[student.levelId];
+  const isCapacityMissing = levelCapacity?.isConfigured === false;
+  const isLevelFull =
+    student.application.schoolYear.isActive &&
+    typeof activeLevelStats?.remainingPlaces === "number" &&
+    activeLevelStats.remainingPlaces <= 0;
+  const acceptBlockMessage = isCapacityMissing
+    ? "Places disponibles non renseignées pour ce niveau."
+    : isLevelFull
+    ? "Ce niveau est complet. Aucune place restante."
+    : null;
+  const isAcceptDisabled =
+    isUpdatingStatus || isAccepted || Boolean(acceptBlockMessage);
 
   return (
     <>
@@ -292,7 +354,7 @@ const StudentDetailPage = () => {
               </button>
               <button
                 type="button"
-                disabled={isUpdatingStatus || isAccepted}
+                disabled={isAcceptDisabled}
                 onClick={() => void handleStatusChange("ACCEPTED")}
                 className="rounded-full bg-success px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-green-700 disabled:cursor-not-allowed disabled:opacity-55"
               >
@@ -308,6 +370,11 @@ const StudentDetailPage = () => {
               </button>
             </div>
           </div>
+          {acceptBlockMessage ? (
+            <p className="mt-4 rounded-2xl border border-white/15 bg-white/10 px-4 py-2 text-sm font-semibold text-white">
+              {acceptBlockMessage}
+            </p>
+          ) : null}
         </div>
 
         <div className="grid items-start gap-4 bg-[#fffaf2] p-5 sm:p-6 lg:grid-cols-3">

--- a/apps/web/src/types/dashboard.ts
+++ b/apps/web/src/types/dashboard.ts
@@ -1,4 +1,7 @@
-import type { ApplicationStatus } from "./application";
+import type {
+  ApplicationStatus,
+  StudentAdmissionStatus
+} from "./application";
 
 export type DashboardApplicationStatus = ApplicationStatus;
 
@@ -8,12 +11,19 @@ export type DashboardStats = {
   byStatus: Record<DashboardApplicationStatus, number>;
   byLevel: DashboardLevelStat[];
   priorityApplications: DashboardPriorityApplication[];
+  studentStats?: DashboardStudentStats;
 };
 
 export type DashboardLevelStat = {
+  id?: string;
   code: string;
   label: string;
   count: number;
+  requestedStudentsCount?: number;
+  acceptedStudentsCount?: number;
+  availablePlaces?: number;
+  isCapacityConfigured?: boolean;
+  remainingPlaces?: number;
 };
 
 export type DashboardPriorityApplication = {
@@ -34,10 +44,30 @@ export type DashboardPriorityApplication = {
 };
 
 export type DashboardPriorityStudent = {
+  id?: string;
   firstName: string;
   lastName: string;
+  admissionStatus?: StudentAdmissionStatus;
+  isPriority?: boolean;
   level: {
+    id?: string;
     code: string;
     label: string;
   };
+};
+
+export type DashboardStudentStats = {
+  totalStudents: number;
+  acceptedStudents: number;
+  waitlistedStudents: number;
+  byLevel: DashboardLevelStat[];
+  priorityStudents: Array<DashboardPriorityStudent & {
+    application: {
+      id: string;
+      isPriority: boolean;
+      createdAt: string;
+      schoolYear: DashboardPriorityApplication["schoolYear"];
+      family: DashboardPriorityApplication["family"];
+    };
+  }>;
 };


### PR DESCRIPTION
## 🎯 Objectif

Empêcher l’acceptation d’un élève lorsqu’il n’y a plus de place disponible dans son niveau pour la campagne active.

Cette PR ajoute un véritable verrou métier côté backend ainsi qu’une UX claire côté frontend pour éviter les erreurs de traitement.

## ✅ Changements principaux

### Backend — Contrôle de capacité

#### Blocage métier des acceptations
Ajout d’un contrôle dans `application.controller.ts` avant tout passage au statut `ACCEPTED`.

Le calcul est désormais dynamique :

remainingPlaces =
availablePlaces - acceptedStudentsCount

Règles appliquées :
- seuls les élèves `ACCEPTED` consomment une place ;
- les élèves `WAITLISTED` / `PENDING` ne consomment pas de place ;
- un élève déjà `ACCEPTED` peut être sauvegardé sans consommer une place supplémentaire ;
- une capacité absente bloque l’acceptation.

#### Gestion des erreurs métier
Ajout d’erreurs structurées :
- `LEVEL_CAPACITY_FULL`
- `LEVEL_CAPACITY_NOT_CONFIGURED`

Retour API :
- `409 Conflict`
- message métier explicite
- informations de capacité :
  - `levelCode`
  - `availablePlaces`
  - `acceptedStudentsCount`
  - `remainingPlaces`

#### Sécurisation concurrence
Ajout d’un verrou SQL `FOR UPDATE` sur la capacité du niveau afin de limiter les courses critiques lorsque deux administrateurs tentent d’accepter simultanément un élève sur la dernière place disponible.

### Frontend — Fiche élève

#### Désactivation intelligente du bouton Accepter
Sur la fiche élève :
- le bouton `Accepter` est désactivé lorsque :
  - le niveau est complet ;
  - la capacité n’est pas renseignée.

Ajout d’aides UX claires :
- `Ce niveau est complet. Aucune place restante.`
- `Places disponibles non renseignées pour ce niveau.`

#### Gestion des erreurs API
Si le backend refuse l’acceptation :
- affichage propre du message d’erreur ;
- aucun changement local de statut.

### Frontend — Détail demande / famille

Même logique appliquée sur les décisions individuelles :
- désactivation du bouton `Accepter` ;
- messages explicatifs ;
- gestion propre des erreurs API.

### Dashboard — Capacités niveaux

Le dashboard affiche désormais clairement :
- `Complet`
- `Surcapacité`
- `Non renseigné`

selon l’état des places restantes.

## 🧪 Vérifications effectuées

### Vérifications techniques
- `npm run build -w apps/api`
- `npm exec -w apps/web -- tsc -b`
- `npm run build -w apps/web`

## 📌 Résultat

L’application empêche maintenant toute acceptation incohérente lorsqu’un niveau n’a plus de capacité disponible, tout en conservant :
- un calcul dynamique fiable ;
- une cohérence dashboard ↔ traitement ;
- une UX claire pour l’administration.