### PR TITLE
feat(api): configure Gmail SMTP for real email sending

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,12 +14,12 @@ RUN_PRISMA_SEED=true
 SYNC_ADMIN_PASSWORD_ON_SEED=true
 
 # SMTP email sending
-SMTP_HOST=smtp.example.com
-SMTP_PORT=587
-SMTP_SECURE=false
-SMTP_USER=notifications@example.com
-SMTP_PASS=change-me
-SMTP_FROM="ECE Admissions <notifications@example.com>"
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=465
+SMTP_SECURE=true
+SMTP_USER=ece.inscriptions@gmail.com
+SMTP_PASS=replace_with_google_app_password_without_spaces
+MAIL_FROM="École ECE Narbonne — Service Inscriptions <ece.inscriptions@gmail.com>"
 
 # Admin authentication
 ADMIN_EMAIL=admin@example.com

--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@ Configuration de developpement locale pour lancer l'application complete avec Do
 cp .env.example .env
 ```
 
-3. Renseigner les variables Mailtrap dans `.env` si l'envoi mail doit etre teste :
+3. Renseigner les variables SMTP dans `.env` si l'envoi mail doit etre teste :
 
 ```env
-SMTP_HOST=sandbox.smtp.mailtrap.io
-SMTP_PORT=2525
-SMTP_USER=your-mailtrap-user
-SMTP_PASS=your-mailtrap-password
-SMTP_FROM="ECE Admissions <no-reply@ece.test>"
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=465
+SMTP_SECURE=true
+SMTP_USER=ece.inscriptions@gmail.com
+SMTP_PASS=replace_with_google_app_password_without_spaces
+MAIL_FROM="École ECE Narbonne — Service Inscriptions <ece.inscriptions@gmail.com>"
 ```
 
 4. Lancer toute la stack :
@@ -60,6 +61,18 @@ Password: change-me-now
 ```
 
 Ces valeurs se changent avec `ADMIN_EMAIL` et `ADMIN_PASSWORD` dans `.env`.
+
+## Configuration Gmail SMTP pour les tests réels
+
+Pour envoyer de vrais emails depuis Gmail, utiliser une adresse Gmail dediee aux inscriptions, par exemple `ece.inscriptions@gmail.com`. Activer la validation en deux etapes sur ce compte Google, puis generer un mot de passe d'application Google.
+
+Coller ce mot de passe d'application dans le vrai fichier `.env`, sur `SMTP_PASS`, sans espaces. Ne jamais commiter le vrai `.env` ni un vrai secret. La valeur de `.env.example` doit rester un placeholder.
+
+Apres modification de `.env`, redemarrer l'API Docker :
+
+```bash
+docker compose restart api
+```
 
 ## Commandes Utiles
 

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -132,7 +132,7 @@ export const config = {
     secure: readOptionalBoolean("SMTP_SECURE", false),
     user: readOptionalString("SMTP_USER"),
     pass: readOptionalString("SMTP_PASS"),
-    from: readOptionalString("SMTP_FROM")
+    from: readOptionalString("MAIL_FROM") ?? readOptionalString("SMTP_FROM")
   },
   admin: {
     email: readOptionalString("ADMIN_EMAIL"),

--- a/apps/api/src/services/mailer.service.ts
+++ b/apps/api/src/services/mailer.service.ts
@@ -15,6 +15,15 @@ type SendMailInput = {
   html?: string;
 };
 
+type SmtpErrorMetadata = {
+  name?: string;
+  message: string;
+  code?: unknown;
+  command?: unknown;
+  responseCode?: unknown;
+  response?: unknown;
+};
+
 const getSmtpConfig = () => {
   const { host, port, secure, user, pass, from } = config.email;
 
@@ -28,6 +37,43 @@ const getSmtpConfig = () => {
     secure,
     from,
     auth: { user, pass }
+  };
+};
+
+const redactSecret = (value: string): string => {
+  const { pass } = config.email;
+
+  if (!pass) {
+    return value;
+  }
+
+  return value.split(pass).join("[REDACTED]");
+};
+
+const getSmtpErrorMetadata = (error: unknown): SmtpErrorMetadata => {
+  if (!(error instanceof Error)) {
+    return {
+      message: redactSecret(String(error))
+    };
+  }
+
+  const errorWithMetadata = error as Error & {
+    code?: unknown;
+    command?: unknown;
+    responseCode?: unknown;
+    response?: unknown;
+  };
+
+  return {
+    name: error.name,
+    message: redactSecret(error.message),
+    code: errorWithMetadata.code,
+    command: errorWithMetadata.command,
+    responseCode: errorWithMetadata.responseCode,
+    response:
+      typeof errorWithMetadata.response === "string"
+        ? redactSecret(errorWithMetadata.response)
+        : errorWithMetadata.response
   };
 };
 
@@ -105,13 +151,18 @@ const sendMail = async ({
     auth: smtpConfig.auth
   });
 
-  await transporter.sendMail({
-    from: smtpConfig.from,
-    to,
-    subject,
-    text,
-    html
-  });
+  try {
+    await transporter.sendMail({
+      from: smtpConfig.from,
+      to,
+      subject,
+      text,
+      html
+    });
+  } catch (error) {
+    console.error("SMTP email sending failed", getSmtpErrorMetadata(error));
+    throw new Error("Email sending failed");
+  }
 };
 
 export const sendApplicationMail = async ({

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       SMTP_SECURE: ${SMTP_SECURE:-false}
       SMTP_USER: ${SMTP_USER:-}
       SMTP_PASS: ${SMTP_PASS:-}
+      MAIL_FROM: ${MAIL_FROM:-}
       SMTP_FROM: ${SMTP_FROM:-}
       ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@example.com}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD:-change-me-now}


### PR DESCRIPTION
gh pr create \
  --base dev \
  --head feature/gmail-smtp-ece \
  --title "feat(api): configure Gmail SMTP for ECE email sending" \
  --body "## Résumé
- Configure l’envoi SMTP réel via Gmail pour l’adresse dédiée ece.inscriptions@gmail.com.
- Ajoute MAIL_FROM comme variable principale avec fallback SMTP_FROM.
- Transmet MAIL_FROM au service API Docker.
- Met à jour .env.example avec la configuration Gmail sans secret réel.
- Améliore les logs SMTP sans exposer SMTP_PASS.
- Documente la configuration Gmail SMTP dans le README.

## Vérifications
- npm run build -w apps/api : OK
- npm run lint -w apps/api : non lancé, aucun script lint n’existe dans apps/api.

## Notes
Le vrai mot de passe d’application Google doit rester uniquement dans le .env local, sans espaces, et ne doit jamais être commité."