### PR TITLE
feat(api): improve ECE email branding and signature

### DIFF
--- a/apps/api/src/services/mailer.service.ts
+++ b/apps/api/src/services/mailer.service.ts
@@ -24,6 +24,44 @@ type SmtpErrorMetadata = {
   response?: unknown;
 };
 
+const INSTITUTIONAL_TEXT_SIGNATURE = `Cordialement,
+
+École ECE Narbonne
+Service Inscriptions
+
+📧 ece.inscriptions@gmail.com`;
+
+const appendTextSignature = (value: string): string => {
+  return `${value.trimEnd()}\n\n${INSTITUTIONAL_TEXT_SIGNATURE}`;
+};
+
+const buildEceLogoHtml = (): string => {
+  return `<div style="margin:0 0 22px;">
+          <span style="display:inline-block;border:1px solid #E6E1D8;border-radius:10px;background:#FFFFFF;padding:8px 11px;font-family:Arial,Helvetica,sans-serif;font-size:0;line-height:1;box-shadow:0 6px 16px rgba(31,41,55,0.06);">
+            <span style="display:inline-block;color:#1F8A3A;font-size:24px;font-weight:800;letter-spacing:0;line-height:1;">E</span>
+            <span style="display:inline-block;color:#E7C74D;font-size:24px;font-weight:800;letter-spacing:0;line-height:1;">C</span>
+            <span style="display:inline-block;color:#1F8A3A;font-size:24px;font-weight:800;letter-spacing:0;line-height:1;">E</span>
+          </span>
+        </div>`;
+};
+
+const buildInstitutionalSignatureHtml = (): string => {
+  return `<div style="border-top:1px solid #E5E7EB;margin:26px 0 0;padding:18px 0 0;">
+          <p style="margin:0 0 12px;color:#6B7280;font-size:14px;line-height:1.65;">
+            Cordialement,
+          </p>
+          <p style="margin:0;color:#4B5563;font-size:14px;font-weight:700;line-height:1.55;">
+            École ECE Narbonne<br />
+            Service Inscriptions
+          </p>
+          <p style="margin:10px 0 0;color:#6B7280;font-size:13px;line-height:1.55;">
+            <a href="mailto:ece.inscriptions@gmail.com" style="color:#1F8A3A;text-decoration:none;">
+              📧 ece.inscriptions@gmail.com
+            </a>
+          </p>
+        </div>`;
+};
+
 const getSmtpConfig = () => {
   const { host, port, secure, user, pass, from } = config.email;
 
@@ -102,6 +140,8 @@ const textToHtmlParagraphs = (value: string): string => {
 const buildApplicationMailHtml = (subject: string, body: string): string => {
   const safeSubject = escapeHtml(subject);
   const htmlBody = textToHtmlParagraphs(body);
+  const logoHtml = buildEceLogoHtml();
+  const signatureHtml = buildInstitutionalSignatureHtml();
 
   return `<!doctype html>
 <html lang="fr">
@@ -113,24 +153,14 @@ const buildApplicationMailHtml = (subject: string, body: string): string => {
   <body style="margin:0;background:#F8F6F2;color:#1F2937;font-family:Arial,Helvetica,sans-serif;">
     <div style="background:#F8F6F2;padding:32px 16px;">
       <div style="max-width:640px;margin:0 auto;background:#FFFFFF;border:1px solid #E5E7EB;border-radius:16px;padding:32px;box-shadow:0 16px 36px rgba(31,41,55,0.08);">
-        <div style="margin:0 0 18px;">
-          <span style="display:inline-block;border-radius:999px;background:#D4A24C;color:#FFFFFF;font-size:12px;font-weight:700;letter-spacing:0.04em;line-height:1;padding:8px 12px;text-transform:uppercase;">
-            ECE
-          </span>
-        </div>
+        ${logoHtml}
         <h1 style="margin:0 0 24px;color:#1F4D3A;font-family:Georgia,'Times New Roman',serif;font-size:28px;line-height:1.2;">
           ${safeSubject}
         </h1>
         <div style="color:#1F2937;font-size:15px;line-height:1.7;">
           ${htmlBody}
         </div>
-        <hr style="border:none;border-top:1px solid #E5E7EB;margin:24px 0;" />
-        <p style="margin:0;color:#6B7280;font-size:13px;line-height:1.6;">
-          École de la Culture et de l’Éducation
-        </p>
-        <p style="margin:8px 0 0;color:#9CA3AF;font-size:12px;line-height:1.5;">
-          Cet email concerne le suivi de votre demande d'inscription auprès de l'ECE.
-        </p>
+        ${signatureHtml}
       </div>
     </div>
   </body>
@@ -156,7 +186,7 @@ const sendMail = async ({
       from: smtpConfig.from,
       to,
       subject,
-      text,
+      text: appendTextSignature(text),
       html
     });
   } catch (error) {
@@ -195,6 +225,8 @@ export const sendPasswordResetMail = async (
   resetLink: string
 ): Promise<void> => {
   const safeResetLink = escapeHtml(resetLink);
+  const logoHtml = buildEceLogoHtml();
+  const signatureHtml = buildInstitutionalSignatureHtml();
   const text = `Bonjour,
 
 Une demande de réinitialisation de mot de passe a été effectuée pour votre compte administrateur.
@@ -205,10 +237,7 @@ ${resetLink}
 
 Ce lien est valable 30 minutes.
 
-Si vous n’êtes pas à l’origine de cette demande, vous pouvez ignorer cet email.
-
-Cordialement,
-L’administration de l’École de la Culture et de l’Éducation`;
+Si vous n’êtes pas à l’origine de cette demande, vous pouvez ignorer cet email.`;
 
   await sendMail({
     to,
@@ -224,6 +253,7 @@ L’administration de l’École de la Culture et de l’Éducation`;
   <body style="margin:0;background:#f8f6f2;color:#172033;font-family:Arial,Helvetica,sans-serif;">
     <div style="padding:32px 16px;">
       <div style="margin:0 auto;max-width:560px;border:1px solid #ede7de;border-radius:18px;background:#ffffff;padding:32px;box-shadow:0 18px 40px rgba(15,23,42,0.08);">
+        ${logoHtml}
         <h1 style="margin:0 0 18px;color:#1F4D3A;font-family:Georgia,'Times New Roman',serif;font-size:30px;line-height:1.15;">
           Réinitialisation de votre mot de passe
         </h1>
@@ -247,10 +277,7 @@ L’administration de l’École de la Culture et de l’Éducation`;
         <p style="margin:0 0 22px;color:#334155;font-size:15px;line-height:1.65;">
           Si vous n’êtes pas à l’origine de cette demande, vous pouvez ignorer cet email.
         </p>
-        <p style="margin:0;color:#64748b;font-size:14px;line-height:1.6;">
-          Cordialement,<br />
-          L’administration de l’École de la Culture et de l’Éducation
-        </p>
+        ${signatureHtml}
       </div>
     </div>
   </body>


### PR DESCRIPTION
gh pr create \
  --base dev \
  --head feature/email-signature-polish \
  --title "feat(api): improve ECE email branding and signature" \
  --body "## Résumé
- Ajoute une signature institutionnelle automatique aux emails ECE.
- Améliore le rendu HTML des signatures avec séparateur discret et lien mailto.
- Remplace le badge ECE doré par un mini logo inline HTML/CSS respectant l’identité visuelle ECE.
- Applique le nouveau branding aux emails de décision et reset password.
- Supprime les anciens pieds de mail dupliqués.

## Détails visuels
Logo ECE :
- E vert (#1F8A3A)
- C doré (#E7C74D)
- E vert (#1F8A3A)

Signature :
- “Cordialement,”
- École ECE Narbonne
- Service Inscriptions
- ece.inscriptions@gmail.com

## Vérifications
- npm run build -w apps/api : OK

## Notes
Aucune modification :
- routes API
- frontend
- logique métier
- ApplicationEmailLog
- configuration SMTP"