### PR TITLE
fix(auth): configure admin recovery email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,5 +22,5 @@ SMTP_PASS=replace_with_google_app_password_without_spaces
 MAIL_FROM="École ECE Narbonne — Service Inscriptions <ece.inscriptions@gmail.com>"
 
 # Admin authentication
-ADMIN_EMAIL=admin@example.com
+ADMIN_EMAIL=ece.inscriptions@gmail.com
 ADMIN_PASSWORD=change-me-now

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Le service `web` lance Vite en mode dev avec HMR.
 Identifiants admin par defaut en dev :
 
 ```text
-Email: admin@example.com
+Email: ece.inscriptions@gmail.com
 Password: change-me-now
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       SMTP_PASS: ${SMTP_PASS:-}
       MAIL_FROM: ${MAIL_FROM:-}
       SMTP_FROM: ${SMTP_FROM:-}
-      ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@example.com}
+      ADMIN_EMAIL: ${ADMIN_EMAIL:-ece.inscriptions@gmail.com}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD:-change-me-now}
       SEED_DEMO_DATA: ${SEED_DEMO_DATA:-false}
       SYNC_ADMIN_PASSWORD_ON_SEED: ${SYNC_ADMIN_PASSWORD_ON_SEED:-true}


### PR DESCRIPTION
Configure l’adresse administrateur de récupération par défaut sur ece.inscriptions@gmail.com dans les fichiers versionnés sûrs.