### PR TITLE
feat(web): improve email decision workflow UX

### DIFF
--- a/apps/web/src/pages/ApplicationEmailPage.tsx
+++ b/apps/web/src/pages/ApplicationEmailPage.tsx
@@ -4,6 +4,7 @@ import {
   useMemo,
   useState,
   type CSSProperties,
+  type FormEvent,
   type ReactNode
 } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
@@ -25,7 +26,8 @@ import { useToast } from "../context/ToastContext";
 import {
   getApplicationById,
   getApplicationEmailLogs,
-  sendApplicationEmail
+  sendApplicationEmail,
+  updateApplicationContactEmail
 } from "../lib/api";
 import {
   applicationEmailSendStatusLabels,
@@ -127,6 +129,18 @@ const formatParentName = (
   return parts.length > 0 ? parts.join(" ") : "Non renseigné";
 };
 
+const getActionErrorMessage = (fallbackMessage: string, error: unknown): string => {
+  if (!(error instanceof Error) || error.message.trim().length === 0) {
+    return fallbackMessage;
+  }
+
+  if (error.message === fallbackMessage) {
+    return fallbackMessage;
+  }
+
+  return `${fallbackMessage} ${error.message}`;
+};
+
 const getApplicationFamilyTitle = (
   application: ApplicationDetail | null
 ): string => {
@@ -216,6 +230,24 @@ const SendIcon = ({ className = "h-4 w-4" }: IconProps) => {
   );
 };
 
+const EditIcon = ({ className = "h-4 w-4" }: IconProps) => {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.6"
+      className={className}
+    >
+      <path d="M9.75 3.25 12.75 6.25" />
+      <path d="M3.5 10.5 10.75 3.25a2.12 2.12 0 0 1 3 3L6.5 13.5H3.25l.25-3Z" />
+    </svg>
+  );
+};
+
 const DetailField = ({ label, children }: DetailFieldProps) => {
   return (
     <div className="rounded-2xl border border-slate-200/90 bg-white/80 p-4 shadow-[0_10px_24px_-24px_rgba(15,23,42,0.18)]">
@@ -279,6 +311,10 @@ const ApplicationEmailPage = () => {
   const [isEmailSubmitting, setIsEmailSubmitting] = useState(false);
   const [isSendConfirmationOpen, setIsSendConfirmationOpen] = useState(false);
   const [hasEmailSendSuccess, setHasEmailSendSuccess] = useState(false);
+  const [isContactEmailModalOpen, setIsContactEmailModalOpen] = useState(false);
+  const [contactEmailDraft, setContactEmailDraft] = useState("");
+  const [contactEmailError, setContactEmailError] = useState<string | null>(null);
+  const [isUpdatingContactEmail, setIsUpdatingContactEmail] = useState(false);
 
   const resetEmailForm = useCallback((
     nextApplication?: ApplicationDetail,
@@ -548,6 +584,78 @@ const ApplicationEmailPage = () => {
     setIsSendConfirmationOpen(false);
   }, [selectedEmailType, emailSubject, emailBody]);
 
+  useEffect(() => {
+    setIsContactEmailModalOpen(false);
+    setContactEmailDraft("");
+    setContactEmailError(null);
+  }, [application?.id]);
+
+  const handleOpenContactEmailModal = useCallback((): void => {
+    setContactEmailDraft(application?.family.contactEmail ?? "");
+    setContactEmailError(null);
+    setIsContactEmailModalOpen(true);
+  }, [application?.family.contactEmail]);
+
+  const handleCloseContactEmailModal = useCallback((): void => {
+    if (isUpdatingContactEmail) {
+      return;
+    }
+
+    setIsContactEmailModalOpen(false);
+    setContactEmailError(null);
+  }, [isUpdatingContactEmail]);
+
+  const handleSubmitContactEmailUpdate = useCallback(
+    async (event: FormEvent<HTMLFormElement>): Promise<void> => {
+      event.preventDefault();
+
+      if (!application) {
+        return;
+      }
+
+      const normalizedEmail = contactEmailDraft.trim();
+
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedEmail)) {
+        setContactEmailError("Veuillez saisir une adresse email valide.");
+        return;
+      }
+
+      setIsUpdatingContactEmail(true);
+      setContactEmailError(null);
+
+      try {
+        const updateResult = await updateApplicationContactEmail(
+          application.id,
+          normalizedEmail
+        );
+
+        setApplication((currentApplication) =>
+          currentApplication
+            ? {
+                ...currentApplication,
+                family: {
+                  ...currentApplication.family,
+                  ...updateResult.family
+                }
+              }
+            : currentApplication
+        );
+        setIsContactEmailModalOpen(false);
+        showSuccess("L'email de contact a bien été corrigé.");
+      } catch (updateError) {
+        setContactEmailError(
+          getActionErrorMessage(
+            "Impossible de corriger l'email de contact.",
+            updateError
+          )
+        );
+      } finally {
+        setIsUpdatingContactEmail(false);
+      }
+    },
+    [application, contactEmailDraft, showSuccess]
+  );
+
   const detailPath = applicationId ? `/applications/${applicationId}` : "/applications";
   const decisionEmailContext = useMemo(() => {
     return application ? getApplicationDecisionEmailContext(application) : null;
@@ -692,9 +800,21 @@ const ApplicationEmailPage = () => {
               <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
                 Destinataire
               </p>
-              <p className="mt-2 break-all text-sm font-semibold text-slate-900">
-                {formatOptionalText(application.family.contactEmail)}
-              </p>
+              <div className="mt-2 flex items-center justify-between gap-3">
+                <p className="min-w-0 break-all text-sm font-semibold text-slate-900">
+                  {formatOptionalText(application.family.contactEmail)}
+                </p>
+                <button
+                  type="button"
+                  onClick={handleOpenContactEmailModal}
+                  className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-primary/15 bg-primary/5 text-primary transition hover:border-secondary/40 hover:bg-secondary/10 hover:text-secondaryDark"
+                  aria-label="Modifier l'email de contact"
+                  title="Modifier l'email de contact"
+                  disabled={isEmailSubmitting}
+                >
+                  <EditIcon />
+                </button>
+              </div>
             </div>
 
             {decisionEmailContext.warnings.length > 0 ? (
@@ -882,7 +1002,21 @@ const ApplicationEmailPage = () => {
               <StatusBadge status={application.status} />
             </DetailField>
             <DetailField label="Contact">
-              {formatOptionalText(application.family.contactEmail)}
+              <div className="flex items-center justify-between gap-3">
+                <span className="min-w-0 break-all">
+                  {formatOptionalText(application.family.contactEmail)}
+                </span>
+                <button
+                  type="button"
+                  onClick={handleOpenContactEmailModal}
+                  className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-primary/15 bg-primary/5 text-primary transition hover:border-secondary/40 hover:bg-secondary/10 hover:text-secondaryDark"
+                  aria-label="Modifier l'email de contact"
+                  title="Modifier l'email de contact"
+                  disabled={isEmailSubmitting}
+                >
+                  <EditIcon />
+                </button>
+              </div>
             </DetailField>
           </div>
 
@@ -1056,6 +1190,82 @@ const ApplicationEmailPage = () => {
               </button>
             </div>
           </div>
+        </div>
+      ) : null}
+
+      {isContactEmailModalOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/35 px-4 py-6 backdrop-blur-sm">
+          <form
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="contact-email-edit-title"
+            className="w-full max-w-lg rounded-[28px] border border-white/80 bg-white p-6 shadow-[0_24px_70px_-24px_rgba(15,23,42,0.45)]"
+            onSubmit={handleSubmitContactEmailUpdate}
+          >
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-secondaryDark">
+              Correction administrative
+            </p>
+            <h2
+              id="contact-email-edit-title"
+              className="mt-2 text-2xl font-semibold text-slate-900"
+            >
+              Modifier l'email de contact ?
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              Cette adresse est utilisée pour le suivi et l'envoi des emails à
+              la famille. Corrigez-la uniquement en cas d'erreur de saisie
+              constatée.
+            </p>
+
+            <label className="mt-5 block">
+              <span className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                Nouvel email de contact
+              </span>
+              <input
+                type="email"
+                value={contactEmailDraft}
+                onChange={(event) => {
+                  setContactEmailDraft(event.target.value);
+                  setContactEmailError(null);
+                }}
+                className="mt-2 w-full rounded-2xl border border-primary/15 bg-white px-4 py-3 text-sm font-semibold text-slate-900 outline-none transition placeholder:text-slate-400 hover:border-primary/30 focus:border-secondary focus:ring-2 focus:ring-secondary/20"
+                placeholder="famille@example.com"
+                disabled={isUpdatingContactEmail}
+                autoFocus
+              />
+            </label>
+
+            <div className="mt-4 rounded-[20px] border border-warning/20 bg-warning/10 px-4 py-3 text-sm leading-6 text-slate-700">
+              Email actuel :{" "}
+              <span className="font-semibold text-slate-900">
+                {formatOptionalText(application.family.contactEmail)}
+              </span>
+            </div>
+
+            {contactEmailError ? (
+              <p className="mt-3 rounded-[18px] border border-danger/20 bg-danger/10 px-4 py-3 text-sm font-medium text-danger">
+                {contactEmailError}
+              </p>
+            ) : null}
+
+            <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                onClick={handleCloseContactEmailModal}
+                disabled={isUpdatingContactEmail}
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-5 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-primary/25 hover:text-primary disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Annuler
+              </button>
+              <button
+                type="submit"
+                disabled={isUpdatingContactEmail}
+                className="inline-flex items-center justify-center rounded-full bg-secondary px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-secondaryDark disabled:cursor-wait disabled:opacity-70"
+              >
+                {isUpdatingContactEmail ? "Correction..." : "Corriger l'email"}
+              </button>
+            </div>
+          </form>
         </div>
       ) : null}
     </>

--- a/apps/web/src/pages/ApplicationsPage.tsx
+++ b/apps/web/src/pages/ApplicationsPage.tsx
@@ -18,9 +18,11 @@ import EmptyState from "../components/ui/EmptyState";
 import ErrorState from "../components/ui/ErrorState";
 import LevelBadge from "../components/ui/LevelBadge";
 import LoadingState from "../components/ui/LoadingState";
+import { FamilyAvatar } from "../components/ui/PersonAvatar";
 import PriorityBadge from "../components/ui/PriorityBadge";
 import StatusBadge from "../components/ui/StatusBadge";
 import { getApplications, getSchoolYears } from "../lib/api";
+import { consumePostLoginFilterDefaults } from "../lib/postLoginFilterDefaults";
 import type {
   ApplicationFilterParams,
   ApplicationListItem,
@@ -432,8 +434,14 @@ const PaginationControls = memo(function PaginationControls({
 const ApplicationsPage = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const [storedListViewState] = useState(() => readStoredApplicationsListViewState());
+  const [storedListViewState] = useState(() =>
+    consumePostLoginFilterDefaults("applications")
+      ? {}
+      : readStoredApplicationsListViewState()
+  );
   const requestedSchoolYearId = searchParams.get("schoolYearId")?.trim() ?? "";
+  const hasRequestedStatusFilter = searchParams.has("status");
+  const hasRequestedPriorityFilter = searchParams.has("isPriority");
   const requestedStatus = getRequestedStatusFilter(searchParams);
   const requestedPriority = getRequestedPriorityFilter(searchParams);
   const storedFilters = storedListViewState.filters;
@@ -444,9 +452,11 @@ const ApplicationsPage = () => {
     requestedSchoolYearId.length > 0 || hasStoredListViewState
   );
   const [filters, setFilters] = useState<FilterState>(() => ({
-    status: requestedStatus || (storedFilters?.status ?? ""),
+    status: hasRequestedStatusFilter ? requestedStatus : (storedFilters?.status ?? ""),
     schoolYearId: requestedSchoolYearId || storedFilters?.schoolYearId || "",
-    isPriority: requestedPriority || (storedFilters?.isPriority ?? ""),
+    isPriority: hasRequestedPriorityFilter
+      ? requestedPriority
+      : (storedFilters?.isPriority ?? ""),
     search: storedFilters?.search ?? ""
   }));
   const [sort, setSort] = useState<SortOption>(
@@ -594,21 +604,37 @@ const ApplicationsPage = () => {
     requestedSchoolYearId.length === 0 && !hasInitializedSchoolYearFilter;
 
   useEffect(() => {
+    if (!hasRequestedStatusFilter && !hasRequestedPriorityFilter) {
+      return;
+    }
+
     setFilters((currentFilters) => {
+      const nextStatus = hasRequestedStatusFilter
+        ? requestedStatus
+        : currentFilters.status;
+      const nextPriority = hasRequestedPriorityFilter
+        ? requestedPriority
+        : currentFilters.isPriority;
+
       if (
-        currentFilters.status === requestedStatus &&
-        currentFilters.isPriority === requestedPriority
+        currentFilters.status === nextStatus &&
+        currentFilters.isPriority === nextPriority
       ) {
         return currentFilters;
       }
 
       return {
         ...currentFilters,
-        status: requestedStatus,
-        isPriority: requestedPriority
+        status: nextStatus,
+        isPriority: nextPriority
       };
     });
-  }, [requestedPriority, requestedStatus]);
+  }, [
+    hasRequestedPriorityFilter,
+    hasRequestedStatusFilter,
+    requestedPriority,
+    requestedStatus
+  ]);
 
   const resetFilters = useCallback((): void => {
     setFilters({
@@ -1155,6 +1181,11 @@ const ApplicationsPage = () => {
               <div className="space-y-3">
                 {currentPageApplications.map((application, index) => {
                   const createdAtDate = new Date(application.createdAt);
+                  const familyDisplayName = getFamilyDisplayName(application);
+                  const familyAvatarLabel =
+                    familyDisplayName === "Famille non renseignée"
+                      ? familyDisplayName
+                      : `Famille ${familyDisplayName}`;
                   const rowSurfaceClassName = application.isPriority
                     ? "border-secondary/20 bg-secondary/5"
                     : "border-slate-200/90 bg-slate-50/80";
@@ -1164,23 +1195,26 @@ const ApplicationsPage = () => {
                       key={application.id}
                       role="link"
                       tabIndex={0}
-                      aria-label={`Ouvrir la demande de la famille ${getFamilyDisplayName(application)}`}
+                      aria-label={`Ouvrir la demande de la famille ${familyDisplayName}`}
                       onClick={() => openApplicationDetail(application.id)}
                       onKeyDown={(event) => handleApplicationRowKeyDown(event, application.id)}
                       className={`group ui-animate-in ui-surface-hover ui-surface-hover--soft cursor-pointer rounded-[28px] border p-4 shadow-[0_14px_30px_-24px_rgba(15,23,42,0.16)] outline-none transition focus-visible:ring-4 focus-visible:ring-primary/20 sm:p-5 ${rowSurfaceClassName}`}
                       style={getEnterStyle(310 + index * 55)}
                     >
                       <div className="grid gap-4 xl:grid-cols-[minmax(0,1.5fr)_170px_minmax(0,1.7fr)_180px_130px_108px] xl:items-center">
-                        <div className="min-w-0">
-                          <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500 xl:hidden">
-                            Famille
-                          </p>
-                          <h3 className="mt-1 text-lg font-semibold text-slate-900 xl:mt-0">
-                            Famille {getFamilyDisplayName(application)}
-                          </h3>
-                          <p className="mt-1 break-all text-sm text-slate-500">
-                            {application.family.contactEmail ?? "Contact non renseigné"}
-                          </p>
+                        <div className="flex min-w-0 items-center gap-4">
+                          <FamilyAvatar label={familyAvatarLabel} size="md" />
+                          <div className="min-w-0">
+                            <p className="text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-slate-500 xl:hidden">
+                              Famille
+                            </p>
+                            <h3 className="mt-1 text-lg font-semibold text-slate-900 xl:mt-0">
+                              Famille {familyDisplayName}
+                            </h3>
+                            <p className="mt-1 break-all text-sm text-slate-500">
+                              {application.family.contactEmail ?? "Contact non renseigné"}
+                            </p>
+                          </div>
                         </div>
 
                         <div>

--- a/apps/web/src/pages/EmailsPage.tsx
+++ b/apps/web/src/pages/EmailsPage.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useMemo, useState, type ChangeEvent } from "react";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type ChangeEvent
+} from "react";
 import { Link } from "react-router-dom";
 
 import PageSectionHeader from "../components/layout/PageSectionHeader";
@@ -62,6 +68,12 @@ const formatOptionalDateTime = (value: string | null): string => {
   return value ? dateTimeFormatter.format(new Date(value)) : "Non envoyé";
 };
 
+const getEnterStyle = (delay: number): CSSProperties => {
+  return {
+    "--ui-enter-delay": `${delay}ms`
+  } as CSSProperties;
+};
+
 const formatParentName = (
   firstName: string | null | undefined,
   lastName: string | null | undefined
@@ -117,10 +129,12 @@ const getApplicationSearchText = (application: ReadyEmailApplication): string =>
 
 const SummaryCard = ({
   label,
+  motionDelay = 0,
   value,
   tone = "default"
 }: {
   label: string;
+  motionDelay?: number;
   value: number;
   tone?: "default" | "success" | "info" | "gold";
 }) => {
@@ -132,7 +146,10 @@ const SummaryCard = ({
   };
 
   return (
-    <article className={`rounded-[26px] border p-5 shadow-[0_18px_36px_-32px_rgba(15,23,42,0.35)] ${toneClassNames[tone]}`}>
+    <article
+      className={`ui-animate-in ui-surface-hover ui-surface-hover--soft rounded-[26px] border p-5 shadow-[0_18px_36px_-32px_rgba(15,23,42,0.35)] ${toneClassNames[tone]}`}
+      style={getEnterStyle(motionDelay)}
+    >
       <p className="text-3xl font-semibold">{value}</p>
       <p className="mt-2 text-xs font-semibold uppercase tracking-[0.2em]">
         {label}
@@ -230,11 +247,13 @@ const EmailsPage = () => {
   if (isLoading) {
     return (
       <>
-        <PageSectionHeader
-          eyebrow="E-mail"
-          title="E-mails de décision"
-          description="Demandes prêtes pour l'envoi aux familles."
-        />
+        <div className="ui-animate-in ui-animate-in--subtle" style={getEnterStyle(120)}>
+          <PageSectionHeader
+            eyebrow="E-mail"
+            title="E-mails de décision"
+            description="Demandes prêtes pour l'envoi aux familles."
+          />
+        </div>
         <LoadingState />
       </>
     );
@@ -243,11 +262,13 @@ const EmailsPage = () => {
   if (error && applications.length === 0) {
     return (
       <>
-        <PageSectionHeader
-          eyebrow="E-mail"
-          title="E-mails de décision"
-          description="Demandes prêtes pour l'envoi aux familles."
-        />
+        <div className="ui-animate-in ui-animate-in--subtle" style={getEnterStyle(120)}>
+          <PageSectionHeader
+            eyebrow="E-mail"
+            title="E-mails de décision"
+            description="Demandes prêtes pour l'envoi aux familles."
+          />
+        </div>
         <ErrorState
           message={error}
           actionLabel="Réessayer"
@@ -259,26 +280,31 @@ const EmailsPage = () => {
 
   return (
     <>
-      <PageSectionHeader
-        eyebrow="E-mail"
-        title="E-mails de décision"
-        description="Demandes prêtes pour l'envoi aux familles."
-        aside={
-          <span className="rounded-full border border-primary/15 bg-white px-4 py-2 text-sm font-semibold text-primaryDark">
-            {displayedApplications.length} dossier{displayedApplications.length > 1 ? "s" : ""}
-          </span>
-        }
-      />
+      <div className="ui-animate-in ui-animate-in--subtle" style={getEnterStyle(120)}>
+        <PageSectionHeader
+          eyebrow="E-mail"
+          title="E-mails de décision"
+          description="Demandes prêtes pour l'envoi aux familles."
+          aside={
+            <span className="rounded-full border border-primary/15 bg-white px-4 py-2 text-sm font-semibold text-primaryDark">
+              {displayedApplications.length} dossier{displayedApplications.length > 1 ? "s" : ""}
+            </span>
+          }
+        />
+      </div>
 
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
-        <SummaryCard label="Prêtes" value={summary.total} />
-        <SummaryCard label="Acceptées" value={summary.accepted} tone="success" />
-        <SummaryCard label="En attente" value={summary.waitlisted} tone="info" />
-        <SummaryCard label="Partielles" value={summary.partial} tone="gold" />
-        <SummaryCard label="Déjà envoyées" value={summary.sent} tone="default" />
+        <SummaryCard label="Prêtes" value={summary.total} motionDelay={180} />
+        <SummaryCard label="Acceptées" value={summary.accepted} tone="success" motionDelay={220} />
+        <SummaryCard label="En attente" value={summary.waitlisted} tone="info" motionDelay={260} />
+        <SummaryCard label="Partielles" value={summary.partial} tone="gold" motionDelay={300} />
+        <SummaryCard label="Déjà envoyées" value={summary.sent} tone="default" motionDelay={340} />
       </section>
 
-      <section className="mt-6 overflow-hidden rounded-[30px] border border-primary/15 bg-white/90 shadow-[0_24px_48px_-36px_rgba(15,23,42,0.32)]">
+      <section
+        className="ui-animate-in ui-surface-hover ui-surface-hover--soft ui-surface-hover--no-accent mt-6 overflow-hidden rounded-[30px] border border-primary/15 bg-white/90 shadow-[0_24px_48px_-36px_rgba(15,23,42,0.32)]"
+        style={getEnterStyle(400)}
+      >
         <div className="border-b border-secondary/25 bg-[#fffaf2] px-5 py-5 sm:px-6">
           <div className="grid gap-4 xl:grid-cols-[minmax(260px,0.8fr)_minmax(0,1.2fr)] xl:items-center">
             <label className="block">
@@ -332,10 +358,11 @@ const EmailsPage = () => {
             />
           ) : (
             <div className="space-y-4">
-              {displayedApplications.map((application) => (
+              {displayedApplications.map((application, index) => (
                 <article
                   key={application.id}
-                  className="rounded-[26px] border border-slate-200/90 bg-white p-5 shadow-[0_18px_36px_-32px_rgba(15,23,42,0.35)]"
+                  className="ui-animate-in ui-surface-hover ui-surface-hover--soft rounded-[26px] border border-slate-200/90 bg-white p-5 shadow-[0_18px_36px_-32px_rgba(15,23,42,0.35)]"
+                  style={getEnterStyle(460 + index * 35)}
                 >
                   <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
                     <div className="min-w-0">
@@ -390,14 +417,16 @@ const EmailsPage = () => {
                     ))}
                   </div>
 
-                  <div className="mt-5 flex justify-end">
-                    <Link
-                      to={`/applications/${application.id}/email`}
-                      className="inline-flex items-center rounded-full bg-secondary px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-secondaryDark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary"
-                    >
-                      Préparer l'e-mail
-                    </Link>
-                  </div>
+                  {!application.hasSentEmail ? (
+                    <div className="mt-5 flex justify-end">
+                      <Link
+                        to={`/applications/${application.id}/email`}
+                        className="inline-flex items-center rounded-full bg-secondary px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-secondaryDark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-secondary"
+                      >
+                        Préparer l'e-mail
+                      </Link>
+                    </div>
+                  ) : null}
                 </article>
               ))}
             </div>


### PR DESCRIPTION
gh pr create \
  --base dev \
  --head feature/email-decision-page-ux \
  --title "feat(web): improve email decision workflow UX" \
  --body "## Résumé
- Masque le bouton “Préparer l'e-mail” lorsqu’un email a déjà été envoyé.
- Ajoute la modification de l’email destinataire sur la page d’envoi d’email avec la même modale que la page détail demande.
- Ajoute les avatars famille dans les cards de la liste des demandes.

## Détails
### EmailsPage
- Le bouton “Préparer l'e-mail” n’apparaît plus si application.hasSentEmail est vrai.
- Le badge “Email déjà envoyé” reste affiché.

### ApplicationEmailPage
- Ajout du bouton de modification email sur :
  - bloc Destinataire
  - bloc Contact
- Réutilisation exacte de la modale existante de la page détail demande.
- Mise à jour immédiate de l’adresse affichée après modification.

### ApplicationsPage
- Intégration du composant FamilyAvatar dans les cards liste demandes.
- Alignement propre avec nom + email famille.
- Label accessible cohérent.

## Vérifications
- npm run build -w apps/web : OK

## Notes
- Warning Vite sur chunk JS > 500 kB non bloquant.
- Aucun changement backend ou logique métier."